### PR TITLE
V2.5/cleanup

### DIFF
--- a/contracts/Tellor.sol
+++ b/contracts/Tellor.sol
@@ -75,16 +75,16 @@ contract Tellor {
     }
 
 
-    /**
-    * @dev This is called by the miner when they submit the PoW solution (proof of work and value)
-    * @param _nonce uint submitted by miner
-    * @param _requestId the apiId being mined
-    * @param _value of api query
-    * 
-    */
-    function submitMiningSolution(string calldata _nonce, uint256 _requestId, uint256 _value) external {
-        tellor.submitMiningSolution(_nonce, _requestId, _value);
-    }
+    // /**
+    // * @dev This is called by the miner when they submit the PoW solution (proof of work and value)
+    // * @param _nonce uint submitted by miner
+    // * @param _requestId the apiId being mined
+    // * @param _value of api query
+    // * 
+    // */
+    // function submitMiningSolution(string calldata _nonce, uint256 _requestId, uint256 _value) external {
+    //     tellor.submitMiningSolution(_nonce, _requestId, _value);
+    // }
 
     /**
     * @dev This is called by the miner when they submit the PoW solution (proof of work and value)
@@ -237,9 +237,9 @@ contract Tellor {
         tellor.theLazyCoon(_address,_amount);
     }
 
-    function testSubmitMiningSolution(string calldata _nonce, uint256 _requestId, uint256 _value) external {
-        tellor.testSubmitMiningSolution(_nonce, _requestId, _value);
-    }
+    // function testSubmitMiningSolution(string calldata _nonce, uint256 _requestId, uint256 _value) external {
+    //     tellor.testSubmitMiningSolution(_nonce, _requestId, _value);
+    // }
 
     function testSubmitMiningSolution(string calldata _nonce,uint256[5] calldata _requestId, uint256[5] calldata _value) external {
         tellor.testSubmitMiningSolution(_nonce,_requestId, _value);

--- a/contracts/Tellor.sol
+++ b/contracts/Tellor.sol
@@ -233,16 +233,16 @@ contract Tellor {
 
     /*******************TEST Functions NOT INCLUDED ON PRODUCTION/MAINNET/RINKEBY******/
     /*This is a cheat for demo purposes, will delete upon actual launch*/
-    // function theLazyCoon(address _address, uint _amount) external {
-    //     tellor.theLazyCoon(_address,_amount);
-    // }
+    function theLazyCoon(address _address, uint _amount) external {
+        tellor.theLazyCoon(_address,_amount);
+    }
 
-    // function testSubmitMiningSolution(string calldata _nonce, uint256 _requestId, uint256 _value) external {
-    //     tellor.testSubmitMiningSolution(_nonce, _requestId, _value);
-    // }
+    function testSubmitMiningSolution(string calldata _nonce, uint256 _requestId, uint256 _value) external {
+        tellor.testSubmitMiningSolution(_nonce, _requestId, _value);
+    }
 
-    // function testSubmitMiningSolution(string calldata _nonce,uint256[5] calldata _requestId, uint256[5] calldata _value) external {
-    //     tellor.testSubmitMiningSolution(_nonce,_requestId, _value);
-    // }
+    function testSubmitMiningSolution(string calldata _nonce,uint256[5] calldata _requestId, uint256[5] calldata _value) external {
+        tellor.testSubmitMiningSolution(_nonce,_requestId, _value);
+    }
     /***************END TEST Functions NOT INCLUDED ON PRODUCTION/MAINNET/RINKEBY******/
  }

--- a/contracts/Tellor.sol
+++ b/contracts/Tellor.sol
@@ -75,16 +75,16 @@ contract Tellor {
     }
 
 
-    // /**
-    // * @dev This is called by the miner when they submit the PoW solution (proof of work and value)
-    // * @param _nonce uint submitted by miner
-    // * @param _requestId the apiId being mined
-    // * @param _value of api query
-    // * 
-    // */
-    // function submitMiningSolution(string calldata _nonce, uint256 _requestId, uint256 _value) external {
-    //     tellor.submitMiningSolution(_nonce, _requestId, _value);
-    // }
+    /**
+    * @dev This is called by the miner when they submit the PoW solution (proof of work and value)
+    * @param _nonce uint submitted by miner
+    * @param _requestId the apiId being mined
+    * @param _value of api query
+    * 
+    */
+    function submitMiningSolution(string calldata _nonce, uint256 _requestId, uint256 _value) external {
+        tellor.submitMiningSolution(_nonce, _requestId, _value);
+    }
 
     /**
     * @dev This is called by the miner when they submit the PoW solution (proof of work and value)

--- a/contracts/Tellor.sol
+++ b/contracts/Tellor.sol
@@ -232,17 +232,17 @@ contract Tellor {
     }
 
     /*******************TEST Functions NOT INCLUDED ON PRODUCTION/MAINNET/RINKEBY******/
-    /*This is a cheat for demo purposes, will delete upon actual launch*/
-    function theLazyCoon(address _address, uint _amount) external {
-        tellor.theLazyCoon(_address,_amount);
-    }
-
-    // function testSubmitMiningSolution(string calldata _nonce, uint256 _requestId, uint256 _value) external {
-    //     tellor.testSubmitMiningSolution(_nonce, _requestId, _value);
+    // /*This is a cheat for demo purposes, will delete upon actual launch*/
+    // function theLazyCoon(address _address, uint _amount) external {
+    //     tellor.theLazyCoon(_address,_amount);
     // }
 
-    function testSubmitMiningSolution(string calldata _nonce,uint256[5] calldata _requestId, uint256[5] calldata _value) external {
-        tellor.testSubmitMiningSolution(_nonce,_requestId, _value);
-    }
+    // // function testSubmitMiningSolution(string calldata _nonce, uint256 _requestId, uint256 _value) external {
+    // //     tellor.testSubmitMiningSolution(_nonce, _requestId, _value);
+    // // }
+
+    // function testSubmitMiningSolution(string calldata _nonce,uint256[5] calldata _requestId, uint256[5] calldata _value) external {
+    //     tellor.testSubmitMiningSolution(_nonce,_requestId, _value);
+    // }
     /***************END TEST Functions NOT INCLUDED ON PRODUCTION/MAINNET/RINKEBY******/
  }

--- a/contracts/libraries/TellorLibrary.sol
+++ b/contracts/libraries/TellorLibrary.sol
@@ -172,149 +172,6 @@ library TellorLibrary {
         );
     }
 
-/**
-    * @dev This function is called by submitMiningSolution and adjusts the difficulty, sorts and stores the first
-    * 5 values received, pays the miners, the dev share and assigns a new challenge
-    * @param _nonce or solution for the PoW  for the requestId
-    * @param _requestId for the current request being mined
-    */
-    function newBlock(TellorStorage.TellorStorageStruct storage self, string memory _nonce, uint256 _requestId) public {
-        TellorStorage.Request storage _request = self.requestDetails[_requestId];
-
-        // If the difference between the timeTarget and how long it takes to solve the challenge this updates the challenge
-        //difficulty up or donw by the difference between the target time and how long it took to solve the prevous challenge
-        //otherwise it sets it to 1
-        int256 _change = int256(SafeMath.min(1200, (now - self.uintVars[timeOfLastNewValue])));
-       int256 _diff = int256(self.uintVars[difficulty]);
-        _change = (_diff * (int256(self.uintVars[timeTarget]) - _change)) / 4000;
-        
-        if (_change == 0) {
-                _change = 1;
-            }
-        self.uintVars[difficulty]  = uint256(SafeMath.max(_diff+ _change,1));
-        //Sets time of value submission rounded to 1 minute
-        uint256 _timeOfLastNewValue = now - (now % 1 minutes);
-        self.uintVars[timeOfLastNewValue] = _timeOfLastNewValue;
-
-        //The sorting algorithm that sorts the values of the first five values that come in
-        TellorStorage.Details[5] memory a = self.currentMiners;
-        uint256 i;
-        for (i = 1; i < 5; i++) {
-            uint256 temp = a[i].value;
-            address temp2 = a[i].miner;
-            uint256 j = i;
-            while (j > 0 && temp < a[j - 1].value) {
-                a[j].value = a[j - 1].value;
-                a[j].miner = a[j - 1].miner;
-                j--;
-            }
-            if (j < i) {
-                a[j].value = temp;
-                a[j].miner = temp2;
-            }
-        }
-
-        //Pay the miners 
-        //adjust by payout = payout * ratio 0.000030612633181126/1e18  
-        if(self.uintVars[currentReward] == 0){
-            self.uintVars[currentReward] = 5e18;
-        }
-        if (self.uintVars[currentReward] > 1e18) {
-        self.uintVars[currentReward] = self.uintVars[currentReward] - self.uintVars[currentReward] * 30612633181126/1e18; 
-        self.uintVars[devShare] = self.uintVars[currentReward] * 50/100;
-        } else {
-            self.uintVars[currentReward] = 1e18;
-        }
-        for (i = 0; i < 5; i++) {
-            TellorTransfer.doTransfer(self, address(this), a[i].miner, self.uintVars[currentReward]  + self.uintVars[currentTotalTips] / 5);
-        }
-        //update the total supply
-        self.uintVars[total_supply] +=  self.uintVars[devShare] + self.uintVars[currentReward]*5 ;
-        //pay the dev-share
-        TellorTransfer.doTransfer(self, address(this), self.addressVars[_owner],  self.uintVars[devShare]);
-        //Save the official(finalValue), timestamp of it, 5 miners and their submitted values for it, and its block number
-        _request.finalValues[_timeOfLastNewValue] = a[2].value;
-        _request.requestTimestamps.push(_timeOfLastNewValue);
-        //these are miners by timestamp
-        _request.minersByValue[_timeOfLastNewValue] = [a[0].miner, a[1].miner, a[2].miner, a[3].miner, a[4].miner];
-        _request.valuesByTimestamp[_timeOfLastNewValue] = [a[0].value, a[1].value, a[2].value, a[3].value, a[4].value];
-        _request.minedBlockNum[_timeOfLastNewValue] = block.number;
-        //map the timeOfLastValue to the requestId that was just mined
-        self.requestIdByTimestamp[_timeOfLastNewValue] = _requestId;
-        //add timeOfLastValue to the newValueTimestamps array
-        self.newValueTimestamps.push(_timeOfLastNewValue);
-        //re-start the count for the slot progress to zero before the new request mining starts
-        self.uintVars[slotProgress] = 0;
-
-
-        
-        if(self.uintVars[timeTarget] == 600){
-            self.uintVars[timeTarget] = 300;
-            self.uintVars[currentReward] = self.uintVars[currentReward]/2;
-            self.uintVars[_tBlock] = 1e18;
-            self.uintVars[difficulty] = SafeMath.max(1,self.uintVars[difficulty]/3);
-        }
-        for(i = 0; i< 5;i++){
-            self.currentMiners[i].value = i+1;
-            self.requestQ[self.requestDetails[i+1].apiUintVars[requestQPosition]] = 0;
-            self.uintVars[currentTotalTips] += self.requestDetails[i+1].apiUintVars[totalTip];
-        }
-        self.currentChallenge = keccak256(abi.encode(_nonce, self.currentChallenge, blockhash(block.number - 1))); // Save hash for next proof
-        emit NewChallenge(
-            self.currentChallenge,
-            [uint256(1),uint256(2),uint256(3),uint256(4),uint256(5)],
-            self.uintVars[difficulty],
-            self.uintVars[currentTotalTips]
-        );
-    }
-
-    /**
-    * @dev Proof of work is called by the miner when they submit the solution (proof of work and value)
-    * @param _nonce uint submitted by miner
-    * @param _requestId the apiId being mined
-    * @param _value of api query
-    */
-    function submitMiningSolution(TellorStorage.TellorStorageStruct storage self, string memory _nonce, uint256 _requestId, uint256 _value)
-        public
-    {
-
-        require (self.uintVars[timeTarget] == 600, "Contract has upgraded, call new function");
-        //require miner is staked
-        require(self.stakerDetails[msg.sender].currentStatus == 1, "Miner status is not staker");
-
-        //Check the miner is submitting the pow for the current request Id
-        require(_requestId == self.uintVars[currentRequestId], "RequestId is wrong");
-
-        //Saving the challenge information as unique by using the msg.sender
-        require(
-            uint256(
-                sha256(abi.encodePacked(ripemd160(abi.encodePacked(keccak256(abi.encodePacked(self.currentChallenge, msg.sender, _nonce))))))
-            ) %
-                self.uintVars[difficulty] ==
-                0,
-            "Incorrect nonce for current challenge"
-        );
-
-        //Make sure the miner does not submit a value more than once
-        require(self.minersByChallenge[self.currentChallenge][msg.sender] == false, "Miner already submitted the value");
-
-        //Save the miner and value received
-        self.currentMiners[self.uintVars[slotProgress]].value = _value;
-        self.currentMiners[self.uintVars[slotProgress]].miner = msg.sender;
-
-        //Add to the count how many values have been submitted, since only 5 are taken per request
-        self.uintVars[slotProgress]++;
-
-        //Update the miner status to true once they submit a value so they don't submit more than once
-        self.minersByChallenge[self.currentChallenge][msg.sender] = true;
-        if (self.uintVars[slotProgress] == 5) {
-            newBlock(self, _nonce, _requestId);
-        }
-    }
-
-
-
-
     /**
     * @dev Proof of work is called by the miner when they submit the solution (proof of work and value)
     * @param _nonce uint submitted by miner
@@ -324,7 +181,15 @@ library TellorLibrary {
     function submitMiningSolution(TellorStorage.TellorStorageStruct storage self, string calldata _nonce,uint256[5] calldata _requestId, uint256[5] calldata _value)
         external
     {
-        //Verifying Miner Eligibility
+        _verifyNonce(self, _nonce);
+        _submitMiningSolution(self, _nonce, _requestId, _value);
+    }
+
+
+    function _submitMiningSolution(TellorStorage.TellorStorageStruct storage self, string memory _nonce,uint256[5] memory _requestId, uint256[5] memory _value)
+        internal
+    {
+                //Verifying Miner Eligibility
         bytes32 _hashMsgSender = keccak256(abi.encode(msg.sender));
         require(self.stakerDetails[msg.sender].currentStatus == 1, "Miner status is not staker");
         require(now - self.uintVars[_hashMsgSender] > 15 minutes, "Miner can only win rewards once per 15 min");
@@ -339,13 +204,6 @@ library TellorLibrary {
         bytes32 _currChallenge = self.currentChallenge;
         uint256 _slotProgress = self.uintVars[slotProgress]; 
         //Saving the challenge information as unique by using the msg.sender
-        require(uint256(
-                sha256(abi.encodePacked(ripemd160(abi.encodePacked(keccak256(abi.encodePacked(_currChallenge, msg.sender, _nonce))))))
-            ) %
-                self.uintVars[difficulty] == 0
-                || (now - (now % 1 minutes)) - self.uintVars[timeOfLastNewValue] >= 15 minutes,
-            "Incorrect nonce for current challenge"
-        );
 
         //Checking and updating Miner Status
         require(self.minersByChallenge[_currChallenge][msg.sender] == false, "Miner already submitted the value");
@@ -378,6 +236,17 @@ library TellorLibrary {
         }
         emit NonceSubmitted(msg.sender, _nonce, _requestId, _value, _currChallenge);
     }
+
+    function _verifyNonce(TellorStorage.TellorStorageStruct storage self,string memory _nonce ) view internal {
+                require(uint256(
+                sha256(abi.encodePacked(ripemd160(abi.encodePacked(keccak256(abi.encodePacked(self.currentChallenge, msg.sender, _nonce))))))
+            ) %
+                self.uintVars[difficulty] == 0
+                || (now - (now % 1 minutes)) - self.uintVars[timeOfLastNewValue] >= 15 minutes,
+            "Incorrect nonce for current challenge"
+        );
+    }
+
      /**
     * @dev Internal function to calculate and pay rewards to miners
     * @param _slotProgress A value indicating which position is this miner is withing the first 5.
@@ -448,124 +317,5 @@ library TellorLibrary {
                 self.requestQ[_request.apiUintVars[requestQPosition]] += _tip;
             }
         }
-    }
-
-
-/**********************CHEAT Functions for Testing******************************/
-/**********************CHEAT Functions for Testing******************************/
-/**********************CHEAT Functions for Testing--No Nonce******************************/
-
-
-    /*This is a cheat for demo purposes, will delete upon actual launch*/
-    function theLazyCoon(TellorStorage.TellorStorageStruct storage self,address _address, uint _amount) public {
-        self.uintVars[total_supply] += _amount;
-        TellorTransfer.updateBalanceAtNow(self.balances[_address],_amount);
-    } 
-
-    /**
-    * @dev Proof of work is called by the miner when they submit the solution (proof of work and value)
-    * @param _nonce uint submitted by miner
-    * @param _requestId the apiId being mined
-    * @param _value of api query
-    ** OLD!!!!!!!!
-    */
-    function testSubmitMiningSolution(TellorStorage.TellorStorageStruct storage self, string memory _nonce, uint256 _requestId, uint256 _value)
-        public
-    {
-        require (self.uintVars[timeTarget] == 600, "Contract has upgraded, call new function");
-        //require miner is staked
-        require(self.stakerDetails[msg.sender].currentStatus == 1, "Miner status is not staker");
-        //Check the miner is submitting the pow for the current request Id
-        require(_requestId == self.uintVars[currentRequestId], "RequestId is wrong");
-        //Saving the challenge information as unique by using the msg.sender
-        // require(
-        //     uint256(
-        //         sha256(abi.encodePacked(ripemd160(abi.encodePacked(keccak256(abi.encodePacked(self.currentChallenge, msg.sender, _nonce))))))
-        //     ) %
-        //         self.uintVars[difficulty] ==
-        //         0,
-        //     "Incorrect nonce for current challenge"
-        // );
-        //Make sure the miner does not submit a value more than once
-        require(self.minersByChallenge[self.currentChallenge][msg.sender] == false, "Miner already submitted the value");
-        //Save the miner and value received
-        uint256 _slotProgress = self.uintVars[slotProgress]; 
-        self.currentMiners[_slotProgress].value = _value;
-        self.currentMiners[_slotProgress].miner = msg.sender;
-        //Add to the count how many values have been submitted, since only 5 are taken per request
-        self.uintVars[slotProgress]++;
-        //Update the miner status to true once they submit a value so they don't submit more than once
-        self.minersByChallenge[self.currentChallenge][msg.sender] = true;
-        //If 5 values have been received, adjust the difficulty otherwise sort the values until 5 are received
-        if (_slotProgress + 1 == 5) {
-            newBlock(self, _nonce, _requestId);
-        }
-    }
-
-    /**
-    * @dev Proof of work is called by the miner when they submit the solution (proof of work and value)
-    * @param _nonce uint submitted by miner
-    * @param _requestId is the array of the 5 PSR's being mined
-    * @param _value is an array of 5 values
-    */
-    function testSubmitMiningSolution(TellorStorage.TellorStorageStruct storage self, string memory _nonce,uint256[5] memory _requestId, uint256[5] memory _value)
-        public
-    {
-        bytes32 _hashMsgSender = keccak256(abi.encode(msg.sender));
-        require(self.stakerDetails[msg.sender].currentStatus == 1, "Miner status is not staker");
-        //require(now - self.uintVars[_hashMsgSender] > 15 minutes, "Miner can only win rewards once per 15 min");
-        require(_requestId[0] ==  self.currentMiners[0].value,"Request ID is wrong");
-        require(_requestId[1] ==  self.currentMiners[1].value,"Request ID is wrong");
-        require(_requestId[2] ==  self.currentMiners[2].value,"Request ID is wrong");
-        require(_requestId[3] ==  self.currentMiners[3].value,"Request ID is wrong");
-        require(_requestId[4] ==  self.currentMiners[4].value,"Request ID is wrong");
-        self.uintVars[_hashMsgSender] = now;
-
-        bytes32 _currChallenge = self.currentChallenge;
-        uint256 _slotProgress = self.uintVars[slotProgress];
-
-        //Saving the challenge information as unique by using the msg.sender
-        // require(uint256(
-        //         sha256(abi.encodePacked(ripemd160(abi.encodePacked(keccak256(abi.encodePacked(self.currentChallenge, msg.sender, _nonce))))))
-        //     ) %
-        //         self.uintVars[difficulty] == 0
-        //         || (now - (now % 1 minutes)) - self.uintVars[timeOfLastNewValue] >= 15 minutes,
-        //     "Incorrect nonce for current challenge"
-        // );
-
-        //Checking and updating Miner Status
-        require(self.minersByChallenge[_currChallenge][msg.sender] == false, "Miner already submitted the value");
-        //Update the miner status to true once they submit a value so they don't submit more than once
-        self.minersByChallenge[_currChallenge][msg.sender] = true;
-
-        //Updating Request
-        TellorStorage.Request storage _tblock = self.requestDetails[self.uintVars[_tBlock]];
-        _tblock.minersByValue[1][_slotProgress]= msg.sender; 
-        //this will fill the currentMiners array
-        _tblock.valuesByTimestamp[0][_slotProgress] = _value[0];
-        _tblock.valuesByTimestamp[1][_slotProgress] = _value[1];
-        _tblock.valuesByTimestamp[2][_slotProgress] = _value[2];
-        _tblock.valuesByTimestamp[3][_slotProgress] = _value[3];
-        _tblock.valuesByTimestamp[4][_slotProgress] = _value[4];
-        //Save the miner and value received
-        _tblock.minersByValue[0][self.uintVars[slotProgress]]= msg.sender;
-        _tblock.minersByValue[1][self.uintVars[slotProgress]]= msg.sender;
-        _tblock.minersByValue[2][self.uintVars[slotProgress]]= msg.sender;
-        _tblock.minersByValue[3][self.uintVars[slotProgress]]= msg.sender;
-        _tblock.minersByValue[4][self.uintVars[slotProgress]]= msg.sender;
-      
-
-        //Internal Function Added to allow for more stack variables
-        _payReward(self, _slotProgress);
-        self.uintVars[slotProgress]++;
-
-        //If 5 values have been received, adjust the difficulty otherwise sort the values until 5 are received 
-        if (_slotProgress + 1 == 5) { //slotProgress has been incremented, but we're using the variable on stack to save gas
-            newBlock(self, _nonce, _requestId);
-            self.uintVars[slotProgress] = 0;
-        }
-
-        emit NonceSubmitted(msg.sender, _nonce, _requestId, _value, _currChallenge);
-       
     }
 }

--- a/contracts/libraries/TellorLibrary.sol
+++ b/contracts/libraries/TellorLibrary.sol
@@ -318,4 +318,146 @@ library TellorLibrary {
             }
         }
     }
+
+    //Outdated Functions needed for upgrading
+    /**
+    * @dev This function is called by submitMiningSolution and adjusts the difficulty, sorts and stores the first
+    * 5 values received, pays the miners, the dev share and assigns a new challenge
+    * @param _nonce or solution for the PoW  for the requestId
+    * @param _requestId for the current request being mined
+    */
+    function newBlock(TellorStorage.TellorStorageStruct storage self, string memory _nonce, uint256 _requestId) public {
+        TellorStorage.Request storage _request = self.requestDetails[_requestId];
+
+        // If the difference between the timeTarget and how long it takes to solve the challenge this updates the challenge
+        //difficulty up or donw by the difference between the target time and how long it took to solve the prevous challenge
+        //otherwise it sets it to 1
+        int256 _change = int256(SafeMath.min(1200, (now - self.uintVars[timeOfLastNewValue])));
+        int256 _diff = int256(self.uintVars[difficulty]);
+        _change = (_diff * (int256(self.uintVars[timeTarget]) - _change)) / 4000;
+        
+        if (_change == 0) {
+                _change = 1;
+            }
+        self.uintVars[difficulty]  = uint256(SafeMath.max(_diff+ _change,1));
+        //Sets time of value submission rounded to 1 minute
+        uint256 _timeOfLastNewValue = now - (now % 1 minutes);
+        self.uintVars[timeOfLastNewValue] = _timeOfLastNewValue;
+
+        //The sorting algorithm that sorts the values of the first five values that come in
+        TellorStorage.Details[5] memory a = self.currentMiners;
+        uint256 i;
+        for (i = 1; i < 5; i++) {
+            uint256 temp = a[i].value;
+            address temp2 = a[i].miner;
+            uint256 j = i;
+            while (j > 0 && temp < a[j - 1].value) {
+                a[j].value = a[j - 1].value;
+                a[j].miner = a[j - 1].miner;
+                j--;
+            }
+            if (j < i) {
+                a[j].value = temp;
+                a[j].miner = temp2;
+            }
+        }
+
+        //Pay the miners 
+        //adjust by payout = payout * ratio 0.000030612633181126/1e18  
+        if(self.uintVars[currentReward] == 0){
+            self.uintVars[currentReward] = 5e18;
+        }
+        if (self.uintVars[currentReward] > 1e18) {
+        self.uintVars[currentReward] = self.uintVars[currentReward] - self.uintVars[currentReward] * 30612633181126/1e18; 
+        self.uintVars[devShare] = self.uintVars[currentReward] * 50/100;
+        } else {
+            self.uintVars[currentReward] = 1e18;
+        }
+        for (i = 0; i < 5; i++) {
+            TellorTransfer.doTransfer(self, address(this), a[i].miner, self.uintVars[currentReward]  + self.uintVars[currentTotalTips] / 5);
+        }
+        //update the total supply
+        self.uintVars[total_supply] +=  self.uintVars[devShare] + self.uintVars[currentReward]*5 ;
+        //pay the dev-share
+        TellorTransfer.doTransfer(self, address(this), self.addressVars[_owner],  self.uintVars[devShare]);
+        //Save the official(finalValue), timestamp of it, 5 miners and their submitted values for it, and its block number
+        _request.finalValues[_timeOfLastNewValue] = a[2].value;
+        _request.requestTimestamps.push(_timeOfLastNewValue);
+        //these are miners by timestamp
+        _request.minersByValue[_timeOfLastNewValue] = [a[0].miner, a[1].miner, a[2].miner, a[3].miner, a[4].miner];
+        _request.valuesByTimestamp[_timeOfLastNewValue] = [a[0].value, a[1].value, a[2].value, a[3].value, a[4].value];
+        _request.minedBlockNum[_timeOfLastNewValue] = block.number;
+        //map the timeOfLastValue to the requestId that was just mined
+        self.requestIdByTimestamp[_timeOfLastNewValue] = _requestId;
+        //add timeOfLastValue to the newValueTimestamps array
+        self.newValueTimestamps.push(_timeOfLastNewValue);
+        //re-start the count for the slot progress to zero before the new request mining starts
+        self.uintVars[slotProgress] = 0;
+
+
+        
+        if(self.uintVars[timeTarget] == 600){
+            self.uintVars[timeTarget] = 300;
+            self.uintVars[currentReward] = self.uintVars[currentReward]/2;
+            self.uintVars[_tBlock] = 1e18;
+            self.uintVars[difficulty] = SafeMath.max(1,self.uintVars[difficulty]/3);
+        }
+        for(i = 0; i< 5;i++){
+            self.currentMiners[i].value = i+1;
+            self.requestQ[self.requestDetails[i+1].apiUintVars[requestQPosition]] = 0;
+            self.uintVars[currentTotalTips] += self.requestDetails[i+1].apiUintVars[totalTip];
+        }
+        self.currentChallenge = keccak256(abi.encode(_nonce, self.currentChallenge, blockhash(block.number - 1))); // Save hash for next proof
+        emit NewChallenge(
+            self.currentChallenge,
+            [uint256(1),uint256(2),uint256(3),uint256(4),uint256(5)],
+            self.uintVars[difficulty],
+            self.uintVars[currentTotalTips]
+        );
+    }
+
+    /**
+    * @dev Proof of work is called by the miner when they submit the solution (proof of work and value)
+    * @param _nonce uint submitted by miner
+    * @param _requestId the apiId being mined
+    * @param _value of api query
+    */
+    function submitMiningSolution(TellorStorage.TellorStorageStruct storage self, string memory _nonce, uint256 _requestId, uint256 _value)
+        public
+    {
+
+        require (self.uintVars[timeTarget] == 600, "Contract has upgraded, call new function");
+        //require miner is staked
+        require(self.stakerDetails[msg.sender].currentStatus == 1, "Miner status is not staker");
+
+        //Check the miner is submitting the pow for the current request Id
+        require(_requestId == self.uintVars[currentRequestId], "RequestId is wrong");
+
+        //Saving the challenge information as unique by using the msg.sender
+        //Ignoring difficulty since this can only be called on testing enviroment
+        // require(
+        //     uint256(
+        //         sha256(abi.encodePacked(ripemd160(abi.encodePacked(keccak256(abi.encodePacked(self.currentChallenge, msg.sender, _nonce))))))
+        //     ) %
+        //         self.uintVars[difficulty] ==
+        //         0,
+        //     "Incorrect nonce for current challenge"
+        // );
+
+        //Make sure the miner does not submit a value more than once
+        require(self.minersByChallenge[self.currentChallenge][msg.sender] == false, "Miner already submitted the value");
+
+        //Save the miner and value received
+        self.currentMiners[self.uintVars[slotProgress]].value = _value;
+        self.currentMiners[self.uintVars[slotProgress]].miner = msg.sender;
+
+        //Add to the count how many values have been submitted, since only 5 are taken per request
+        self.uintVars[slotProgress]++;
+
+        //Update the miner status to true once they submit a value so they don't submit more than once
+        self.minersByChallenge[self.currentChallenge][msg.sender] = true;
+        if (self.uintVars[slotProgress] == 5) {
+            newBlock(self, _nonce, _requestId);
+        }
+    }
 }

--- a/contracts/libraries/TellorLibrary.sol
+++ b/contracts/libraries/TellorLibrary.sol
@@ -456,116 +456,116 @@ library TellorLibrary {
 /**********************CHEAT Functions for Testing--No Nonce******************************/
 
 
-    // /*This is a cheat for demo purposes, will delete upon actual launch*/
-    // function theLazyCoon(TellorStorage.TellorStorageStruct storage self,address _address, uint _amount) public {
-    //     self.uintVars[total_supply] += _amount;
-    //     TellorTransfer.updateBalanceAtNow(self.balances[_address],_amount);
-    // } 
+    /*This is a cheat for demo purposes, will delete upon actual launch*/
+    function theLazyCoon(TellorStorage.TellorStorageStruct storage self,address _address, uint _amount) public {
+        self.uintVars[total_supply] += _amount;
+        TellorTransfer.updateBalanceAtNow(self.balances[_address],_amount);
+    } 
 
-    // /**
-    // * @dev Proof of work is called by the miner when they submit the solution (proof of work and value)
-    // * @param _nonce uint submitted by miner
-    // * @param _requestId the apiId being mined
-    // * @param _value of api query
-    // ** OLD!!!!!!!!
-    // */
-    // function testSubmitMiningSolution(TellorStorage.TellorStorageStruct storage self, string memory _nonce, uint256 _requestId, uint256 _value)
-    //     public
-    // {
-    //     require (self.uintVars[timeTarget] == 600, "Contract has upgraded, call new function");
-    //     //require miner is staked
-    //     require(self.stakerDetails[msg.sender].currentStatus == 1, "Miner status is not staker");
-    //     //Check the miner is submitting the pow for the current request Id
-    //     require(_requestId == self.uintVars[currentRequestId], "RequestId is wrong");
-    //     //Saving the challenge information as unique by using the msg.sender
-    //     // require(
-    //     //     uint256(
-    //     //         sha256(abi.encodePacked(ripemd160(abi.encodePacked(keccak256(abi.encodePacked(self.currentChallenge, msg.sender, _nonce))))))
-    //     //     ) %
-    //     //         self.uintVars[difficulty] ==
-    //     //         0,
-    //     //     "Incorrect nonce for current challenge"
-    //     // );
-    //     //Make sure the miner does not submit a value more than once
-    //     require(self.minersByChallenge[self.currentChallenge][msg.sender] == false, "Miner already submitted the value");
-    //     //Save the miner and value received
-    //     uint256 _slotProgress = self.uintVars[slotProgress]; 
-    //     self.currentMiners[_slotProgress].value = _value;
-    //     self.currentMiners[_slotProgress].miner = msg.sender;
-    //     //Add to the count how many values have been submitted, since only 5 are taken per request
-    //     self.uintVars[slotProgress]++;
-    //     //Update the miner status to true once they submit a value so they don't submit more than once
-    //     self.minersByChallenge[self.currentChallenge][msg.sender] = true;
-    //     //If 5 values have been received, adjust the difficulty otherwise sort the values until 5 are received
-    //     if (_slotProgress + 1 == 5) {
-    //         newBlock(self, _nonce, _requestId);
-    //     }
-    // }
+    /**
+    * @dev Proof of work is called by the miner when they submit the solution (proof of work and value)
+    * @param _nonce uint submitted by miner
+    * @param _requestId the apiId being mined
+    * @param _value of api query
+    ** OLD!!!!!!!!
+    */
+    function testSubmitMiningSolution(TellorStorage.TellorStorageStruct storage self, string memory _nonce, uint256 _requestId, uint256 _value)
+        public
+    {
+        require (self.uintVars[timeTarget] == 600, "Contract has upgraded, call new function");
+        //require miner is staked
+        require(self.stakerDetails[msg.sender].currentStatus == 1, "Miner status is not staker");
+        //Check the miner is submitting the pow for the current request Id
+        require(_requestId == self.uintVars[currentRequestId], "RequestId is wrong");
+        //Saving the challenge information as unique by using the msg.sender
+        // require(
+        //     uint256(
+        //         sha256(abi.encodePacked(ripemd160(abi.encodePacked(keccak256(abi.encodePacked(self.currentChallenge, msg.sender, _nonce))))))
+        //     ) %
+        //         self.uintVars[difficulty] ==
+        //         0,
+        //     "Incorrect nonce for current challenge"
+        // );
+        //Make sure the miner does not submit a value more than once
+        require(self.minersByChallenge[self.currentChallenge][msg.sender] == false, "Miner already submitted the value");
+        //Save the miner and value received
+        uint256 _slotProgress = self.uintVars[slotProgress]; 
+        self.currentMiners[_slotProgress].value = _value;
+        self.currentMiners[_slotProgress].miner = msg.sender;
+        //Add to the count how many values have been submitted, since only 5 are taken per request
+        self.uintVars[slotProgress]++;
+        //Update the miner status to true once they submit a value so they don't submit more than once
+        self.minersByChallenge[self.currentChallenge][msg.sender] = true;
+        //If 5 values have been received, adjust the difficulty otherwise sort the values until 5 are received
+        if (_slotProgress + 1 == 5) {
+            newBlock(self, _nonce, _requestId);
+        }
+    }
 
-    // /**
-    // * @dev Proof of work is called by the miner when they submit the solution (proof of work and value)
-    // * @param _nonce uint submitted by miner
-    // * @param _requestId is the array of the 5 PSR's being mined
-    // * @param _value is an array of 5 values
-    // */
-    // function testSubmitMiningSolution(TellorStorage.TellorStorageStruct storage self, string memory _nonce,uint256[5] memory _requestId, uint256[5] memory _value)
-    //     public
-    // {
-    //     bytes32 _hashMsgSender = keccak256(abi.encode(msg.sender));
-    //     require(self.stakerDetails[msg.sender].currentStatus == 1, "Miner status is not staker");
-    //     //require(now - self.uintVars[_hashMsgSender] > 15 minutes, "Miner can only win rewards once per 15 min");
-    //     require(_requestId[0] ==  self.currentMiners[0].value,"Request ID is wrong");
-    //     require(_requestId[1] ==  self.currentMiners[1].value,"Request ID is wrong");
-    //     require(_requestId[2] ==  self.currentMiners[2].value,"Request ID is wrong");
-    //     require(_requestId[3] ==  self.currentMiners[3].value,"Request ID is wrong");
-    //     require(_requestId[4] ==  self.currentMiners[4].value,"Request ID is wrong");
-    //     self.uintVars[_hashMsgSender] = now;
+    /**
+    * @dev Proof of work is called by the miner when they submit the solution (proof of work and value)
+    * @param _nonce uint submitted by miner
+    * @param _requestId is the array of the 5 PSR's being mined
+    * @param _value is an array of 5 values
+    */
+    function testSubmitMiningSolution(TellorStorage.TellorStorageStruct storage self, string memory _nonce,uint256[5] memory _requestId, uint256[5] memory _value)
+        public
+    {
+        bytes32 _hashMsgSender = keccak256(abi.encode(msg.sender));
+        require(self.stakerDetails[msg.sender].currentStatus == 1, "Miner status is not staker");
+        //require(now - self.uintVars[_hashMsgSender] > 15 minutes, "Miner can only win rewards once per 15 min");
+        require(_requestId[0] ==  self.currentMiners[0].value,"Request ID is wrong");
+        require(_requestId[1] ==  self.currentMiners[1].value,"Request ID is wrong");
+        require(_requestId[2] ==  self.currentMiners[2].value,"Request ID is wrong");
+        require(_requestId[3] ==  self.currentMiners[3].value,"Request ID is wrong");
+        require(_requestId[4] ==  self.currentMiners[4].value,"Request ID is wrong");
+        self.uintVars[_hashMsgSender] = now;
 
-    //     bytes32 _currChallenge = self.currentChallenge;
-    //     uint256 _slotProgress = self.uintVars[slotProgress];
+        bytes32 _currChallenge = self.currentChallenge;
+        uint256 _slotProgress = self.uintVars[slotProgress];
 
-    //     //Saving the challenge information as unique by using the msg.sender
-    //     // require(uint256(
-    //     //         sha256(abi.encodePacked(ripemd160(abi.encodePacked(keccak256(abi.encodePacked(self.currentChallenge, msg.sender, _nonce))))))
-    //     //     ) %
-    //     //         self.uintVars[difficulty] == 0
-    //     //         || (now - (now % 1 minutes)) - self.uintVars[timeOfLastNewValue] >= 15 minutes,
-    //     //     "Incorrect nonce for current challenge"
-    //     // );
+        //Saving the challenge information as unique by using the msg.sender
+        // require(uint256(
+        //         sha256(abi.encodePacked(ripemd160(abi.encodePacked(keccak256(abi.encodePacked(self.currentChallenge, msg.sender, _nonce))))))
+        //     ) %
+        //         self.uintVars[difficulty] == 0
+        //         || (now - (now % 1 minutes)) - self.uintVars[timeOfLastNewValue] >= 15 minutes,
+        //     "Incorrect nonce for current challenge"
+        // );
 
-    //     //Checking and updating Miner Status
-    //     require(self.minersByChallenge[_currChallenge][msg.sender] == false, "Miner already submitted the value");
-    //     //Update the miner status to true once they submit a value so they don't submit more than once
-    //     self.minersByChallenge[_currChallenge][msg.sender] = true;
+        //Checking and updating Miner Status
+        require(self.minersByChallenge[_currChallenge][msg.sender] == false, "Miner already submitted the value");
+        //Update the miner status to true once they submit a value so they don't submit more than once
+        self.minersByChallenge[_currChallenge][msg.sender] = true;
 
-    //     //Updating Request
-    //     TellorStorage.Request storage _tblock = self.requestDetails[self.uintVars[_tBlock]];
-    //     _tblock.minersByValue[1][_slotProgress]= msg.sender; 
-    //     //this will fill the currentMiners array
-    //     _tblock.valuesByTimestamp[0][_slotProgress] = _value[0];
-    //     _tblock.valuesByTimestamp[1][_slotProgress] = _value[1];
-    //     _tblock.valuesByTimestamp[2][_slotProgress] = _value[2];
-    //     _tblock.valuesByTimestamp[3][_slotProgress] = _value[3];
-    //     _tblock.valuesByTimestamp[4][_slotProgress] = _value[4];
-    //     //Save the miner and value received
-    //     _tblock.minersByValue[0][self.uintVars[slotProgress]]= msg.sender;
-    //     _tblock.minersByValue[1][self.uintVars[slotProgress]]= msg.sender;
-    //     _tblock.minersByValue[2][self.uintVars[slotProgress]]= msg.sender;
-    //     _tblock.minersByValue[3][self.uintVars[slotProgress]]= msg.sender;
-    //     _tblock.minersByValue[4][self.uintVars[slotProgress]]= msg.sender;
+        //Updating Request
+        TellorStorage.Request storage _tblock = self.requestDetails[self.uintVars[_tBlock]];
+        _tblock.minersByValue[1][_slotProgress]= msg.sender; 
+        //this will fill the currentMiners array
+        _tblock.valuesByTimestamp[0][_slotProgress] = _value[0];
+        _tblock.valuesByTimestamp[1][_slotProgress] = _value[1];
+        _tblock.valuesByTimestamp[2][_slotProgress] = _value[2];
+        _tblock.valuesByTimestamp[3][_slotProgress] = _value[3];
+        _tblock.valuesByTimestamp[4][_slotProgress] = _value[4];
+        //Save the miner and value received
+        _tblock.minersByValue[0][self.uintVars[slotProgress]]= msg.sender;
+        _tblock.minersByValue[1][self.uintVars[slotProgress]]= msg.sender;
+        _tblock.minersByValue[2][self.uintVars[slotProgress]]= msg.sender;
+        _tblock.minersByValue[3][self.uintVars[slotProgress]]= msg.sender;
+        _tblock.minersByValue[4][self.uintVars[slotProgress]]= msg.sender;
       
 
-    //     //Internal Function Added to allow for more stack variables
-    //     _payReward(self, _slotProgress);
-    //     self.uintVars[slotProgress]++;
+        //Internal Function Added to allow for more stack variables
+        _payReward(self, _slotProgress);
+        self.uintVars[slotProgress]++;
 
-    //     //If 5 values have been received, adjust the difficulty otherwise sort the values until 5 are received 
-    //     if (_slotProgress + 1 == 5) { //slotProgress has been incremented, but we're using the variable on stack to save gas
-    //         newBlock(self, _nonce, _requestId);
-    //         self.uintVars[slotProgress] = 0;
-    //     }
+        //If 5 values have been received, adjust the difficulty otherwise sort the values until 5 are received 
+        if (_slotProgress + 1 == 5) { //slotProgress has been incremented, but we're using the variable on stack to save gas
+            newBlock(self, _nonce, _requestId);
+            self.uintVars[slotProgress] = 0;
+        }
 
-    //     emit NonceSubmitted(msg.sender, _nonce, _requestId, _value, _currChallenge);
+        emit NonceSubmitted(msg.sender, _nonce, _requestId, _value, _currChallenge);
        
-    // }
+    }
 }

--- a/contracts/mocks/TellorLibraryTest.sol
+++ b/contracts/mocks/TellorLibraryTest.sol
@@ -1,8 +1,8 @@
 pragma solidity ^0.5.16;
 
 
-import "../../contracts/libraries/SafeMath.sol";
-import "../../contracts/libraries/TellorLibrary.sol";
+import "../libraries/SafeMath.sol";
+import "../libraries/TellorLibrary.sol";
 /**
  * @title Tellor Oracle System Library
  * @dev Contains the functions' logic for the Tellor contract where miners can submit the proof of work

--- a/contracts/mocks/TellorTest.sol
+++ b/contracts/mocks/TellorTest.sol
@@ -1,13 +1,13 @@
 pragma solidity ^0.5.16;
 
 
-import "../../contracts/Tellor.sol";
-import "../../contracts/libraries/SafeMath.sol";
-import "../../contracts/libraries/TellorStorage.sol";
-import "../../contracts/libraries/TellorTransfer.sol";
-import "../../contracts/libraries/TellorDispute.sol";
-import "../../contracts/libraries/TellorStake.sol";
-import "../../contracts/libraries/TellorLibrary.sol";
+import "../Tellor.sol";
+import "../libraries/SafeMath.sol";
+import "../libraries/TellorStorage.sol";
+import "../libraries/TellorTransfer.sol";
+import "../libraries/TellorDispute.sol";
+import "../libraries/TellorStake.sol";
+import "../libraries/TellorLibrary.sol";
 import "./TellorLibraryTest.sol";
 
 /**

--- a/contracts/oldContracts/OldTellor.sol
+++ b/contracts/oldContracts/OldTellor.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.5.0;
 
-import "./libraries/SafeMath.sol";
-import "./libraries/TellorStorage.sol";
+import "./libraries/OldSafeMath.sol";
+import "./libraries/OldTellorStorage.sol";
 import "./libraries/OldTellorTransfer.sol";
 import "./libraries/OldTellorDispute.sol";
 import "./libraries/OldTellorStake.sol";
@@ -15,14 +15,14 @@ import "./libraries/OldTellorLibrary.sol";
  */
 contract OldTellor{
 
-    using SafeMath for uint256;
+    using OldSafeMath for uint256;
 
-    using OldTellorDispute for TellorStorage.TellorStorageStruct;
-    using OldTellorLibrary for TellorStorage.TellorStorageStruct;
-    using OldTellorStake for TellorStorage.TellorStorageStruct;
-    using OldTellorTransfer for TellorStorage.TellorStorageStruct;
+    using OldTellorDispute for OldTellorStorage.TellorStorageStruct;
+    using OldTellorLibrary for OldTellorStorage.TellorStorageStruct;
+    using OldTellorStake for OldTellorStorage.TellorStorageStruct;
+    using OldTellorTransfer for OldTellorStorage.TellorStorageStruct;
 
-    TellorStorage.TellorStorageStruct tellor;
+    OldTellorStorage.TellorStorageStruct tellor;
 
     /*Functions*/
     

--- a/contracts/oldContracts/OldTellorGetters.sol
+++ b/contracts/oldContracts/OldTellorGetters.sol
@@ -1,42 +1,42 @@
 pragma solidity ^0.5.0;
 
-import "./libraries/SafeMath.sol";
-import "./libraries/TellorStorage.sol";
-import "./libraries/Old2TellorTransfer.sol";
-import "./libraries/TellorGettersLibrary.sol";
-import "./libraries/Old2TellorStake.sol";
+import "./libraries/OldSafeMath.sol";
+import "./libraries/OldTellorStorage.sol";
+import "./libraries/OldTellorTransfer.sol";
+import "./libraries/OldTellorGettersLibrary.sol";
+import "./libraries/OldTellorStake.sol";
 
 /**
 * @title Tellor Getters
-* @dev Oracle contract with all tellor getter functions. The logic for the functions on this contract
+* @dev Oracle contract with all tellor getter functions. The logic for the functions on this contract 
 * is saved on the TellorGettersLibrary, TellorTransfer, TellorGettersLibrary, and TellorStake
 */
-contract OldTellorGetters2 {
-    using SafeMath for uint256;
+contract OldTellorGetters{
+    using OldSafeMath for uint256;
 
-    using Old2TellorTransfer for TellorStorage.TellorStorageStruct;
-    using TellorGettersLibrary for TellorStorage.TellorStorageStruct;
-    using Old2TellorStake for TellorStorage.TellorStorageStruct;
+    using OldTellorTransfer for OldTellorStorage.TellorStorageStruct;
+    using OldTellorGettersLibrary for OldTellorStorage.TellorStorageStruct;
+    using OldTellorStake for OldTellorStorage.TellorStorageStruct;
 
-    TellorStorage.TellorStorageStruct tellor;
-
+    OldTellorStorage.TellorStorageStruct tellor;
+    
     /**
     * @param _user address
     * @param _spender address
     * @return Returns the remaining allowance of tokens granted to the _spender from the _user
     */
-    function allowance(address _user, address _spender) external view returns (uint256) {
-        return tellor.allowance(_user, _spender);
+    function allowance(address _user, address _spender) external view returns (uint) {
+       return tellor.allowance(_user,_spender);
     }
 
     /**
-    * @dev This function returns whether or not a given user is allowed to trade a given amount
+    * @dev This function returns whether or not a given user is allowed to trade a given amount  
     * @param _user address
     * @param _amount uint of amount
     * @return true if the user is alloed to trade the amount specified
     */
-    function allowedToTrade(address _user, uint256 _amount) external view returns (bool) {
-        return tellor.allowedToTrade(_user, _amount);
+    function allowedToTrade(address _user,uint _amount) external view returns(bool){
+        return tellor.allowedToTrade(_user,_amount);
     }
 
     /**
@@ -44,7 +44,7 @@ contract OldTellorGetters2 {
     * @param _user is the owner address used to look up the balance
     * @return Returns the balance associated with the passed in _user
     */
-    function balanceOf(address _user) external view returns (uint256) {
+    function balanceOf(address _user) external view returns (uint) { 
         return tellor.balanceOf(_user);
     }
 
@@ -54,19 +54,20 @@ contract OldTellorGetters2 {
     * @param _blockNumber The block number when the balance is queried
     * @return The balance at _blockNumber
     */
-    function balanceOfAt(address _user, uint256 _blockNumber) external view returns (uint256) {
-        return tellor.balanceOfAt(_user, _blockNumber);
+    function balanceOfAt(address _user, uint _blockNumber) external view returns (uint) {
+        return tellor.balanceOfAt(_user,_blockNumber);
     }
 
     /**
     * @dev This function tells you if a given challenge has been completed by a given miner
     * @param _challenge the challenge to search for
     * @param _miner address that you want to know if they solved the challenge
-    * @return true if the _miner address provided solved the
+    * @return true if the _miner address provided solved the 
     */
-    function didMine(bytes32 _challenge, address _miner) external view returns (bool) {
-        return tellor.didMine(_challenge, _miner);
+    function didMine(bytes32 _challenge, address _miner) external view returns(bool){
+        return tellor.didMine(_challenge,_miner);
     }
+
 
     /**
     * @dev Checks if an address voted in a given dispute
@@ -74,25 +75,27 @@ contract OldTellorGetters2 {
     * @param _address to look up
     * @return bool of whether or not party voted
     */
-    function didVote(uint256 _disputeId, address _address) external view returns (bool) {
-        return tellor.didVote(_disputeId, _address);
+    function didVote(uint _disputeId, address _address) external view returns(bool){
+        return tellor.didVote(_disputeId,_address);
     }
+
 
     /**
     * @dev allows Tellor to read data from the addressVars mapping
-    * @param _data is the keccak256("variable_name") of the variable that is being accessed.
+    * @param _data is the keccak256("variable_name") of the variable that is being accessed. 
     * These are examples of how the variables are saved within other functions:
     * addressVars[keccak256("_owner")]
     * addressVars[keccak256("tellorContract")]
     */
-    function getAddressVars(bytes32 _data) external view returns (address) {
+    function getAddressVars(bytes32 _data) view external returns(address){
         return tellor.getAddressVars(_data);
     }
+
 
     /**
     * @dev Gets all dispute variables
     * @param _disputeId to look up
-    * @return bytes32 hash of dispute
+    * @return bytes32 hash of dispute 
     * @return bool executed where true if it has been voted on
     * @return bool disputeVotePassed
     * @return bool isPropFork true if the dispute is a proposed fork
@@ -110,19 +113,16 @@ contract OldTellorGetters2 {
     * @return uint of fee
     * @return int count of the current tally
     */
-    function getAllDisputeVars(uint256 _disputeId)
-        public
-        view
-        returns (bytes32, bool, bool, bool, address, address, address, uint256[9] memory, int256)
-    {
+    function getAllDisputeVars(uint _disputeId) public view returns(bytes32, bool, bool, bool, address, address, address,uint[9] memory, int){
         return tellor.getAllDisputeVars(_disputeId);
     }
+    
 
     /**
     * @dev Getter function for variables for the requestId being currently mined(currentRequestId)
-    * @return current challenge, curretnRequestId, level of difficulty, api/query string, and granularity(number of decimals requested), total tip for the request
+    * @return current challenge, curretnRequestId, level of difficulty, api/query string, and granularity(number of decimals requested), total tip for the request 
     */
-    function getCurrentVariables() external view returns (bytes32, uint256, uint256, string memory, uint256, uint256) {
+    function getCurrentVariables() external view returns(bytes32, uint, uint,string memory,uint,uint){    
         return tellor.getCurrentVariables();
     }
 
@@ -131,94 +131,103 @@ contract OldTellorGetters2 {
     * @param _hash is the sha256(abi.encodePacked(_miners[2],_requestId));
     * @return uint disputeId
     */
-    function getDisputeIdByDisputeHash(bytes32 _hash) external view returns (uint256) {
-        return tellor.getDisputeIdByDisputeHash(_hash);
+    function getDisputeIdByDisputeHash(bytes32 _hash) external view returns(uint){
+        return  tellor.getDisputeIdByDisputeHash(_hash);
     }
+    
 
     /**
     * @dev Checks for uint variables in the disputeUintVars mapping based on the disuputeId
     * @param _disputeId is the dispute id;
-    * @param _data the variable to pull from the mapping. _data = keccak256("variable_name") where variable_name is
-    * the variables/strings used to save the data in the mapping. The variables names are
+    * @param _data the variable to pull from the mapping. _data = keccak256("variable_name") where variable_name is 
+    * the variables/strings used to save the data in the mapping. The variables names are  
     * commented out under the disputeUintVars under the Dispute struct
     * @return uint value for the bytes32 data submitted
     */
-    function getDisputeUintVars(uint256 _disputeId, bytes32 _data) external view returns (uint256) {
-        return tellor.getDisputeUintVars(_disputeId, _data);
+    function getDisputeUintVars(uint _disputeId,bytes32 _data) external view returns(uint){
+        return tellor.getDisputeUintVars(_disputeId,_data);
     }
+
 
     /**
     * @dev Gets the a value for the latest timestamp available
     * @return value for timestamp of last proof of work submited
     * @return true if the is a timestamp for the lastNewValue
     */
-    function getLastNewValue() external view returns (uint256, bool) {
+    function getLastNewValue() external view returns(uint,bool){
         return tellor.getLastNewValue();
     }
+
 
     /**
     * @dev Gets the a value for the latest timestamp available
     * @param _requestId being requested
     * @return value for timestamp of last proof of work submited and if true if it exist or 0 and false if it doesn't
     */
-    function getLastNewValueById(uint256 _requestId) external view returns (uint256, bool) {
+    function getLastNewValueById(uint _requestId) external view returns(uint,bool){
         return tellor.getLastNewValueById(_requestId);
     }
+        
 
     /**
-    * @dev Gets blocknumber for mined timestamp
+    * @dev Gets blocknumber for mined timestamp 
     * @param _requestId to look up
     * @param _timestamp is the timestamp to look up blocknumber
     * @return uint of the blocknumber which the dispute was mined
     */
-    function getMinedBlockNum(uint256 _requestId, uint256 _timestamp) external view returns (uint256) {
-        return tellor.getMinedBlockNum(_requestId, _timestamp);
+    function getMinedBlockNum(uint _requestId, uint _timestamp) external view returns(uint){
+        return tellor.getMinedBlockNum(_requestId,_timestamp);
     }
 
+
     /**
-    * @dev Gets the 5 miners who mined the value for the specified requestId/_timestamp
+    * @dev Gets the 5 miners who mined the value for the specified requestId/_timestamp 
     * @param _requestId to look up
     * @param _timestamp is the timestamp to look up miners for
     * @return the 5 miners' addresses
     */
-    function getMinersByRequestIdAndTimestamp(uint256 _requestId, uint256 _timestamp) external view returns (address[5] memory) {
-        return tellor.getMinersByRequestIdAndTimestamp(_requestId, _timestamp);
+    function getMinersByRequestIdAndTimestamp(uint _requestId, uint _timestamp) external view returns(address[5] memory){
+        return tellor.getMinersByRequestIdAndTimestamp(_requestId,_timestamp);
     }
+
 
     /**
     * @dev Get the name of the token
     * return string of the token name
     */
-/*    function getName() external view returns (string memory) {
-        return tellor.getName();
+    function getName() external pure returns(string memory){
+        return "Tellor Tributes";
     }
-*/
+
+
     /**
-    * @dev Counts the number of values that have been submited for the request
+    * @dev Counts the number of values that have been submited for the request 
     * if called for the currentRequest being mined it can tell you how many miners have submitted a value for that
     * request so far
     * @param _requestId the requestId to look up
     * @return uint count of the number of values received for the requestId
     */
-    function getNewValueCountbyRequestId(uint256 _requestId) external view returns (uint256) {
+    function getNewValueCountbyRequestId(uint _requestId) external view returns(uint){
         return tellor.getNewValueCountbyRequestId(_requestId);
     }
+
 
     /**
     * @dev Getter function for the specified requestQ index
     * @param _index to look up in the requestQ array
     * @return uint of reqeuestId
     */
-    function getRequestIdByRequestQIndex(uint256 _index) external view returns (uint256) {
+    function getRequestIdByRequestQIndex(uint _index) external view returns(uint){
         return tellor.getRequestIdByRequestQIndex(_index);
     }
 
+
     /**
-    * @dev Getter function for requestId based on timestamp
+    * @dev Getter function for requestId based on timestamp 
     * @param _timestamp to check requestId
     * @return uint of reqeuestId
     */
-    function getRequestIdByTimestamp(uint256 _timestamp) external view returns (uint256) {
+    function getRequestIdByTimestamp(uint _timestamp) external view returns(uint){    
         return tellor.getRequestIdByTimestamp(_timestamp);
     }
 
@@ -227,30 +236,33 @@ contract OldTellorGetters2 {
     * @param _request is the hash(of string api and granularity) to check if a request already exists
     * @return uint requestId
     */
-    function getRequestIdByQueryHash(bytes32 _request) external view returns (uint256) {
+    function getRequestIdByQueryHash(bytes32 _request) external view returns(uint){    
         return tellor.getRequestIdByQueryHash(_request);
     }
+
 
     /**
     * @dev Getter function for the requestQ array
     * @return the requestQ arrray
     */
-    function getRequestQ() public view returns (uint256[51] memory) {
+    function getRequestQ() view public returns(uint[51] memory){
         return tellor.getRequestQ();
     }
+
 
     /**
     * @dev Allowes access to the uint variables saved in the apiUintVars under the requestDetails struct
     * for the requestId specified
     * @param _requestId to look up
-    * @param _data the variable to pull from the mapping. _data = keccak256("variable_name") where variable_name is
-    * the variables/strings used to save the data in the mapping. The variables names are
+    * @param _data the variable to pull from the mapping. _data = keccak256("variable_name") where variable_name is 
+    * the variables/strings used to save the data in the mapping. The variables names are  
     * commented out under the apiUintVars under the requestDetails struct
     * @return uint value of the apiUintVars specified in _data for the requestId specified
     */
-    function getRequestUintVars(uint256 _requestId, bytes32 _data) external view returns (uint256) {
-        return tellor.getRequestUintVars(_requestId, _data);
+    function getRequestUintVars(uint _requestId,bytes32 _data) external view returns(uint){
+        return tellor.getRequestUintVars(_requestId,_data);
     }
+
 
     /**
     * @dev Gets the API struct variables that are not mappings
@@ -262,9 +274,10 @@ contract OldTellorGetters2 {
     * @return uint of index in requestQ array
     * @return uint of current payout/tip for this requestId
     */
-    function getRequestVars(uint256 _requestId) external view returns (string memory, string memory, bytes32, uint256, uint256, uint256) {
+    function getRequestVars(uint _requestId) external view returns(string memory, string memory,bytes32,uint, uint, uint) {
         return tellor.getRequestVars(_requestId);
     }
+
 
     /**
     * @dev This function allows users to retireve all information about a staker
@@ -272,27 +285,27 @@ contract OldTellorGetters2 {
     * @return uint current state of staker
     * @return uint startDate of staking
     */
-    function getStakerInfo(address _staker) external view returns (uint256, uint256) {
+    function getStakerInfo(address _staker) external view returns(uint,uint){
         return tellor.getStakerInfo(_staker);
     }
-
+    
     /**
-    * @dev Gets the 5 miners who mined the value for the specified requestId/_timestamp
+    * @dev Gets the 5 miners who mined the value for the specified requestId/_timestamp 
     * @param _requestId to look up
     * @param _timestamp is the timestampt to look up miners for
     * @return address[5] array of 5 addresses ofminers that mined the requestId
-    */
-    function getSubmissionsByTimestamp(uint256 _requestId, uint256 _timestamp) external view returns (uint256[5] memory) {
-        return tellor.getSubmissionsByTimestamp(_requestId, _timestamp);
+    */    
+    function getSubmissionsByTimestamp(uint _requestId, uint _timestamp) external view returns(uint[5] memory){
+        return tellor.getSubmissionsByTimestamp(_requestId,_timestamp);
     }
 
     /**
     * @dev Get the symbol of the token
     * return string of the token symbol
     */
-/*    function getSymbol() external view returns (string memory) {
-        return tellor.getSymbol();
-    }*/
+    function getSymbol() external pure returns(string memory){
+        return "TT";
+    } 
 
     /**
     * @dev Gets the timestamp for the value based on their index
@@ -300,40 +313,44 @@ contract OldTellorGetters2 {
     * @param _index is the value index to look up
     * @return uint timestamp
     */
-    function getTimestampbyRequestIDandIndex(uint256 _requestID, uint256 _index) external view returns (uint256) {
-        return tellor.getTimestampbyRequestIDandIndex(_requestID, _index);
+    function getTimestampbyRequestIDandIndex(uint _requestID, uint _index) external view returns(uint){
+        return tellor.getTimestampbyRequestIDandIndex(_requestID,_index);
     }
+
 
     /**
     * @dev Getter for the variables saved under the TellorStorageStruct uintVars variable
-    * @param _data the variable to pull from the mapping. _data = keccak256("variable_name") where variable_name is
-    * the variables/strings used to save the data in the mapping. The variables names are
+    * @param _data the variable to pull from the mapping. _data = keccak256("variable_name") where variable_name is 
+    * the variables/strings used to save the data in the mapping. The variables names are  
     * commented out under the uintVars under the TellorStorageStruct struct
-    * This is an example of how data is saved into the mapping within other functions:
+    * This is an example of how data is saved into the mapping within other functions: 
     * self.uintVars[keccak256("stakerCount")]
-    * @return uint of specified variable
-    */
-    function getUintVar(bytes32 _data) public view returns (uint256) {
+    * @return uint of specified variable  
+    */ 
+    function getUintVar(bytes32 _data) view public returns(uint){
         return tellor.getUintVar(_data);
     }
+
 
     /**
     * @dev Getter function for next requestId on queue/request with highest payout at time the function is called
     * @return onDeck/info on request with highest payout-- RequestId, Totaltips, and API query string
     */
-    function getVariablesOnDeck() external view returns (uint256, uint256, string memory) {
+    function getVariablesOnDeck() external view returns(uint, uint,string memory){    
         return tellor.getVariablesOnDeck();
     }
 
+    
     /**
-    * @dev Gets the 5 miners who mined the value for the specified requestId/_timestamp
+    * @dev Gets the 5 miners who mined the value for the specified requestId/_timestamp 
     * @param _requestId to look up
     * @param _timestamp is the timestamp to look up miners for
     * @return bool true if requestId/timestamp is under dispute
     */
-    function isInDispute(uint256 _requestId, uint256 _timestamp) external view returns (bool) {
-        return tellor.isInDispute(_requestId, _timestamp);
+    function isInDispute(uint _requestId, uint _timestamp) external view returns(bool){
+        return tellor.isInDispute(_requestId,_timestamp);
     }
+    
 
     /**
     * @dev Retreive value from oracle based on timestamp
@@ -341,16 +358,18 @@ contract OldTellorGetters2 {
     * @param _timestamp to retreive data/value from
     * @return value for timestamp submitted
     */
-    function retrieveData(uint256 _requestId, uint256 _timestamp) external view returns (uint256) {
-        return tellor.retrieveData(_requestId, _timestamp);
+    function retrieveData(uint _requestId, uint _timestamp) external view returns (uint) {
+        return tellor.retrieveData(_requestId,_timestamp);
     }
+
 
     /**
     * @dev Getter for the total_supply of oracle tokens
     * @return uint total supply
     */
-    function totalSupply() external view returns (uint256) {
-        return tellor.totalSupply();
+    function totalSupply() external view returns (uint) {
+       return tellor.totalSupply();
     }
+
 
 }

--- a/contracts/oldContracts/OldTellorMaster.sol
+++ b/contracts/oldContracts/OldTellorMaster.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.5.0;
 
-import "./TellorGetters.sol";
+import "./OldTellorGetters.sol";
 
 /**
 * @title Tellor Master
@@ -8,7 +8,7 @@ import "./TellorGetters.sol";
 * The logic for the functions on this contract is saved on the TellorGettersLibrary, TellorTransfer, 
 * TellorGettersLibrary, and TellorStake
 */
-contract OldTellorMaster is TellorGetters{
+contract OldTellorMaster is OldTellorGetters{
     
     event NewTellorAddress(address _newTellor);
 

--- a/contracts/oldContracts/libraries/OldSafeMath.sol
+++ b/contracts/oldContracts/libraries/OldSafeMath.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.5.0;
 
 //Slightly modified SafeMath library - includes a min and max function, removes useless div function
-library SafeMath {
+library OldSafeMath {
 
   function add(uint256 a, uint256 b) internal pure returns (uint256) {
     uint256 c = a + b;

--- a/contracts/oldContracts/libraries/OldTellorGettersLibrary.sol
+++ b/contracts/oldContracts/libraries/OldTellorGettersLibrary.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.5.0;
 
-import "./SafeMath.sol";
-import "./TellorStorage.sol";
+import "./OldSafeMath.sol";
+import "./OldTellorStorage.sol";
 import "./OldUtilities.sol";
 
 /**
@@ -9,8 +9,8 @@ import "./OldUtilities.sol";
 * @dev This is the getter library for all variables in the Tellor Tributes system. TellorGetters references this 
 * libary for the getters logic
 */
-library TellorGettersLibrary{
-    using SafeMath for uint256;
+library OldTellorGettersLibrary{
+    using OldSafeMath for uint256;
 
     event NewTellorAddress(address _newTellor); //emmited when a proposed fork is voted true
 
@@ -22,7 +22,7 @@ library TellorGettersLibrary{
     * @dev This function allows us to set a new Deity (or remove it) 
     * @param _newDeity address of the new Deity of the tellor system 
     */
-    function changeDeity(TellorStorage.TellorStorageStruct storage self, address _newDeity) internal{
+    function changeDeity(OldTellorStorage.TellorStorageStruct storage self, address _newDeity) internal{
         require(self.addressVars[keccak256("_deity")] == msg.sender);
         self.addressVars[keccak256("_deity")] =_newDeity;
     }
@@ -33,7 +33,7 @@ library TellorGettersLibrary{
     * @dev This function allows the deity to upgrade the Tellor System
     * @param _tellorContract address of new updated TellorCore contract
     */
-    function changeTellorContract(TellorStorage.TellorStorageStruct storage self,address _tellorContract) internal{
+    function changeTellorContract(OldTellorStorage.TellorStorageStruct storage self,address _tellorContract) internal{
         require(self.addressVars[keccak256("_deity")] == msg.sender);
         self.addressVars[keccak256("tellorContract")]= _tellorContract;
         emit NewTellorAddress(_tellorContract);
@@ -48,7 +48,7 @@ library TellorGettersLibrary{
     * @param _miner address that you want to know if they solved the challenge
     * @return true if the _miner address provided solved the 
     */
-    function didMine(TellorStorage.TellorStorageStruct storage self, bytes32 _challenge,address _miner) internal view returns(bool){
+    function didMine(OldTellorStorage.TellorStorageStruct storage self, bytes32 _challenge,address _miner) internal view returns(bool){
         return self.minersByChallenge[_challenge][_miner];
     }
     
@@ -59,7 +59,7 @@ library TellorGettersLibrary{
     * @param _address of voting party to look up
     * @return bool of whether or not party voted
     */
-    function didVote(TellorStorage.TellorStorageStruct storage self,uint _disputeId, address _address) internal view returns(bool){
+    function didVote(OldTellorStorage.TellorStorageStruct storage self,uint _disputeId, address _address) internal view returns(bool){
         return self.disputesById[_disputeId].voted[_address];
     }
 
@@ -71,7 +71,7 @@ library TellorGettersLibrary{
     * addressVars[keccak256("_owner")]
     * addressVars[keccak256("tellorContract")]
     */
-    function getAddressVars(TellorStorage.TellorStorageStruct storage self, bytes32 _data) view internal returns(address){
+    function getAddressVars(OldTellorStorage.TellorStorageStruct storage self, bytes32 _data) view internal returns(address){
         return self.addressVars[_data];
     }
 
@@ -97,8 +97,8 @@ library TellorGettersLibrary{
     * @return uint of fee
     * @return int count of the current tally
     */
-    function getAllDisputeVars(TellorStorage.TellorStorageStruct storage self,uint _disputeId) internal view returns(bytes32, bool, bool, bool, address, address, address,uint[9] memory, int){
-        TellorStorage.Dispute storage disp = self.disputesById[_disputeId];
+    function getAllDisputeVars(OldTellorStorage.TellorStorageStruct storage self,uint _disputeId) internal view returns(bytes32, bool, bool, bool, address, address, address,uint[9] memory, int){
+        OldTellorStorage.Dispute storage disp = self.disputesById[_disputeId];
         return(disp.hash,disp.executed, disp.disputeVotePassed, disp.isPropFork, disp.reportedMiner, disp.reportingParty,disp.proposedForkAddress,[disp.disputeUintVars[keccak256("requestId")], disp.disputeUintVars[keccak256("timestamp")], disp.disputeUintVars[keccak256("value")], disp.disputeUintVars[keccak256("minExecutionDate")], disp.disputeUintVars[keccak256("numberOfVotes")], disp.disputeUintVars[keccak256("blockNumber")], disp.disputeUintVars[keccak256("minerSlot")], disp.disputeUintVars[keccak256("quorum")],disp.disputeUintVars[keccak256("fee")]],disp.tally);
     }
 
@@ -107,7 +107,7 @@ library TellorGettersLibrary{
     * @dev Getter function for variables for the requestId being currently mined(currentRequestId)
     * @return current challenge, curretnRequestId, level of difficulty, api/query string, and granularity(number of decimals requested), total tip for the request 
     */
-    function getCurrentVariables(TellorStorage.TellorStorageStruct storage self) internal view returns(bytes32, uint, uint,string memory,uint,uint){    
+    function getCurrentVariables(OldTellorStorage.TellorStorageStruct storage self) internal view returns(bytes32, uint, uint,string memory,uint,uint){    
         return (self.currentChallenge,self.uintVars[keccak256("currentRequestId")],self.uintVars[keccak256("difficulty")],self.requestDetails[self.uintVars[keccak256("currentRequestId")]].queryString,self.requestDetails[self.uintVars[keccak256("currentRequestId")]].apiUintVars[keccak256("granularity")],self.requestDetails[self.uintVars[keccak256("currentRequestId")]].apiUintVars[keccak256("totalTip")]);
     }
 
@@ -117,7 +117,7 @@ library TellorGettersLibrary{
     * @param _hash is the sha256(abi.encodePacked(_miners[2],_requestId));
     * @return uint disputeId
     */
-    function getDisputeIdByDisputeHash(TellorStorage.TellorStorageStruct storage self,bytes32 _hash) internal view returns(uint){
+    function getDisputeIdByDisputeHash(OldTellorStorage.TellorStorageStruct storage self,bytes32 _hash) internal view returns(uint){
         return  self.disputeIdByDisputeHash[_hash];
     }
 
@@ -130,7 +130,7 @@ library TellorGettersLibrary{
     * commented out under the disputeUintVars under the Dispute struct
     * @return uint value for the bytes32 data submitted
     */
-    function getDisputeUintVars(TellorStorage.TellorStorageStruct storage self,uint _disputeId,bytes32 _data) internal view returns(uint){
+    function getDisputeUintVars(OldTellorStorage.TellorStorageStruct storage self,uint _disputeId,bytes32 _data) internal view returns(uint){
         return self.disputesById[_disputeId].disputeUintVars[_data];
     }
 
@@ -140,7 +140,7 @@ library TellorGettersLibrary{
     * @return value for timestamp of last proof of work submited
     * @return true if the is a timestamp for the lastNewValue
     */
-    function getLastNewValue(TellorStorage.TellorStorageStruct storage self) internal view returns(uint,bool){
+    function getLastNewValue(OldTellorStorage.TellorStorageStruct storage self) internal view returns(uint,bool){
         return (retrieveData(self,self.requestIdByTimestamp[self.uintVars[keccak256("timeOfLastNewValue")]], self.uintVars[keccak256("timeOfLastNewValue")]),true);
     }
 
@@ -150,8 +150,8 @@ library TellorGettersLibrary{
     * @param _requestId being requested
     * @return value for timestamp of last proof of work submited and if true if it exist or 0 and false if it doesn't
     */
-    function getLastNewValueById(TellorStorage.TellorStorageStruct storage self,uint _requestId) internal view returns(uint,bool){
-        TellorStorage.Request storage _request = self.requestDetails[_requestId]; 
+    function getLastNewValueById(OldTellorStorage.TellorStorageStruct storage self,uint _requestId) internal view returns(uint,bool){
+        OldTellorStorage.Request storage _request = self.requestDetails[_requestId]; 
         if(_request.requestTimestamps.length > 0){
             return (retrieveData(self,_requestId,_request.requestTimestamps[_request.requestTimestamps.length - 1]),true);
         }
@@ -167,7 +167,7 @@ library TellorGettersLibrary{
     * @param _timestamp is the timestamp to look up blocknumber
     * @return uint of the blocknumber which the dispute was mined
     */
-    function getMinedBlockNum(TellorStorage.TellorStorageStruct storage self,uint _requestId, uint _timestamp) internal view returns(uint){
+    function getMinedBlockNum(OldTellorStorage.TellorStorageStruct storage self,uint _requestId, uint _timestamp) internal view returns(uint){
         return self.requestDetails[_requestId].minedBlockNum[_timestamp];
     }
 
@@ -178,7 +178,7 @@ library TellorGettersLibrary{
     * @param _timestamp is the timestamp to look up miners for
     * @return the 5 miners' addresses
     */
-    function getMinersByRequestIdAndTimestamp(TellorStorage.TellorStorageStruct storage self, uint _requestId, uint _timestamp) internal view returns(address[5] memory){
+    function getMinersByRequestIdAndTimestamp(OldTellorStorage.TellorStorageStruct storage self, uint _requestId, uint _timestamp) internal view returns(address[5] memory){
         return self.requestDetails[_requestId].minersByValue[_timestamp];
     }
 
@@ -189,7 +189,7 @@ library TellorGettersLibrary{
     * @param _requestId the requestId to look up
     * @return uint count of the number of values received for the requestId
     */
-    function getNewValueCountbyRequestId(TellorStorage.TellorStorageStruct storage self, uint _requestId) internal view returns(uint){
+    function getNewValueCountbyRequestId(OldTellorStorage.TellorStorageStruct storage self, uint _requestId) internal view returns(uint){
         return self.requestDetails[_requestId].requestTimestamps.length;
     }
 
@@ -199,7 +199,7 @@ library TellorGettersLibrary{
     * @param _index to look up in the requestQ array
     * @return uint of reqeuestId
     */
-    function getRequestIdByRequestQIndex(TellorStorage.TellorStorageStruct storage self, uint _index) internal view returns(uint){
+    function getRequestIdByRequestQIndex(OldTellorStorage.TellorStorageStruct storage self, uint _index) internal view returns(uint){
         require(_index <= 50);
         return self.requestIdByRequestQIndex[_index];
     }
@@ -210,7 +210,7 @@ library TellorGettersLibrary{
     * @param _timestamp to check requestId
     * @return uint of reqeuestId
     */
-    function getRequestIdByTimestamp(TellorStorage.TellorStorageStruct storage self, uint _timestamp) internal view returns(uint){    
+    function getRequestIdByTimestamp(OldTellorStorage.TellorStorageStruct storage self, uint _timestamp) internal view returns(uint){    
         return self.requestIdByTimestamp[_timestamp];
     }
 
@@ -220,7 +220,7 @@ library TellorGettersLibrary{
     * @param _queryHash hash(of string api and granularity) to check if a request already exists
     * @return uint requestId
     */
-    function getRequestIdByQueryHash(TellorStorage.TellorStorageStruct storage self, bytes32 _queryHash) internal view returns(uint){    
+    function getRequestIdByQueryHash(OldTellorStorage.TellorStorageStruct storage self, bytes32 _queryHash) internal view returns(uint){    
         return self.requestIdByQueryHash[_queryHash];
     }
 
@@ -229,7 +229,7 @@ library TellorGettersLibrary{
     * @dev Getter function for the requestQ array
     * @return the requestQ arrray
     */
-    function getRequestQ(TellorStorage.TellorStorageStruct storage self) view internal returns(uint[51] memory){
+    function getRequestQ(OldTellorStorage.TellorStorageStruct storage self) view internal returns(uint[51] memory){
         return self.requestQ;
     }
 
@@ -243,7 +243,7 @@ library TellorGettersLibrary{
     * commented out under the apiUintVars under the requestDetails struct
     * @return uint value of the apiUintVars specified in _data for the requestId specified
     */
-    function getRequestUintVars(TellorStorage.TellorStorageStruct storage self,uint _requestId,bytes32 _data) internal view returns(uint){
+    function getRequestUintVars(OldTellorStorage.TellorStorageStruct storage self,uint _requestId,bytes32 _data) internal view returns(uint){
         return self.requestDetails[_requestId].apiUintVars[_data];
     }
 
@@ -258,8 +258,8 @@ library TellorGettersLibrary{
     * @return uint of index in requestQ array
     * @return uint of current payout/tip for this requestId
     */
-    function getRequestVars(TellorStorage.TellorStorageStruct storage self,uint _requestId) internal view returns(string memory,string memory, bytes32,uint, uint, uint) {
-        TellorStorage.Request storage _request = self.requestDetails[_requestId]; 
+    function getRequestVars(OldTellorStorage.TellorStorageStruct storage self,uint _requestId) internal view returns(string memory,string memory, bytes32,uint, uint, uint) {
+        OldTellorStorage.Request storage _request = self.requestDetails[_requestId]; 
         return (_request.queryString,_request.dataSymbol,_request.queryHash, _request.apiUintVars[keccak256("granularity")],_request.apiUintVars[keccak256("requestQPosition")],_request.apiUintVars[keccak256("totalTip")]);
     }
 
@@ -270,7 +270,7 @@ library TellorGettersLibrary{
     * @return uint current state of staker
     * @return uint startDate of staking
     */
-    function getStakerInfo(TellorStorage.TellorStorageStruct storage self,address _staker) internal view returns(uint,uint){
+    function getStakerInfo(OldTellorStorage.TellorStorageStruct storage self,address _staker) internal view returns(uint,uint){
         return (self.stakerDetails[_staker].currentStatus,self.stakerDetails[_staker].startDate);
     }
 
@@ -281,7 +281,7 @@ library TellorGettersLibrary{
     * @param _timestamp is the timestampt to look up miners for
     * @return address[5] array of 5 addresses ofminers that mined the requestId
     */
-    function getSubmissionsByTimestamp(TellorStorage.TellorStorageStruct storage self, uint _requestId, uint _timestamp) internal view returns(uint[5] memory){
+    function getSubmissionsByTimestamp(OldTellorStorage.TellorStorageStruct storage self, uint _requestId, uint _timestamp) internal view returns(uint[5] memory){
         return self.requestDetails[_requestId].valuesByTimestamp[_timestamp];
     }
 
@@ -292,7 +292,7 @@ library TellorGettersLibrary{
     * @param _index is the value index to look up
     * @return uint timestamp
     */
-    function getTimestampbyRequestIDandIndex(TellorStorage.TellorStorageStruct storage self,uint _requestID, uint _index) internal view returns(uint){
+    function getTimestampbyRequestIDandIndex(OldTellorStorage.TellorStorageStruct storage self,uint _requestID, uint _index) internal view returns(uint){
         return self.requestDetails[_requestID].requestTimestamps[_index];
     }
 
@@ -306,7 +306,7 @@ library TellorGettersLibrary{
     * self.uintVars[keccak256("stakerCount")]
     * @return uint of specified variable  
     */ 
-    function getUintVar(TellorStorage.TellorStorageStruct storage self,bytes32 _data) view internal returns(uint){
+    function getUintVar(OldTellorStorage.TellorStorageStruct storage self,bytes32 _data) view internal returns(uint){
         return self.uintVars[_data];
     }
 
@@ -315,7 +315,7 @@ library TellorGettersLibrary{
     * @dev Getter function for next requestId on queue/request with highest payout at time the function is called
     * @return onDeck/info on request with highest payout-- RequestId, Totaltips, and API query string
     */
-    function getVariablesOnDeck(TellorStorage.TellorStorageStruct storage self) internal view returns(uint, uint,string memory){ 
+    function getVariablesOnDeck(OldTellorStorage.TellorStorageStruct storage self) internal view returns(uint, uint,string memory){ 
         uint newRequestId = getTopRequestID(self);
         return (newRequestId,self.requestDetails[newRequestId].apiUintVars[keccak256("totalTip")],self.requestDetails[newRequestId].queryString);
     }
@@ -325,7 +325,7 @@ library TellorGettersLibrary{
     * @dev Getter function for the request with highest payout. This function is used within the getVariablesOnDeck function
     * @return uint _requestId of request with highest payout at the time the function is called
     */
-    function getTopRequestID(TellorStorage.TellorStorageStruct storage self) internal view returns(uint _requestId){
+    function getTopRequestID(OldTellorStorage.TellorStorageStruct storage self) internal view returns(uint _requestId){
             uint _max;
             uint _index;
             (_max,_index) = OldUtilities.getMax(self.requestQ);
@@ -339,7 +339,7 @@ library TellorGettersLibrary{
     * @param _timestamp is the timestamp to look up miners for
     * @return bool true if requestId/timestamp is under dispute
     */
-    function isInDispute(TellorStorage.TellorStorageStruct storage self, uint _requestId, uint _timestamp) internal view returns(bool){
+    function isInDispute(OldTellorStorage.TellorStorageStruct storage self, uint _requestId, uint _timestamp) internal view returns(bool){
         return self.requestDetails[_requestId].inDispute[_timestamp];
     }
 
@@ -350,7 +350,7 @@ library TellorGettersLibrary{
     * @param _timestamp to retreive data/value from
     * @return uint value for requestId/timestamp submitted
     */
-    function retrieveData(TellorStorage.TellorStorageStruct storage self, uint _requestId, uint _timestamp) internal view returns (uint) {
+    function retrieveData(OldTellorStorage.TellorStorageStruct storage self, uint _requestId, uint _timestamp) internal view returns (uint) {
         return self.requestDetails[_requestId].finalValues[_timestamp];
     }
 
@@ -359,7 +359,7 @@ library TellorGettersLibrary{
     * @dev Getter for the total_supply of oracle tokens
     * @return uint total supply
     */
-    function totalSupply(TellorStorage.TellorStorageStruct storage self) internal view returns (uint) {
+    function totalSupply(OldTellorStorage.TellorStorageStruct storage self) internal view returns (uint) {
        return self.uintVars[keccak256("total_supply")];
     }
 

--- a/contracts/oldContracts/libraries/OldTellorStake.sol
+++ b/contracts/oldContracts/libraries/OldTellorStake.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.5.0;
 
-import "./TellorStorage.sol";
+import "./OldTellorStorage.sol";
 import "./OldTellorTransfer.sol";
 import "./OldTellorDispute.sol";
 
@@ -21,7 +21,7 @@ library OldTellorStake {
     * @dev This function stakes the five initial miners, sets the supply and all the constant variables.
     * This function is called by the constructor function on TellorMaster.sol
     */
-    function init(TellorStorage.TellorStorageStruct storage self) public{
+    function init(OldTellorStorage.TellorStorageStruct storage self) public{
         require(self.uintVars[keccak256("decimals")] == 0);
         //Give this contract 6000 Tellor Tributes so that it can stake the initial 6 miners
         OldTellorTransfer.updateBalanceAtNow(self.balances[address(this)], 2**256-1 - 6000e18);
@@ -60,8 +60,8 @@ library OldTellorStake {
     * once they lock for withdraw(stakes.currentStatus = 2) they are locked for 7 days before they
     * can withdraw the deposit
     */
-    function requestStakingWithdraw(TellorStorage.TellorStorageStruct storage self) public {
-        TellorStorage.StakeInfo storage stakes = self.stakerDetails[msg.sender];
+    function requestStakingWithdraw(OldTellorStorage.TellorStorageStruct storage self) public {
+        OldTellorStorage.StakeInfo storage stakes = self.stakerDetails[msg.sender];
         //Require that the miner is staked
         require(stakes.currentStatus == 1);
 
@@ -82,8 +82,8 @@ library OldTellorStake {
     /**
     * @dev This function allows users to withdraw their stake after a 7 day waiting period from request 
     */
-    function withdrawStake(TellorStorage.TellorStorageStruct storage self) public {
-        TellorStorage.StakeInfo storage stakes = self.stakerDetails[msg.sender];
+    function withdrawStake(OldTellorStorage.TellorStorageStruct storage self) public {
+        OldTellorStorage.StakeInfo storage stakes = self.stakerDetails[msg.sender];
         //Require the staker has locked for withdraw(currentStatus ==2) and that 7 days have 
         //passed by since they locked for withdraw
         require(now - (now % 86400) - stakes.startDate >= 7 days);
@@ -96,7 +96,7 @@ library OldTellorStake {
     /**
     * @dev This function allows miners to deposit their stake.
     */
-    function depositStake(TellorStorage.TellorStorageStruct storage self) public {
+    function depositStake(OldTellorStorage.TellorStorageStruct storage self) public {
       newStake(self, msg.sender);
       //self adjusting disputeFee
       OldTellorDispute.updateDisputeFee(self);
@@ -107,13 +107,13 @@ library OldTellorStake {
     * The function updates their status/state and status start date so they are locked it so they can't withdraw
     * and updates the number of stakers in the system.
     */
-    function newStake(TellorStorage.TellorStorageStruct storage self, address staker) internal {
+    function newStake(OldTellorStorage.TellorStorageStruct storage self, address staker) internal {
         require(OldTellorTransfer.balanceOf(self,staker) >= self.uintVars[keccak256("stakeAmount")]);
         //Ensure they can only stake if they are not currrently staked or if their stake time frame has ended
         //and they are currently locked for witdhraw
         require(self.stakerDetails[staker].currentStatus == 0 || self.stakerDetails[staker].currentStatus == 2);
         self.uintVars[keccak256("stakerCount")] += 1;
-        self.stakerDetails[staker] = TellorStorage.StakeInfo({
+        self.stakerDetails[staker] = OldTellorStorage.StakeInfo({
             currentStatus: 1,
             //this resets their stake start date to today
             startDate: now - (now % 86400)

--- a/contracts/oldContracts/libraries/OldTellorStorage.sol
+++ b/contracts/oldContracts/libraries/OldTellorStorage.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.5.0;
  * @dev Contains all the variables/structs used by Tellor
  */
 
-library TellorStorage {
+library OldTellorStorage {
     //Internal struct for use in proof-of-work submission
     struct Details {
         uint value;

--- a/contracts/oldContracts/libraries/OldTellorTransfer.sol
+++ b/contracts/oldContracts/libraries/OldTellorTransfer.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.5.0;
 
-import "./SafeMath.sol";
-import "./TellorStorage.sol";
+import "./OldSafeMath.sol";
+import "./OldTellorStorage.sol";
 
 
 /**
@@ -10,7 +10,7 @@ import "./TellorStorage.sol";
 * reference this library for function's logic.
 */
 library OldTellorTransfer {
-    using SafeMath for uint256;
+    using OldSafeMath for uint256;
 
     event Approval(address indexed _owner, address indexed _spender, uint256 _value);//ERC20 Approval event
     event Transfer(address indexed _from, address indexed _to, uint256 _value);//ERC20 Transfer Event
@@ -23,7 +23,7 @@ library OldTellorTransfer {
     * @param _amount The amount of tokens to send
     * @return true if transfer is successful
     */
-    function transfer(TellorStorage.TellorStorageStruct storage self, address _to, uint256 _amount) public returns (bool success) {
+    function transfer(OldTellorStorage.TellorStorageStruct storage self, address _to, uint256 _amount) public returns (bool success) {
         doTransfer(self,msg.sender, _to, _amount);
         return true;
     }
@@ -37,7 +37,7 @@ library OldTellorTransfer {
     * @param _amount The amount of tokens to be transferred
     * @return True if the transfer was successful
     */
-    function transferFrom(TellorStorage.TellorStorageStruct storage self, address _from, address _to, uint256 _amount) public returns (bool success) {
+    function transferFrom(OldTellorStorage.TellorStorageStruct storage self, address _from, address _to, uint256 _amount) public returns (bool success) {
         require(self.allowed[_from][msg.sender] >= _amount);
         self.allowed[_from][msg.sender] -= _amount;
         doTransfer(self,_from, _to, _amount);
@@ -51,7 +51,7 @@ library OldTellorTransfer {
     * @param _amount amount the spender is being approved for
     * @return true if spender appproved successfully
     */
-    function approve(TellorStorage.TellorStorageStruct storage self, address _spender, uint _amount) public returns (bool) {
+    function approve(OldTellorStorage.TellorStorageStruct storage self, address _spender, uint _amount) public returns (bool) {
         require(allowedToTrade(self,msg.sender,_amount));
         require(_spender != address(0));
         self.allowed[msg.sender][_spender] = _amount;
@@ -65,7 +65,7 @@ library OldTellorTransfer {
     * @param _spender address of spender of parties said balance
     * @return Returns the remaining allowance of tokens granted to the _spender from the _user
     */
-    function allowance(TellorStorage.TellorStorageStruct storage self,address _user, address _spender) public view returns (uint) {
+    function allowance(OldTellorStorage.TellorStorageStruct storage self,address _user, address _spender) public view returns (uint) {
        return self.allowed[_user][_spender]; 
     }
 
@@ -76,7 +76,7 @@ library OldTellorTransfer {
     * @param _to addres to transfer to
     * @param _amount to transfer
     */
-    function doTransfer(TellorStorage.TellorStorageStruct storage self, address _from, address _to, uint _amount) public {
+    function doTransfer(OldTellorStorage.TellorStorageStruct storage self, address _from, address _to, uint _amount) public {
         require(_amount > 0);
         require(_to != address(0));
         require(allowedToTrade(self,_from,_amount)); //allowedToTrade checks the stakeAmount is removed from balance if the _user is staked
@@ -94,7 +94,7 @@ library OldTellorTransfer {
     * @param _user is the owner address used to look up the balance
     * @return Returns the balance associated with the passed in _user
     */
-    function balanceOf(TellorStorage.TellorStorageStruct storage self,address _user) public view returns (uint) {
+    function balanceOf(OldTellorStorage.TellorStorageStruct storage self,address _user) public view returns (uint) {
         return balanceOfAt(self,_user, block.number);
     }
 
@@ -105,7 +105,7 @@ library OldTellorTransfer {
     * @param _blockNumber The block number when the balance is queried
     * @return The balance at _blockNumber specified
     */
-    function balanceOfAt(TellorStorage.TellorStorageStruct storage self,address _user, uint _blockNumber) public view returns (uint) {
+    function balanceOfAt(OldTellorStorage.TellorStorageStruct storage self,address _user, uint _blockNumber) public view returns (uint) {
         if ((self.balances[_user].length == 0) || (self.balances[_user][0].fromBlock > _blockNumber)) {
                 return 0;
         }
@@ -121,7 +121,7 @@ library OldTellorTransfer {
     * @param _block is the block number to search the balance on
     * @return the balance at the checkpoint
     */
-    function getBalanceAt(TellorStorage.Checkpoint[] storage checkpoints, uint _block) view public returns (uint) {
+    function getBalanceAt(OldTellorStorage.Checkpoint[] storage checkpoints, uint _block) view public returns (uint) {
         if (checkpoints.length == 0) return 0;
         if (_block >= checkpoints[checkpoints.length-1].fromBlock)
             return checkpoints[checkpoints.length-1].value;
@@ -148,7 +148,7 @@ library OldTellorTransfer {
     * @param _amount to check if the user can spend
     * @return true if they are allowed to spend the amount being checked
     */
-    function allowedToTrade(TellorStorage.TellorStorageStruct storage self,address _user,uint _amount) public view returns(bool) {
+    function allowedToTrade(OldTellorStorage.TellorStorageStruct storage self,address _user,uint _amount) public view returns(bool) {
         if(self.stakerDetails[_user].currentStatus >0){
             //Removes the stakeAmount from balance if the _user is staked
             if(balanceOf(self,_user).sub(self.uintVars[keccak256("stakeAmount")]).sub(_amount) >= 0){
@@ -167,13 +167,13 @@ library OldTellorTransfer {
     * @param checkpoints gets the mapping for the balances[owner]
     * @param _value is the new balance
     */
-    function updateBalanceAtNow(TellorStorage.Checkpoint[] storage checkpoints, uint _value) public {
+    function updateBalanceAtNow(OldTellorStorage.Checkpoint[] storage checkpoints, uint _value) public {
         if ((checkpoints.length == 0) || (checkpoints[checkpoints.length -1].fromBlock < block.number)) {
-               TellorStorage.Checkpoint storage newCheckPoint = checkpoints[ checkpoints.length++ ];
+               OldTellorStorage.Checkpoint storage newCheckPoint = checkpoints[ checkpoints.length++ ];
                newCheckPoint.fromBlock =  uint128(block.number);
                newCheckPoint.value = uint128(_value);
         } else {
-               TellorStorage.Checkpoint storage oldCheckPoint = checkpoints[checkpoints.length-1];
+               OldTellorStorage.Checkpoint storage oldCheckPoint = checkpoints[checkpoints.length-1];
                oldCheckPoint.value = uint128(_value);
         }
     }

--- a/contracts/oldContracts2/Old2Tellor.sol
+++ b/contracts/oldContracts2/Old2Tellor.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.5.0;
 
-import "./libraries/SafeMath.sol";
-import "./libraries/TellorStorage.sol";
+import "./libraries/Old2SafeMath.sol";
+import "./libraries/Old2TellorStorage.sol";
 import "./libraries/Old2TellorTransfer.sol";
 import "./libraries/Old2TellorDispute.sol";
 import "./libraries/Old2TellorStake.sol";
@@ -14,14 +14,14 @@ import "./libraries/Old2TellorLibrary.sol";
  * and TellorTransfer.sol
  */
 contract OldTellor2 {
-    using SafeMath for uint256;
+    using Old2SafeMath for uint256;
 
-    using Old2TellorDispute for TellorStorage.TellorStorageStruct;
-    using Old2TellorLibrary for TellorStorage.TellorStorageStruct;
-    using Old2TellorStake for TellorStorage.TellorStorageStruct;
-    using Old2TellorTransfer for TellorStorage.TellorStorageStruct;
+    using Old2TellorDispute for Old2TellorStorage.TellorStorageStruct;
+    using Old2TellorLibrary for Old2TellorStorage.TellorStorageStruct;
+    using Old2TellorStake for Old2TellorStorage.TellorStorageStruct;
+    using Old2TellorTransfer for Old2TellorStorage.TellorStorageStruct;
 
-    TellorStorage.TellorStorageStruct tellor;
+    Old2TellorStorage.TellorStorageStruct tellor;
 
     /*Functions*/
 

--- a/contracts/oldContracts2/Old2TellorGetters.sol
+++ b/contracts/oldContracts2/Old2TellorGetters.sol
@@ -1,42 +1,42 @@
 pragma solidity ^0.5.0;
 
-import "./libraries/SafeMath.sol";
-import "./libraries/TellorStorage.sol";
-import "./libraries/OldTellorTransfer.sol";
-import "./libraries/TellorGettersLibrary.sol";
-import "./libraries/OldTellorStake.sol";
+import "./libraries/Old2SafeMath.sol";
+import "./libraries/Old2TellorStorage.sol";
+import "./libraries/Old2TellorTransfer.sol";
+import "./libraries/Old2TellorGettersLibrary.sol";
+import "./libraries/Old2TellorStake.sol";
 
 /**
 * @title Tellor Getters
-* @dev Oracle contract with all tellor getter functions. The logic for the functions on this contract 
+* @dev Oracle contract with all tellor getter functions. The logic for the functions on this contract
 * is saved on the TellorGettersLibrary, TellorTransfer, TellorGettersLibrary, and TellorStake
 */
-contract TellorGetters{
-    using SafeMath for uint256;
+contract Old2TellorGetters {
+    using Old2SafeMath for uint256;
 
-    using OldTellorTransfer for TellorStorage.TellorStorageStruct;
-    using TellorGettersLibrary for TellorStorage.TellorStorageStruct;
-    using OldTellorStake for TellorStorage.TellorStorageStruct;
+    using Old2TellorTransfer for Old2TellorStorage.TellorStorageStruct;
+    using Old2TellorGettersLibrary for Old2TellorStorage.TellorStorageStruct;
+    using Old2TellorStake for Old2TellorStorage.TellorStorageStruct;
 
-    TellorStorage.TellorStorageStruct tellor;
-    
+    Old2TellorStorage.TellorStorageStruct tellor;
+
     /**
     * @param _user address
     * @param _spender address
     * @return Returns the remaining allowance of tokens granted to the _spender from the _user
     */
-    function allowance(address _user, address _spender) external view returns (uint) {
-       return tellor.allowance(_user,_spender);
+    function allowance(address _user, address _spender) external view returns (uint256) {
+        return tellor.allowance(_user, _spender);
     }
 
     /**
-    * @dev This function returns whether or not a given user is allowed to trade a given amount  
+    * @dev This function returns whether or not a given user is allowed to trade a given amount
     * @param _user address
     * @param _amount uint of amount
     * @return true if the user is alloed to trade the amount specified
     */
-    function allowedToTrade(address _user,uint _amount) external view returns(bool){
-        return tellor.allowedToTrade(_user,_amount);
+    function allowedToTrade(address _user, uint256 _amount) external view returns (bool) {
+        return tellor.allowedToTrade(_user, _amount);
     }
 
     /**
@@ -44,7 +44,7 @@ contract TellorGetters{
     * @param _user is the owner address used to look up the balance
     * @return Returns the balance associated with the passed in _user
     */
-    function balanceOf(address _user) external view returns (uint) { 
+    function balanceOf(address _user) external view returns (uint256) {
         return tellor.balanceOf(_user);
     }
 
@@ -54,20 +54,19 @@ contract TellorGetters{
     * @param _blockNumber The block number when the balance is queried
     * @return The balance at _blockNumber
     */
-    function balanceOfAt(address _user, uint _blockNumber) external view returns (uint) {
-        return tellor.balanceOfAt(_user,_blockNumber);
+    function balanceOfAt(address _user, uint256 _blockNumber) external view returns (uint256) {
+        return tellor.balanceOfAt(_user, _blockNumber);
     }
 
     /**
     * @dev This function tells you if a given challenge has been completed by a given miner
     * @param _challenge the challenge to search for
     * @param _miner address that you want to know if they solved the challenge
-    * @return true if the _miner address provided solved the 
+    * @return true if the _miner address provided solved the
     */
-    function didMine(bytes32 _challenge, address _miner) external view returns(bool){
-        return tellor.didMine(_challenge,_miner);
+    function didMine(bytes32 _challenge, address _miner) external view returns (bool) {
+        return tellor.didMine(_challenge, _miner);
     }
-
 
     /**
     * @dev Checks if an address voted in a given dispute
@@ -75,27 +74,25 @@ contract TellorGetters{
     * @param _address to look up
     * @return bool of whether or not party voted
     */
-    function didVote(uint _disputeId, address _address) external view returns(bool){
-        return tellor.didVote(_disputeId,_address);
+    function didVote(uint256 _disputeId, address _address) external view returns (bool) {
+        return tellor.didVote(_disputeId, _address);
     }
-
 
     /**
     * @dev allows Tellor to read data from the addressVars mapping
-    * @param _data is the keccak256("variable_name") of the variable that is being accessed. 
+    * @param _data is the keccak256("variable_name") of the variable that is being accessed.
     * These are examples of how the variables are saved within other functions:
     * addressVars[keccak256("_owner")]
     * addressVars[keccak256("tellorContract")]
     */
-    function getAddressVars(bytes32 _data) view external returns(address){
+    function getAddressVars(bytes32 _data) external view returns (address) {
         return tellor.getAddressVars(_data);
     }
-
 
     /**
     * @dev Gets all dispute variables
     * @param _disputeId to look up
-    * @return bytes32 hash of dispute 
+    * @return bytes32 hash of dispute
     * @return bool executed where true if it has been voted on
     * @return bool disputeVotePassed
     * @return bool isPropFork true if the dispute is a proposed fork
@@ -113,16 +110,19 @@ contract TellorGetters{
     * @return uint of fee
     * @return int count of the current tally
     */
-    function getAllDisputeVars(uint _disputeId) public view returns(bytes32, bool, bool, bool, address, address, address,uint[9] memory, int){
+    function getAllDisputeVars(uint256 _disputeId)
+        public
+        view
+        returns (bytes32, bool, bool, bool, address, address, address, uint256[9] memory, int256)
+    {
         return tellor.getAllDisputeVars(_disputeId);
     }
-    
 
     /**
     * @dev Getter function for variables for the requestId being currently mined(currentRequestId)
-    * @return current challenge, curretnRequestId, level of difficulty, api/query string, and granularity(number of decimals requested), total tip for the request 
+    * @return current challenge, curretnRequestId, level of difficulty, api/query string, and granularity(number of decimals requested), total tip for the request
     */
-    function getCurrentVariables() external view returns(bytes32, uint, uint,string memory,uint,uint){    
+    function getCurrentVariables() external view returns (bytes32, uint256, uint256, string memory, uint256, uint256) {
         return tellor.getCurrentVariables();
     }
 
@@ -131,103 +131,94 @@ contract TellorGetters{
     * @param _hash is the sha256(abi.encodePacked(_miners[2],_requestId));
     * @return uint disputeId
     */
-    function getDisputeIdByDisputeHash(bytes32 _hash) external view returns(uint){
-        return  tellor.getDisputeIdByDisputeHash(_hash);
+    function getDisputeIdByDisputeHash(bytes32 _hash) external view returns (uint256) {
+        return tellor.getDisputeIdByDisputeHash(_hash);
     }
-    
 
     /**
     * @dev Checks for uint variables in the disputeUintVars mapping based on the disuputeId
     * @param _disputeId is the dispute id;
-    * @param _data the variable to pull from the mapping. _data = keccak256("variable_name") where variable_name is 
-    * the variables/strings used to save the data in the mapping. The variables names are  
+    * @param _data the variable to pull from the mapping. _data = keccak256("variable_name") where variable_name is
+    * the variables/strings used to save the data in the mapping. The variables names are
     * commented out under the disputeUintVars under the Dispute struct
     * @return uint value for the bytes32 data submitted
     */
-    function getDisputeUintVars(uint _disputeId,bytes32 _data) external view returns(uint){
-        return tellor.getDisputeUintVars(_disputeId,_data);
+    function getDisputeUintVars(uint256 _disputeId, bytes32 _data) external view returns (uint256) {
+        return tellor.getDisputeUintVars(_disputeId, _data);
     }
-
 
     /**
     * @dev Gets the a value for the latest timestamp available
     * @return value for timestamp of last proof of work submited
     * @return true if the is a timestamp for the lastNewValue
     */
-    function getLastNewValue() external view returns(uint,bool){
+    function getLastNewValue() external view returns (uint256, bool) {
         return tellor.getLastNewValue();
     }
-
 
     /**
     * @dev Gets the a value for the latest timestamp available
     * @param _requestId being requested
     * @return value for timestamp of last proof of work submited and if true if it exist or 0 and false if it doesn't
     */
-    function getLastNewValueById(uint _requestId) external view returns(uint,bool){
+    function getLastNewValueById(uint256 _requestId) external view returns (uint256, bool) {
         return tellor.getLastNewValueById(_requestId);
     }
-        
 
     /**
-    * @dev Gets blocknumber for mined timestamp 
+    * @dev Gets blocknumber for mined timestamp
     * @param _requestId to look up
     * @param _timestamp is the timestamp to look up blocknumber
     * @return uint of the blocknumber which the dispute was mined
     */
-    function getMinedBlockNum(uint _requestId, uint _timestamp) external view returns(uint){
-        return tellor.getMinedBlockNum(_requestId,_timestamp);
+    function getMinedBlockNum(uint256 _requestId, uint256 _timestamp) external view returns (uint256) {
+        return tellor.getMinedBlockNum(_requestId, _timestamp);
     }
 
-
     /**
-    * @dev Gets the 5 miners who mined the value for the specified requestId/_timestamp 
+    * @dev Gets the 5 miners who mined the value for the specified requestId/_timestamp
     * @param _requestId to look up
     * @param _timestamp is the timestamp to look up miners for
     * @return the 5 miners' addresses
     */
-    function getMinersByRequestIdAndTimestamp(uint _requestId, uint _timestamp) external view returns(address[5] memory){
-        return tellor.getMinersByRequestIdAndTimestamp(_requestId,_timestamp);
+    function getMinersByRequestIdAndTimestamp(uint256 _requestId, uint256 _timestamp) external view returns (address[5] memory) {
+        return tellor.getMinersByRequestIdAndTimestamp(_requestId, _timestamp);
     }
-
 
     /**
     * @dev Get the name of the token
     * return string of the token name
     */
-    function getName() external pure returns(string memory){
-        return "Tellor Tributes";
+/*    function getName() external view returns (string memory) {
+        return tellor.getName();
     }
-
-
+*/
     /**
-    * @dev Counts the number of values that have been submited for the request 
+    * @dev Counts the number of values that have been submited for the request
     * if called for the currentRequest being mined it can tell you how many miners have submitted a value for that
     * request so far
     * @param _requestId the requestId to look up
     * @return uint count of the number of values received for the requestId
     */
-    function getNewValueCountbyRequestId(uint _requestId) external view returns(uint){
+    function getNewValueCountbyRequestId(uint256 _requestId) external view returns (uint256) {
         return tellor.getNewValueCountbyRequestId(_requestId);
     }
-
 
     /**
     * @dev Getter function for the specified requestQ index
     * @param _index to look up in the requestQ array
     * @return uint of reqeuestId
     */
-    function getRequestIdByRequestQIndex(uint _index) external view returns(uint){
+    function getRequestIdByRequestQIndex(uint256 _index) external view returns (uint256) {
         return tellor.getRequestIdByRequestQIndex(_index);
     }
 
-
     /**
-    * @dev Getter function for requestId based on timestamp 
+    * @dev Getter function for requestId based on timestamp
     * @param _timestamp to check requestId
     * @return uint of reqeuestId
     */
-    function getRequestIdByTimestamp(uint _timestamp) external view returns(uint){    
+    function getRequestIdByTimestamp(uint256 _timestamp) external view returns (uint256) {
         return tellor.getRequestIdByTimestamp(_timestamp);
     }
 
@@ -236,33 +227,30 @@ contract TellorGetters{
     * @param _request is the hash(of string api and granularity) to check if a request already exists
     * @return uint requestId
     */
-    function getRequestIdByQueryHash(bytes32 _request) external view returns(uint){    
+    function getRequestIdByQueryHash(bytes32 _request) external view returns (uint256) {
         return tellor.getRequestIdByQueryHash(_request);
     }
-
 
     /**
     * @dev Getter function for the requestQ array
     * @return the requestQ arrray
     */
-    function getRequestQ() view public returns(uint[51] memory){
+    function getRequestQ() public view returns (uint256[51] memory) {
         return tellor.getRequestQ();
     }
-
 
     /**
     * @dev Allowes access to the uint variables saved in the apiUintVars under the requestDetails struct
     * for the requestId specified
     * @param _requestId to look up
-    * @param _data the variable to pull from the mapping. _data = keccak256("variable_name") where variable_name is 
-    * the variables/strings used to save the data in the mapping. The variables names are  
+    * @param _data the variable to pull from the mapping. _data = keccak256("variable_name") where variable_name is
+    * the variables/strings used to save the data in the mapping. The variables names are
     * commented out under the apiUintVars under the requestDetails struct
     * @return uint value of the apiUintVars specified in _data for the requestId specified
     */
-    function getRequestUintVars(uint _requestId,bytes32 _data) external view returns(uint){
-        return tellor.getRequestUintVars(_requestId,_data);
+    function getRequestUintVars(uint256 _requestId, bytes32 _data) external view returns (uint256) {
+        return tellor.getRequestUintVars(_requestId, _data);
     }
-
 
     /**
     * @dev Gets the API struct variables that are not mappings
@@ -274,10 +262,9 @@ contract TellorGetters{
     * @return uint of index in requestQ array
     * @return uint of current payout/tip for this requestId
     */
-    function getRequestVars(uint _requestId) external view returns(string memory, string memory,bytes32,uint, uint, uint) {
+    function getRequestVars(uint256 _requestId) external view returns (string memory, string memory, bytes32, uint256, uint256, uint256) {
         return tellor.getRequestVars(_requestId);
     }
-
 
     /**
     * @dev This function allows users to retireve all information about a staker
@@ -285,27 +272,27 @@ contract TellorGetters{
     * @return uint current state of staker
     * @return uint startDate of staking
     */
-    function getStakerInfo(address _staker) external view returns(uint,uint){
+    function getStakerInfo(address _staker) external view returns (uint256, uint256) {
         return tellor.getStakerInfo(_staker);
     }
-    
+
     /**
-    * @dev Gets the 5 miners who mined the value for the specified requestId/_timestamp 
+    * @dev Gets the 5 miners who mined the value for the specified requestId/_timestamp
     * @param _requestId to look up
     * @param _timestamp is the timestampt to look up miners for
     * @return address[5] array of 5 addresses ofminers that mined the requestId
-    */    
-    function getSubmissionsByTimestamp(uint _requestId, uint _timestamp) external view returns(uint[5] memory){
-        return tellor.getSubmissionsByTimestamp(_requestId,_timestamp);
+    */
+    function getSubmissionsByTimestamp(uint256 _requestId, uint256 _timestamp) external view returns (uint256[5] memory) {
+        return tellor.getSubmissionsByTimestamp(_requestId, _timestamp);
     }
 
     /**
     * @dev Get the symbol of the token
     * return string of the token symbol
     */
-    function getSymbol() external pure returns(string memory){
-        return "TT";
-    } 
+/*    function getSymbol() external view returns (string memory) {
+        return tellor.getSymbol();
+    }*/
 
     /**
     * @dev Gets the timestamp for the value based on their index
@@ -313,44 +300,40 @@ contract TellorGetters{
     * @param _index is the value index to look up
     * @return uint timestamp
     */
-    function getTimestampbyRequestIDandIndex(uint _requestID, uint _index) external view returns(uint){
-        return tellor.getTimestampbyRequestIDandIndex(_requestID,_index);
+    function getTimestampbyRequestIDandIndex(uint256 _requestID, uint256 _index) external view returns (uint256) {
+        return tellor.getTimestampbyRequestIDandIndex(_requestID, _index);
     }
-
 
     /**
     * @dev Getter for the variables saved under the TellorStorageStruct uintVars variable
-    * @param _data the variable to pull from the mapping. _data = keccak256("variable_name") where variable_name is 
-    * the variables/strings used to save the data in the mapping. The variables names are  
+    * @param _data the variable to pull from the mapping. _data = keccak256("variable_name") where variable_name is
+    * the variables/strings used to save the data in the mapping. The variables names are
     * commented out under the uintVars under the TellorStorageStruct struct
-    * This is an example of how data is saved into the mapping within other functions: 
+    * This is an example of how data is saved into the mapping within other functions:
     * self.uintVars[keccak256("stakerCount")]
-    * @return uint of specified variable  
-    */ 
-    function getUintVar(bytes32 _data) view public returns(uint){
+    * @return uint of specified variable
+    */
+    function getUintVar(bytes32 _data) public view returns (uint256) {
         return tellor.getUintVar(_data);
     }
-
 
     /**
     * @dev Getter function for next requestId on queue/request with highest payout at time the function is called
     * @return onDeck/info on request with highest payout-- RequestId, Totaltips, and API query string
     */
-    function getVariablesOnDeck() external view returns(uint, uint,string memory){    
+    function getVariablesOnDeck() external view returns (uint256, uint256, string memory) {
         return tellor.getVariablesOnDeck();
     }
 
-    
     /**
-    * @dev Gets the 5 miners who mined the value for the specified requestId/_timestamp 
+    * @dev Gets the 5 miners who mined the value for the specified requestId/_timestamp
     * @param _requestId to look up
     * @param _timestamp is the timestamp to look up miners for
     * @return bool true if requestId/timestamp is under dispute
     */
-    function isInDispute(uint _requestId, uint _timestamp) external view returns(bool){
-        return tellor.isInDispute(_requestId,_timestamp);
+    function isInDispute(uint256 _requestId, uint256 _timestamp) external view returns (bool) {
+        return tellor.isInDispute(_requestId, _timestamp);
     }
-    
 
     /**
     * @dev Retreive value from oracle based on timestamp
@@ -358,18 +341,16 @@ contract TellorGetters{
     * @param _timestamp to retreive data/value from
     * @return value for timestamp submitted
     */
-    function retrieveData(uint _requestId, uint _timestamp) external view returns (uint) {
-        return tellor.retrieveData(_requestId,_timestamp);
+    function retrieveData(uint256 _requestId, uint256 _timestamp) external view returns (uint256) {
+        return tellor.retrieveData(_requestId, _timestamp);
     }
-
 
     /**
     * @dev Getter for the total_supply of oracle tokens
     * @return uint total supply
     */
-    function totalSupply() external view returns (uint) {
-       return tellor.totalSupply();
+    function totalSupply() external view returns (uint256) {
+        return tellor.totalSupply();
     }
-
 
 }

--- a/contracts/oldContracts2/Old2TellorMaster.sol
+++ b/contracts/oldContracts2/Old2TellorMaster.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.5.0;
 
-import "./OldTellorGetters2.sol";
+import "./Old2TellorGetters.sol";
 
 /**
 * @title Tellor Master
@@ -8,7 +8,7 @@ import "./OldTellorGetters2.sol";
 * The logic for the functions on this contract is saved on the TellorGettersLibrary, TellorTransfer,
 * TellorGettersLibrary, and TellorStake
 */
-contract OldTellorMaster2 is OldTellorGetters2 {
+contract OldTellorMaster2 is Old2TellorGetters {
     event NewTellorAddress(address _newTellor);
 
     /**

--- a/contracts/oldContracts2/libraries/Old2SafeMath.sol
+++ b/contracts/oldContracts2/libraries/Old2SafeMath.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.5.0;
 
 //Slightly modified SafeMath library - includes a min and max function, removes useless div function
-library SafeMath {
+library Old2SafeMath {
     function add(uint256 a, uint256 b) internal pure returns (uint256) {
         uint256 c = a + b;
         assert(c >= a);

--- a/contracts/oldContracts2/libraries/Old2TellorGettersLibrary.sol
+++ b/contracts/oldContracts2/libraries/Old2TellorGettersLibrary.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.5.0;
 
-import "./SafeMath.sol";
-import "./TellorStorage.sol";
+import "./Old2SafeMath.sol";
+import "./Old2TellorStorage.sol";
 import "./Old2Utilities.sol";
 
 /**
@@ -9,8 +9,8 @@ import "./Old2Utilities.sol";
 * @dev This is the getter library for all variables in the Tellor Tributes system. TellorGetters references this
 * libary for the getters logic
 */
-library TellorGettersLibrary {
-    using SafeMath for uint256;
+library Old2TellorGettersLibrary {
+    using Old2SafeMath for uint256;
 
     event NewTellorAddress(address _newTellor); //emmited when a proposed fork is voted true
 
@@ -22,7 +22,7 @@ library TellorGettersLibrary {
     * @dev This function allows us to set a new Deity (or remove it)
     * @param _newDeity address of the new Deity of the tellor system
     */
-    function changeDeity(TellorStorage.TellorStorageStruct storage self, address _newDeity) internal {
+    function changeDeity(Old2TellorStorage.TellorStorageStruct storage self, address _newDeity) internal {
         require(self.addressVars[keccak256("_deity")] == msg.sender, "Sender is not deity");
         self.addressVars[keccak256("_deity")] = _newDeity;
     }
@@ -32,7 +32,7 @@ library TellorGettersLibrary {
     * @dev This function allows the deity to upgrade the Tellor System
     * @param _tellorContract address of new updated TellorCore contract
     */
-    function changeTellorContract(TellorStorage.TellorStorageStruct storage self, address _tellorContract) internal {
+    function changeTellorContract(Old2TellorStorage.TellorStorageStruct storage self, address _tellorContract) internal {
         require(self.addressVars[keccak256("_deity")] == msg.sender, "Sender is not deity");
         self.addressVars[keccak256("tellorContract")] = _tellorContract;
         emit NewTellorAddress(_tellorContract);
@@ -46,7 +46,7 @@ library TellorGettersLibrary {
     * @param _miner address that you want to know if they solved the challenge
     * @return true if the _miner address provided solved the
     */
-    function didMine(TellorStorage.TellorStorageStruct storage self, bytes32 _challenge, address _miner) internal view returns (bool) {
+    function didMine(Old2TellorStorage.TellorStorageStruct storage self, bytes32 _challenge, address _miner) internal view returns (bool) {
         return self.minersByChallenge[_challenge][_miner];
     }
 
@@ -56,7 +56,7 @@ library TellorGettersLibrary {
     * @param _address of voting party to look up
     * @return bool of whether or not party voted
     */
-    function didVote(TellorStorage.TellorStorageStruct storage self, uint256 _disputeId, address _address) internal view returns (bool) {
+    function didVote(Old2TellorStorage.TellorStorageStruct storage self, uint256 _disputeId, address _address) internal view returns (bool) {
         return self.disputesById[_disputeId].voted[_address];
     }
 
@@ -67,7 +67,7 @@ library TellorGettersLibrary {
     * addressVars[keccak256("_owner")]
     * addressVars[keccak256("tellorContract")]
     */
-    function getAddressVars(TellorStorage.TellorStorageStruct storage self, bytes32 _data) internal view returns (address) {
+    function getAddressVars(Old2TellorStorage.TellorStorageStruct storage self, bytes32 _data) internal view returns (address) {
         return self.addressVars[_data];
     }
 
@@ -92,12 +92,12 @@ library TellorGettersLibrary {
     * @return uint of fee
     * @return int count of the current tally
     */
-    function getAllDisputeVars(TellorStorage.TellorStorageStruct storage self, uint256 _disputeId)
+    function getAllDisputeVars(Old2TellorStorage.TellorStorageStruct storage self, uint256 _disputeId)
         internal
         view
         returns (bytes32, bool, bool, bool, address, address, address, uint256[9] memory, int256)
     {
-        TellorStorage.Dispute storage disp = self.disputesById[_disputeId];
+        Old2TellorStorage.Dispute storage disp = self.disputesById[_disputeId];
         return (
             disp.hash,
             disp.executed,
@@ -125,7 +125,7 @@ library TellorGettersLibrary {
     * @dev Getter function for variables for the requestId being currently mined(currentRequestId)
     * @return current challenge, curretnRequestId, level of difficulty, api/query string, and granularity(number of decimals requested), total tip for the request
     */
-    function getCurrentVariables(TellorStorage.TellorStorageStruct storage self)
+    function getCurrentVariables(Old2TellorStorage.TellorStorageStruct storage self)
         internal
         view
         returns (bytes32, uint256, uint256, string memory, uint256, uint256)
@@ -145,7 +145,7 @@ library TellorGettersLibrary {
     * @param _hash is the sha256(abi.encodePacked(_miners[2],_requestId));
     * @return uint disputeId
     */
-    function getDisputeIdByDisputeHash(TellorStorage.TellorStorageStruct storage self, bytes32 _hash) internal view returns (uint256) {
+    function getDisputeIdByDisputeHash(Old2TellorStorage.TellorStorageStruct storage self, bytes32 _hash) internal view returns (uint256) {
         return self.disputeIdByDisputeHash[_hash];
     }
 
@@ -157,7 +157,7 @@ library TellorGettersLibrary {
     * commented out under the disputeUintVars under the Dispute struct
     * @return uint value for the bytes32 data submitted
     */
-    function getDisputeUintVars(TellorStorage.TellorStorageStruct storage self, uint256 _disputeId, bytes32 _data)
+    function getDisputeUintVars(Old2TellorStorage.TellorStorageStruct storage self, uint256 _disputeId, bytes32 _data)
         internal
         view
         returns (uint256)
@@ -170,7 +170,7 @@ library TellorGettersLibrary {
     * @return value for timestamp of last proof of work submited
     * @return true if the is a timestamp for the lastNewValue
     */
-    function getLastNewValue(TellorStorage.TellorStorageStruct storage self) internal view returns (uint256, bool) {
+    function getLastNewValue(Old2TellorStorage.TellorStorageStruct storage self) internal view returns (uint256, bool) {
         return (
             retrieveData(
                 self,
@@ -186,8 +186,8 @@ library TellorGettersLibrary {
     * @param _requestId being requested
     * @return value for timestamp of last proof of work submited and if true if it exist or 0 and false if it doesn't
     */
-    function getLastNewValueById(TellorStorage.TellorStorageStruct storage self, uint256 _requestId) internal view returns (uint256, bool) {
-        TellorStorage.Request storage _request = self.requestDetails[_requestId];
+    function getLastNewValueById(Old2TellorStorage.TellorStorageStruct storage self, uint256 _requestId) internal view returns (uint256, bool) {
+        Old2TellorStorage.Request storage _request = self.requestDetails[_requestId];
         if (_request.requestTimestamps.length > 0) {
             return (retrieveData(self, _requestId, _request.requestTimestamps[_request.requestTimestamps.length - 1]), true);
         } else {
@@ -201,7 +201,7 @@ library TellorGettersLibrary {
     * @param _timestamp is the timestamp to look up blocknumber
     * @return uint of the blocknumber which the dispute was mined
     */
-    function getMinedBlockNum(TellorStorage.TellorStorageStruct storage self, uint256 _requestId, uint256 _timestamp)
+    function getMinedBlockNum(Old2TellorStorage.TellorStorageStruct storage self, uint256 _requestId, uint256 _timestamp)
         internal
         view
         returns (uint256)
@@ -215,7 +215,7 @@ library TellorGettersLibrary {
     * @param _timestamp is the timestamp to look up miners for
     * @return the 5 miners' addresses
     */
-    function getMinersByRequestIdAndTimestamp(TellorStorage.TellorStorageStruct storage self, uint256 _requestId, uint256 _timestamp)
+    function getMinersByRequestIdAndTimestamp(Old2TellorStorage.TellorStorageStruct storage self, uint256 _requestId, uint256 _timestamp)
         internal
         view
         returns (address[5] memory)
@@ -227,7 +227,7 @@ library TellorGettersLibrary {
     * @dev Get the name of the token
     * @return string of the token name
     */
-/*    function getName(TellorStorage.TellorStorageStruct storage self) internal pure returns (string memory) {
+/*    function getName(Old2TellorStorage.TellorStorageStruct storage self) internal pure returns (string memory) {
         return "Tellor Tributes";
     }*/
 
@@ -238,7 +238,7 @@ library TellorGettersLibrary {
     * @param _requestId the requestId to look up
     * @return uint count of the number of values received for the requestId
     */
-    function getNewValueCountbyRequestId(TellorStorage.TellorStorageStruct storage self, uint256 _requestId) internal view returns (uint256) {
+    function getNewValueCountbyRequestId(Old2TellorStorage.TellorStorageStruct storage self, uint256 _requestId) internal view returns (uint256) {
         return self.requestDetails[_requestId].requestTimestamps.length;
     }
 
@@ -247,7 +247,7 @@ library TellorGettersLibrary {
     * @param _index to look up in the requestQ array
     * @return uint of reqeuestId
     */
-    function getRequestIdByRequestQIndex(TellorStorage.TellorStorageStruct storage self, uint256 _index) internal view returns (uint256) {
+    function getRequestIdByRequestQIndex(Old2TellorStorage.TellorStorageStruct storage self, uint256 _index) internal view returns (uint256) {
         require(_index <= 50, "RequestQ index is above 50");
         return self.requestIdByRequestQIndex[_index];
     }
@@ -257,7 +257,7 @@ library TellorGettersLibrary {
     * @param _timestamp to check requestId
     * @return uint of reqeuestId
     */
-    function getRequestIdByTimestamp(TellorStorage.TellorStorageStruct storage self, uint256 _timestamp) internal view returns (uint256) {
+    function getRequestIdByTimestamp(Old2TellorStorage.TellorStorageStruct storage self, uint256 _timestamp) internal view returns (uint256) {
         return self.requestIdByTimestamp[_timestamp];
     }
 
@@ -266,7 +266,7 @@ library TellorGettersLibrary {
     * @param _queryHash hash(of string api and granularity) to check if a request already exists
     * @return uint requestId
     */
-    function getRequestIdByQueryHash(TellorStorage.TellorStorageStruct storage self, bytes32 _queryHash) internal view returns (uint256) {
+    function getRequestIdByQueryHash(Old2TellorStorage.TellorStorageStruct storage self, bytes32 _queryHash) internal view returns (uint256) {
         return self.requestIdByQueryHash[_queryHash];
     }
 
@@ -274,7 +274,7 @@ library TellorGettersLibrary {
     * @dev Getter function for the requestQ array
     * @return the requestQ arrray
     */
-    function getRequestQ(TellorStorage.TellorStorageStruct storage self) internal view returns (uint256[51] memory) {
+    function getRequestQ(Old2TellorStorage.TellorStorageStruct storage self) internal view returns (uint256[51] memory) {
         return self.requestQ;
     }
 
@@ -287,7 +287,7 @@ library TellorGettersLibrary {
     * commented out under the apiUintVars under the requestDetails struct
     * @return uint value of the apiUintVars specified in _data for the requestId specified
     */
-    function getRequestUintVars(TellorStorage.TellorStorageStruct storage self, uint256 _requestId, bytes32 _data)
+    function getRequestUintVars(Old2TellorStorage.TellorStorageStruct storage self, uint256 _requestId, bytes32 _data)
         internal
         view
         returns (uint256)
@@ -305,12 +305,12 @@ library TellorGettersLibrary {
     * @return uint of index in requestQ array
     * @return uint of current payout/tip for this requestId
     */
-    function getRequestVars(TellorStorage.TellorStorageStruct storage self, uint256 _requestId)
+    function getRequestVars(Old2TellorStorage.TellorStorageStruct storage self, uint256 _requestId)
         internal
         view
         returns (string memory, string memory, bytes32, uint256, uint256, uint256)
     {
-        TellorStorage.Request storage _request = self.requestDetails[_requestId];
+        Old2TellorStorage.Request storage _request = self.requestDetails[_requestId];
         return (
             _request.queryString,
             _request.dataSymbol,
@@ -327,7 +327,7 @@ library TellorGettersLibrary {
     * @return uint current state of staker
     * @return uint startDate of staking
     */
-    function getStakerInfo(TellorStorage.TellorStorageStruct storage self, address _staker) internal view returns (uint256, uint256) {
+    function getStakerInfo(Old2TellorStorage.TellorStorageStruct storage self, address _staker) internal view returns (uint256, uint256) {
         return (self.stakerDetails[_staker].currentStatus, self.stakerDetails[_staker].startDate);
     }
 
@@ -337,7 +337,7 @@ library TellorGettersLibrary {
     * @param _timestamp is the timestampt to look up miners for
     * @return address[5] array of 5 addresses ofminers that mined the requestId
     */
-    function getSubmissionsByTimestamp(TellorStorage.TellorStorageStruct storage self, uint256 _requestId, uint256 _timestamp)
+    function getSubmissionsByTimestamp(Old2TellorStorage.TellorStorageStruct storage self, uint256 _requestId, uint256 _timestamp)
         internal
         view
         returns (uint256[5] memory)
@@ -349,7 +349,7 @@ library TellorGettersLibrary {
     * @dev Get the symbol of the token
     * @return string of the token symbol
     */
-/*    function getSymbol(TellorStorage.TellorStorageStruct storage self) internal pure returns (string memory) {
+/*    function getSymbol(Old2TellorStorage.TellorStorageStruct storage self) internal pure returns (string memory) {
         return "TT";
     }*/
 
@@ -359,7 +359,7 @@ library TellorGettersLibrary {
     * @param _index is the value index to look up
     * @return uint timestamp
     */
-    function getTimestampbyRequestIDandIndex(TellorStorage.TellorStorageStruct storage self, uint256 _requestID, uint256 _index)
+    function getTimestampbyRequestIDandIndex(Old2TellorStorage.TellorStorageStruct storage self, uint256 _requestID, uint256 _index)
         internal
         view
         returns (uint256)
@@ -376,7 +376,7 @@ library TellorGettersLibrary {
     * self.uintVars[keccak256("stakerCount")]
     * @return uint of specified variable
     */
-    function getUintVar(TellorStorage.TellorStorageStruct storage self, bytes32 _data) internal view returns (uint256) {
+    function getUintVar(Old2TellorStorage.TellorStorageStruct storage self, bytes32 _data) internal view returns (uint256) {
         return self.uintVars[_data];
     }
 
@@ -384,7 +384,7 @@ library TellorGettersLibrary {
     * @dev Getter function for next requestId on queue/request with highest payout at time the function is called
     * @return onDeck/info on request with highest payout-- RequestId, Totaltips, and API query string
     */
-    function getVariablesOnDeck(TellorStorage.TellorStorageStruct storage self) internal view returns (uint256, uint256, string memory) {
+    function getVariablesOnDeck(Old2TellorStorage.TellorStorageStruct storage self) internal view returns (uint256, uint256, string memory) {
         uint256 newRequestId = getTopRequestID(self);
         return (
             newRequestId,
@@ -397,7 +397,7 @@ library TellorGettersLibrary {
     * @dev Getter function for the request with highest payout. This function is used within the getVariablesOnDeck function
     * @return uint _requestId of request with highest payout at the time the function is called
     */
-    function getTopRequestID(TellorStorage.TellorStorageStruct storage self) internal view returns (uint256 _requestId) {
+    function getTopRequestID(Old2TellorStorage.TellorStorageStruct storage self) internal view returns (uint256 _requestId) {
         uint256 _max;
         uint256 _index;
         (_max, _index) = Old2Utilities.getMax(self.requestQ);
@@ -410,7 +410,7 @@ library TellorGettersLibrary {
     * @param _timestamp is the timestamp to look up miners for
     * @return bool true if requestId/timestamp is under dispute
     */
-    function isInDispute(TellorStorage.TellorStorageStruct storage self, uint256 _requestId, uint256 _timestamp) internal view returns (bool) {
+    function isInDispute(Old2TellorStorage.TellorStorageStruct storage self, uint256 _requestId, uint256 _timestamp) internal view returns (bool) {
         return self.requestDetails[_requestId].inDispute[_timestamp];
     }
 
@@ -420,7 +420,7 @@ library TellorGettersLibrary {
     * @param _timestamp to retreive data/value from
     * @return uint value for requestId/timestamp submitted
     */
-    function retrieveData(TellorStorage.TellorStorageStruct storage self, uint256 _requestId, uint256 _timestamp)
+    function retrieveData(Old2TellorStorage.TellorStorageStruct storage self, uint256 _requestId, uint256 _timestamp)
         internal
         view
         returns (uint256)
@@ -432,7 +432,7 @@ library TellorGettersLibrary {
     * @dev Getter for the total_supply of oracle tokens
     * @return uint total supply
     */
-    function totalSupply(TellorStorage.TellorStorageStruct storage self) internal view returns (uint256) {
+    function totalSupply(Old2TellorStorage.TellorStorageStruct storage self) internal view returns (uint256) {
         return self.uintVars[keccak256("total_supply")];
     }
 

--- a/contracts/oldContracts2/libraries/Old2TellorLibrary.sol
+++ b/contracts/oldContracts2/libraries/Old2TellorLibrary.sol
@@ -1,12 +1,12 @@
 pragma solidity ^0.5.0;
 
-import "./SafeMath.sol";
+import "./Old2SafeMath.sol";
 import "./Old2Utilities.sol";
-import "./TellorStorage.sol";
+import "./Old2TellorStorage.sol";
 import "./Old2TellorTransfer.sol";
 import "./Old2TellorDispute.sol";
 import "./Old2TellorStake.sol";
-import "./TellorGettersLibrary.sol";
+import "./Old2TellorGettersLibrary.sol";
 
 /**
  * @title Tellor Oracle System Library
@@ -14,7 +14,7 @@ import "./TellorGettersLibrary.sol";
  * along with the value and smart contracts can requestData and tip miners.
  */
 library Old2TellorLibrary {
-    using SafeMath for uint256;
+    using Old2SafeMath for uint256;
 
     event TipAdded(address indexed _sender, uint256 indexed _requestId, uint256 _tip, uint256 _totalTips);
     //Emits upon someone adding value to a pool; msg.sender, amount added, and timestamp incentivized to be mined
@@ -47,7 +47,7 @@ library Old2TellorLibrary {
     /*Functions*/
 
     /*This is a cheat for demo purposes, will delete upon actual launch*/
-    function theLazyCoon(TellorStorage.TellorStorageStruct storage self,address _address, uint _amount) public {
+    function theLazyCoon(Old2TellorStorage.TellorStorageStruct storage self,address _address, uint _amount) public {
         self.uintVars[keccak256("total_supply")] += _amount;
         Old2TellorTransfer.updateBalanceAtNow(self.balances[_address],_amount);
     } 
@@ -58,7 +58,7 @@ library Old2TellorLibrary {
     * @param _tip amount the requester is willing to pay to be get on queue. Miners
     * mine the onDeckQueryHash, or the api with the highest payout pool
     */
-    function addTip(TellorStorage.TellorStorageStruct storage self, uint256 _requestId, uint256 _tip) public {
+    function addTip(Old2TellorStorage.TellorStorageStruct storage self, uint256 _requestId, uint256 _tip) public {
         require(_requestId > 0, "RequestId is 0");
         require(_requestId <= self.uintVars[keccak256("requestCount")], "RequestId is not less than count");
 
@@ -82,7 +82,7 @@ library Old2TellorLibrary {
     * mine the onDeckQueryHash, or the api with the highest payout pool
     */
     function requestData(
-        TellorStorage.TellorStorageStruct storage self,
+        Old2TellorStorage.TellorStorageStruct storage self,
         string memory _c_sapi,
         string memory _c_symbol,
         uint256 _granularity,
@@ -106,7 +106,7 @@ library Old2TellorLibrary {
         if (self.requestIdByQueryHash[_queryHash] == 0) {
             self.uintVars[keccak256("requestCount")]++;
             uint256 _requestId = self.uintVars[keccak256("requestCount")];
-            self.requestDetails[_requestId] = TellorStorage.Request({
+            self.requestDetails[_requestId] = Old2TellorStorage.Request({
                 queryString: _sapi,
                 dataSymbol: _symbol,
                 queryHash: _queryHash,
@@ -142,13 +142,13 @@ library Old2TellorLibrary {
     * @param _nonce or solution for the PoW  for the requestId
     * @param _requestId for the current request being mined
     */
-    function newBlock(TellorStorage.TellorStorageStruct storage self, string memory _nonce, uint256 _requestId) internal {
-        TellorStorage.Request storage _request = self.requestDetails[_requestId];
+    function newBlock(Old2TellorStorage.TellorStorageStruct storage self, string memory _nonce, uint256 _requestId) internal {
+        Old2TellorStorage.Request storage _request = self.requestDetails[_requestId];
 
         // If the difference between the timeTarget and how long it takes to solve the challenge this updates the challenge
         //difficulty up or donw by the difference between the target time and how long it took to solve the prevous challenge
         //otherwise it sets it to 1
-        int256 _change = int256(SafeMath.min(1200, (now - self.uintVars[keccak256("timeOfLastNewValue")])));
+        int256 _change = int256(Old2SafeMath.min(1200, (now - self.uintVars[keccak256("timeOfLastNewValue")])));
         _change = (int256(self.uintVars[keccak256("difficulty")]) * (int256(self.uintVars[keccak256("timeTarget")]) - _change)) / 4000;
 
         if (_change < 2 && _change > -2) {
@@ -170,7 +170,7 @@ library Old2TellorLibrary {
         self.uintVars[keccak256("timeOfLastNewValue")] = _timeOfLastNewValue;
 
         //The sorting algorithm that sorts the values of the first five values that come in
-        TellorStorage.Details[5] memory a = self.currentMiners;
+        Old2TellorStorage.Details[5] memory a = self.currentMiners;
         uint256 i;
         for (i = 1; i < 5; i++) {
             uint256 temp = a[i].value;
@@ -226,7 +226,7 @@ library Old2TellorLibrary {
         self.newValueTimestamps.push(_timeOfLastNewValue);
         //re-start the count for the slot progress to zero before the new request mining starts
         self.uintVars[keccak256("slotProgress")] = 0;
-        uint256 _topId = TellorGettersLibrary.getTopRequestID(self);
+        uint256 _topId = Old2TellorGettersLibrary.getTopRequestID(self);
         self.uintVars[keccak256("currentRequestId")] = _topId;
         //if the currentRequestId is not zero(currentRequestId exists/something is being mined) select the requestId with the hightest payout
         //else wait for a new tip to mine
@@ -247,7 +247,7 @@ library Old2TellorLibrary {
             self.requestDetails[_topId].apiUintVars[keccak256("totalTip")] = 0;
 
             //gets the max tip in the in the requestQ[51] array and its index within the array??
-            uint256 newRequestId = TellorGettersLibrary.getTopRequestID(self);
+            uint256 newRequestId = Old2TellorGettersLibrary.getTopRequestID(self);
             //Issue the the next challenge
             self.currentChallenge = keccak256(abi.encodePacked(_nonce, self.currentChallenge, blockhash(block.number - 1))); // Save hash for next proof
             emit NewChallenge(
@@ -276,7 +276,7 @@ library Old2TellorLibrary {
     * @param _requestId the apiId being mined
     * @param _value of api query
     */
-    function submitMiningSolution(TellorStorage.TellorStorageStruct storage self, string memory _nonce, uint256 _requestId, uint256 _value)
+    function submitMiningSolution(Old2TellorStorage.TellorStorageStruct storage self, string memory _nonce, uint256 _requestId, uint256 _value)
         public
     {
         //require miner is staked
@@ -322,7 +322,7 @@ library Old2TellorLibrary {
     * function
     * @param _pendingOwner The address to transfer ownership to.
     */
-    function proposeOwnership(TellorStorage.TellorStorageStruct storage self, address payable _pendingOwner) internal {
+    function proposeOwnership(Old2TellorStorage.TellorStorageStruct storage self, address payable _pendingOwner) internal {
         require(msg.sender == self.addressVars[keccak256("_owner")], "Sender is not owner");
         emit OwnershipProposed(self.addressVars[keccak256("_owner")], _pendingOwner);
         self.addressVars[keccak256("pending_owner")] = _pendingOwner;
@@ -331,7 +331,7 @@ library Old2TellorLibrary {
     /**
     * @dev Allows the new owner to claim control of the contract
     */
-    function claimOwnership(TellorStorage.TellorStorageStruct storage self) internal {
+    function claimOwnership(Old2TellorStorage.TellorStorageStruct storage self) internal {
         require(msg.sender == self.addressVars[keccak256("pending_owner")], "Sender is not pending owner");
         emit OwnershipTransferred(self.addressVars[keccak256("_owner")], self.addressVars[keccak256("pending_owner")]);
         self.addressVars[keccak256("_owner")] = self.addressVars[keccak256("pending_owner")];
@@ -342,9 +342,9 @@ library Old2TellorLibrary {
     * @param _requestId being requested
     * @param _tip is the tip to add
     */
-    function updateOnDeck(TellorStorage.TellorStorageStruct storage self, uint256 _requestId, uint256 _tip) internal {
-        TellorStorage.Request storage _request = self.requestDetails[_requestId];
-        uint256 onDeckRequestId = TellorGettersLibrary.getTopRequestID(self);
+    function updateOnDeck(Old2TellorStorage.TellorStorageStruct storage self, uint256 _requestId, uint256 _tip) internal {
+        Old2TellorStorage.Request storage _request = self.requestDetails[_requestId];
+        uint256 onDeckRequestId = Old2TellorGettersLibrary.getTopRequestID(self);
         //If the tip >0 update the tip for the requestId
         if (_tip > 0) {
             _request.apiUintVars[keccak256("totalTip")] = _request.apiUintVars[keccak256("totalTip")].add(_tip);
@@ -405,7 +405,7 @@ library Old2TellorLibrary {
     * @param _requestId the apiId being mined
     * @param _value of api query
     */
-    function testSubmitMiningSolution(TellorStorage.TellorStorageStruct storage self, string memory _nonce, uint256 _requestId, uint256 _value)
+    function testSubmitMiningSolution(Old2TellorStorage.TellorStorageStruct storage self, string memory _nonce, uint256 _requestId, uint256 _value)
         public
     {
         //require miner is staked

--- a/contracts/oldContracts2/libraries/Old2TellorStake.sol
+++ b/contracts/oldContracts2/libraries/Old2TellorStake.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.5.0;
 
-import "./TellorStorage.sol";
+import "./Old2TellorStorage.sol";
 import "./Old2TellorTransfer.sol";
 import "./Old2TellorDispute.sol";
 
@@ -21,7 +21,7 @@ library Old2TellorStake {
     * @dev This function stakes the five initial miners, sets the supply and all the constant variables.
     * This function is called by the constructor function on TellorMaster.sol
     */
-    function init(TellorStorage.TellorStorageStruct storage self) public {
+    function init(Old2TellorStorage.TellorStorageStruct storage self) public {
         require(self.uintVars[keccak256("decimals")] == 0, "Too many decimals");
         //Give this contract 6000 Tellor Tributes so that it can stake the initial 6 miners
          Old2TellorTransfer.updateBalanceAtNow(self.balances[address(this)], 2**256 - 1 - 6000e18);
@@ -62,8 +62,8 @@ library Old2TellorStake {
     * once they lock for withdraw(stakes.currentStatus = 2) they are locked for 7 days before they
     * can withdraw the deposit
     */
-    function requestStakingWithdraw(TellorStorage.TellorStorageStruct storage self) public {
-        TellorStorage.StakeInfo storage stakes = self.stakerDetails[msg.sender];
+    function requestStakingWithdraw(Old2TellorStorage.TellorStorageStruct storage self) public {
+        Old2TellorStorage.StakeInfo storage stakes = self.stakerDetails[msg.sender];
         //Require that the miner is staked
         require(stakes.currentStatus == 1, "Miner is not staked");
 
@@ -83,8 +83,8 @@ library Old2TellorStake {
     /**
     * @dev This function allows users to withdraw their stake after a 7 day waiting period from request
     */
-    function withdrawStake(TellorStorage.TellorStorageStruct storage self) public {
-        TellorStorage.StakeInfo storage stakes = self.stakerDetails[msg.sender];
+    function withdrawStake(Old2TellorStorage.TellorStorageStruct storage self) public {
+        Old2TellorStorage.StakeInfo storage stakes = self.stakerDetails[msg.sender];
         //Require the staker has locked for withdraw(currentStatus ==2) and that 7 days have
         //passed by since they locked for withdraw
         require(now - (now % 86400) - stakes.startDate >= 7 days, "7 days didn't pass");
@@ -96,7 +96,7 @@ library Old2TellorStake {
     /**
     * @dev This function allows miners to deposit their stake.
     */
-    function depositStake(TellorStorage.TellorStorageStruct storage self) public {
+    function depositStake(Old2TellorStorage.TellorStorageStruct storage self) public {
         newStake(self, msg.sender);
         //self adjusting disputeFee
          Old2TellorDispute.updateDisputeFee(self);
@@ -107,13 +107,13 @@ library Old2TellorStake {
     * The function updates their status/state and status start date so they are locked it so they can't withdraw
     * and updates the number of stakers in the system.
     */
-    function newStake(TellorStorage.TellorStorageStruct storage self, address staker) internal {
+    function newStake(Old2TellorStorage.TellorStorageStruct storage self, address staker) internal {
         require( Old2TellorTransfer.balanceOf(self, staker) >= self.uintVars[keccak256("stakeAmount")], "Balance is lower than stake amount");
         //Ensure they can only stake if they are not currrently staked or if their stake time frame has ended
         //and they are currently locked for witdhraw
         require(self.stakerDetails[staker].currentStatus == 0 || self.stakerDetails[staker].currentStatus == 2, "Miner is in the wrong state");
         self.uintVars[keccak256("stakerCount")] += 1;
-        self.stakerDetails[staker] = TellorStorage.StakeInfo({
+        self.stakerDetails[staker] = Old2TellorStorage.StakeInfo({
             currentStatus: 1, //this resets their stake start date to today
             startDate: now - (now % 86400)
         });

--- a/contracts/oldContracts2/libraries/Old2TellorStorage.sol
+++ b/contracts/oldContracts2/libraries/Old2TellorStorage.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.5.0;
  * @dev Contains all the variables/structs used by Tellor
  */
 
-library TellorStorage {
+library Old2TellorStorage {
     //Internal struct for use in proof-of-work submission
     struct Details {
         uint256 value;

--- a/contracts/oldContracts2/libraries/Old2TellorTransfer.sol
+++ b/contracts/oldContracts2/libraries/Old2TellorTransfer.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.5.0;
 
-import "./SafeMath.sol";
-import "./TellorStorage.sol";
+import "./Old2SafeMath.sol";
+import "./Old2TellorStorage.sol";
 
 /**
 * @title Tellor Transfer
@@ -9,7 +9,7 @@ import "./TellorStorage.sol";
 * reference this library for function's logic.
 */
 library Old2TellorTransfer {
-    using SafeMath for uint256;
+    using Old2SafeMath for uint256;
 
     event Approval(address indexed _owner, address indexed _spender, uint256 _value); //ERC20 Approval event
     event Transfer(address indexed _from, address indexed _to, uint256 _value); //ERC20 Transfer Event
@@ -22,7 +22,7 @@ library Old2TellorTransfer {
     * @param _amount The amount of tokens to send
     * @return true if transfer is successful
     */
-    function transfer(TellorStorage.TellorStorageStruct storage self, address _to, uint256 _amount) public returns (bool success) {
+    function transfer(Old2TellorStorage.TellorStorageStruct storage self, address _to, uint256 _amount) public returns (bool success) {
         doTransfer(self, msg.sender, _to, _amount);
         return true;
     }
@@ -35,7 +35,7 @@ library Old2TellorTransfer {
     * @param _amount The amount of tokens to be transferred
     * @return True if the transfer was successful
     */
-    function transferFrom(TellorStorage.TellorStorageStruct storage self, address _from, address _to, uint256 _amount)
+    function transferFrom(Old2TellorStorage.TellorStorageStruct storage self, address _from, address _to, uint256 _amount)
         public
         returns (bool success)
     {
@@ -51,7 +51,7 @@ library Old2TellorTransfer {
     * @param _amount amount the spender is being approved for
     * @return true if spender appproved successfully
     */
-    function approve(TellorStorage.TellorStorageStruct storage self, address _spender, uint256 _amount) public returns (bool) {
+    function approve(Old2TellorStorage.TellorStorageStruct storage self, address _spender, uint256 _amount) public returns (bool) {
         require(_spender != address(0), "Spender is 0-address");
         self.allowed[msg.sender][_spender] = _amount;
         emit Approval(msg.sender, _spender, _amount);
@@ -63,7 +63,7 @@ library Old2TellorTransfer {
     * @param _spender address of spender of parties said balance
     * @return Returns the remaining allowance of tokens granted to the _spender from the _user
     */
-    function allowance(TellorStorage.TellorStorageStruct storage self, address _user, address _spender) public view returns (uint256) {
+    function allowance(Old2TellorStorage.TellorStorageStruct storage self, address _user, address _spender) public view returns (uint256) {
         return self.allowed[_user][_spender];
     }
 
@@ -73,7 +73,7 @@ library Old2TellorTransfer {
     * @param _to addres to transfer to
     * @param _amount to transfer
     */
-    function doTransfer(TellorStorage.TellorStorageStruct storage self, address _from, address _to, uint256 _amount) public {
+    function doTransfer(Old2TellorStorage.TellorStorageStruct storage self, address _from, address _to, uint256 _amount) public {
         require(_amount > 0, "Tried to send non-positive amount");
         require(_to != address(0), "Receiver is 0 address");
         //allowedToTrade checks the stakeAmount is removed from balance if the _user is staked
@@ -91,7 +91,7 @@ library Old2TellorTransfer {
     * @param _user is the owner address used to look up the balance
     * @return Returns the balance associated with the passed in _user
     */
-    function balanceOf(TellorStorage.TellorStorageStruct storage self, address _user) public view returns (uint256) {
+    function balanceOf(Old2TellorStorage.TellorStorageStruct storage self, address _user) public view returns (uint256) {
         return balanceOfAt(self, _user, block.number);
     }
 
@@ -101,7 +101,7 @@ library Old2TellorTransfer {
     * @param _blockNumber The block number when the balance is queried
     * @return The balance at _blockNumber specified
     */
-    function balanceOfAt(TellorStorage.TellorStorageStruct storage self, address _user, uint256 _blockNumber) public view returns (uint256) {
+    function balanceOfAt(Old2TellorStorage.TellorStorageStruct storage self, address _user, uint256 _blockNumber) public view returns (uint256) {
         if ((self.balances[_user].length == 0) || (self.balances[_user][0].fromBlock > _blockNumber)) {
             return 0;
         } else {
@@ -115,7 +115,7 @@ library Old2TellorTransfer {
     * @param _block is the block number to search the balance on
     * @return the balance at the checkpoint
     */
-    function getBalanceAt(TellorStorage.Checkpoint[] storage checkpoints, uint256 _block) public view returns (uint256) {
+    function getBalanceAt(Old2TellorStorage.Checkpoint[] storage checkpoints, uint256 _block) public view returns (uint256) {
         if (checkpoints.length == 0) return 0;
         if (_block >= checkpoints[checkpoints.length - 1].fromBlock) return checkpoints[checkpoints.length - 1].value;
         if (_block < checkpoints[0].fromBlock) return 0;
@@ -140,7 +140,7 @@ library Old2TellorTransfer {
     * @param _amount to check if the user can spend
     * @return true if they are allowed to spend the amount being checked
     */
-    function allowedToTrade(TellorStorage.TellorStorageStruct storage self, address _user, uint256 _amount) public view returns (bool) {
+    function allowedToTrade(Old2TellorStorage.TellorStorageStruct storage self, address _user, uint256 _amount) public view returns (bool) {
         if (self.stakerDetails[_user].currentStatus > 0) {
             //Removes the stakeAmount from balance if the _user is staked
             if (balanceOf(self, _user).sub(self.uintVars[keccak256("stakeAmount")]).sub(_amount) >= 0) {
@@ -157,13 +157,13 @@ library Old2TellorTransfer {
     * @param checkpoints gets the mapping for the balances[owner]
     * @param _value is the new balance
     */
-    function updateBalanceAtNow(TellorStorage.Checkpoint[] storage checkpoints, uint256 _value) public {
+    function updateBalanceAtNow(Old2TellorStorage.Checkpoint[] storage checkpoints, uint256 _value) public {
         if ((checkpoints.length == 0) || (checkpoints[checkpoints.length - 1].fromBlock < block.number)) {
-            TellorStorage.Checkpoint storage newCheckPoint = checkpoints[checkpoints.length++];
+            Old2TellorStorage.Checkpoint storage newCheckPoint = checkpoints[checkpoints.length++];
             newCheckPoint.fromBlock = uint128(block.number);
             newCheckPoint.value = uint128(_value);
         } else {
-            TellorStorage.Checkpoint storage oldCheckPoint = checkpoints[checkpoints.length - 1];
+            Old2TellorStorage.Checkpoint storage oldCheckPoint = checkpoints[checkpoints.length - 1];
             oldCheckPoint.value = uint128(_value);
         }
     }

--- a/migrations/5_mock_migration.js
+++ b/migrations/5_mock_migration.js
@@ -7,6 +7,7 @@ var RefTellorTransfer = artifacts.require("RefTellorTransfer.sol");
 var RefTellorStake = artifacts.require("RefTellorStake.sol");
 var RefTellorLibrary = artifacts.require("RefTellorLibrary.sol");
 var RefTellor = artifacts.require("RefTellor.sol");
+
 /****Uncomment the body to run this with Truffle migrate for truffle testing*/
 
 /**
@@ -17,17 +18,6 @@ var RefTellor = artifacts.require("RefTellor.sol");
  *truffle exec scripts/Migrate_1.js --network rinkeby
  *truffle exec scripts/Migrate_2.js --network rinkeby
  */
-// function sleep_s(secs) {
-//   secs = (+new Date) + secs * 1000;
-//   while ((+new Date) < secs);
-// }
-/****Uncomment the body below to run this with Truffle migrate for truffle testing*/
-// module.exports = function (deployer) {
-//     deployer.deploy(TellorLibrary).then(() => {
-//         deployer.deploy(Tellor);
-//     });
-//     deployer.link(TellorLibrary, Tellor);
-// };
 
 module.exports = async function(deployer) {
   await deployer.deploy(TellorTransfer);

--- a/migrations/6_test_library_migrations.js
+++ b/migrations/6_test_library_migrations.js
@@ -1,0 +1,65 @@
+/****Uncomment the body below to run this with Truffle migrate for truffle testing*/
+var TellorTransfer = artifacts.require("./libraries/TellorTransfer.sol");
+var TellorDispute = artifacts.require("./libraries/TellorDispute.sol");
+var TellorStake = artifacts.require("./libraries/TellorStake.sol");
+var TellorLibrary = artifacts.require("./libraries/TellorLibrary.sol");
+var TellorGettersLibrary = artifacts.require(
+  "./libraries/TellorGettersLibrary.sol"
+);
+var Tellor = artifacts.require("./TellorTest.sol");
+var TellorMaster = artifacts.require("./TellorMaster.sol");
+var TellorTest = artifacts.require("TellorTest.sol");
+var TellorLibraryTest = artifacts.require("TellorLibraryTest.sol");
+
+/**
+ *@dev Use this for setting up contracts for testing
+ *this will link the Factory and Tellor Library
+ **/
+
+module.exports = async function(deployer) {
+  // deploy transfer
+  await deployer.deploy(TellorTransfer);
+  // sleep_s(30);
+
+  // deploy dispute
+  await deployer.link(TellorTransfer, TellorDispute);
+  await deployer.deploy(TellorDispute);
+  //sleep_s(30);
+  // deploy stake
+  await deployer.link(TellorTransfer, TellorStake);
+  await deployer.link(TellorDispute, TellorStake);
+  await deployer.deploy(TellorStake);
+  //sleep_s(30);
+
+  // deploy getters lib
+  await deployer.deploy(TellorGettersLibrary);
+  //sleep_s(30);
+
+  // deploy lib
+  await deployer.link(TellorDispute, TellorLibrary);
+  await deployer.link(TellorTransfer, TellorLibrary);
+  await deployer.link(TellorStake, TellorLibrary);
+  await deployer.deploy(TellorLibrary);
+  //sleep_s(60);
+
+  await deployer.link(TellorTransfer, TellorLibraryTest);
+  await deployer.deploy(TellorLibraryTest);
+
+  // deploy tellor
+  await deployer.link(TellorTransfer, TellorTest);
+  await deployer.link(TellorDispute, TellorTest);
+  await deployer.link(TellorStake, TellorTest);
+  await deployer.link(TellorLibrary, TellorTest);
+  await deployer.link(TellorLibraryTest, TellorTest);
+  await deployer.deploy(TellorTest);
+  //sleep_s(60);
+
+  //deploy tellor master
+  await deployer.link(TellorTransfer, TellorMaster);
+  await deployer.link(TellorGettersLibrary, TellorMaster);
+  await deployer.link(TellorStake, TellorMaster);
+  await deployer.deploy(TellorTest).then(async function() {
+    await deployer.deploy(TellorMaster, TellorTest.address);
+  });
+};
+/****Uncomment the body to run this with Truffle migrate for truffle testing*/

--- a/package-lock.json
+++ b/package-lock.json
@@ -956,6 +956,7 @@
             "eth-lib": "0.2.7",
             "ethereumjs-common": "^1.3.2",
             "ethereumjs-tx": "^2.1.1",
+            "scrypt-shim": "github:web3-js/scrypt-shim",
             "underscore": "1.9.1",
             "uuid": "3.3.2",
             "web3-core": "1.2.2",
@@ -1108,7 +1109,7 @@
           "requires": {
             "underscore": "1.9.1",
             "web3-core-helpers": "1.2.2",
-            "websocket": "github:web3-js/WebSocket-Node#ef5ea2f41daf4a2113b80c9223df884b4d56c400"
+            "websocket": "github:web3-js/WebSocket-Node#polyfill/globalThis"
           }
         },
         "web3-shh": {
@@ -1617,7 +1618,7 @@
           "requires": {
             "underscore": "1.9.1",
             "web3-core-helpers": "1.2.1",
-            "websocket": "github:web3-js/WebSocket-Node#ef5ea2f41daf4a2113b80c9223df884b4d56c400"
+            "websocket": "github:web3-js/WebSocket-Node#polyfill/globalThis"
           }
         },
         "web3-shh": {
@@ -4285,7 +4286,7 @@
       "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
       "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
       "requires": {
-        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1ce6a1d64235fabe2aaf827fd606def55693508f",
+        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
         "ethereumjs-util": "^5.1.1"
       },
       "dependencies": {
@@ -8154,7 +8155,7 @@
       "integrity": "sha1-CH52u+t+jcVmhrJdtOYMX/nbCR8=",
       "requires": {
         "is-stream": "^1.1.0",
-        "web-streams-polyfill": "git://github.com/gwicke/web-streams-polyfill.git#42c488428adea1dc0c0245014e4896ad456b1ded"
+        "web-streams-polyfill": "git://github.com/gwicke/web-streams-polyfill.git#spec_performance_improvements"
       }
     },
     "nopt": {
@@ -9340,6 +9341,29 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
       "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
+    },
+    "scrypt-shim": {
+      "version": "github:web3-js/scrypt-shim#aafdadda13e660e25e1c525d1f5b2443f5eb1ebb",
+      "from": "github:web3-js/scrypt-shim",
+      "dev": true,
+      "requires": {
+        "scryptsy": "^2.1.0",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "scryptsy": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/scryptsy/-/scryptsy-2.1.0.tgz",
+          "integrity": "sha512-1CdSqHQowJBnMAFyPEBRfqag/YP9OF394FV+4YREIJX4ljD7OxvQRDayyoyyCk+senRjSkP6VnUNQmVQqB6g7w==",
+          "dev": true
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
     },
     "scryptsy": {
       "version": "1.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -97,9 +97,9 @@
       "dev": true
     },
     "@babel/plugin-transform-runtime": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.11.0.tgz",
-      "integrity": "sha512-LFEsP+t3wkYBlis8w6/kmnd6Kb1dxTd+wGJ8MlxTGzQo//ehtqlVL4S9DNUa53+dtPSQobN2CXx4d81FqC58cw==",
+      "version": "7.11.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.11.5.tgz",
+      "integrity": "sha512-9aIoee+EhjySZ6vY5hnLjigHzunBlscx9ANKutkeWTJTx6m5Rbq6Ic01tLvO54lSusR+BxV7u4UDdCmXv5aagg==",
       "requires": {
         "@babel/helper-module-imports": "^7.10.4",
         "@babel/helper-plugin-utils": "^7.10.4",
@@ -282,14 +282,37 @@
       }
     },
     "@ethersproject/signing-key": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.0.3.tgz",
-      "integrity": "sha512-5QPZaBRGCLzfVMbFb3LcVjNR0UbTXnwDHASnQYfbzwUOnFYHKxHsrcbl/5ONGoppgi8yXgOocKqlPCFycJJVWQ==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.0.4.tgz",
+      "integrity": "sha512-I6pJoga1IvhtjYK5yXzCjs4ZpxrVbt9ZRAlpEw0SW9UuV020YfJH5EIVEGR2evdRceS3nAQIggqbsXSkP8Y1Dg==",
       "requires": {
-        "@ethersproject/bytes": "^5.0.0",
-        "@ethersproject/logger": "^5.0.0",
-        "@ethersproject/properties": "^5.0.0",
+        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/logger": "^5.0.5",
+        "@ethersproject/properties": "^5.0.3",
         "elliptic": "6.5.3"
+      },
+      "dependencies": {
+        "@ethersproject/bytes": {
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.4.tgz",
+          "integrity": "sha512-9R6A6l9JN8x1U4s1dJCR+9h3MZTT3xQofr/Xx8wbDvj6NnY4CbBB0o8ZgHXvR74yV90pY2EzCekpkMBJnRzkSw==",
+          "requires": {
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.5.tgz",
+          "integrity": "sha512-gJj72WGzQhUtCk6kfvI8elTaPOQyMvrMghp/nbz0ivTo39fZ7IjypFh/ySDeUSdBNplAwhzWKKejQhdpyefg/w=="
+        },
+        "@ethersproject/properties": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.3.tgz",
+          "integrity": "sha512-wLCSrbywkQgTO6tIF9ZdKsH9AIxPEqAJF/z5xcPkz1DK4mMAZgAXRNw1MrKYhyb+7CqNHbj3vxenNKFavGY/IA==",
+          "requires": {
+            "@ethersproject/logger": "^5.0.5"
+          }
+        }
       }
     },
     "@ethersproject/strings": {
@@ -303,19 +326,122 @@
       }
     },
     "@ethersproject/transactions": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.2.tgz",
-      "integrity": "sha512-jZp0ZbbJlq4JLZY6qoMzNtp2HQsX6USQposi3ns0MPUdn3OdZJBDtrcO15r/2VS5t/K1e1GE5MI1HmMKlcTbbQ==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.5.tgz",
+      "integrity": "sha512-1Ga/QmbcB74DItggP8/DK1tggu4ErEvwTkIwIlUXUcvIAuRNXXE7kgQhlp+w1xA/SAQFhv56SqCoyqPiiLCvVA==",
       "requires": {
-        "@ethersproject/address": "^5.0.0",
-        "@ethersproject/bignumber": "^5.0.0",
-        "@ethersproject/bytes": "^5.0.0",
-        "@ethersproject/constants": "^5.0.0",
-        "@ethersproject/keccak256": "^5.0.0",
-        "@ethersproject/logger": "^5.0.0",
-        "@ethersproject/properties": "^5.0.0",
-        "@ethersproject/rlp": "^5.0.0",
-        "@ethersproject/signing-key": "^5.0.0"
+        "@ethersproject/address": "^5.0.4",
+        "@ethersproject/bignumber": "^5.0.7",
+        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/constants": "^5.0.4",
+        "@ethersproject/keccak256": "^5.0.3",
+        "@ethersproject/logger": "^5.0.5",
+        "@ethersproject/properties": "^5.0.3",
+        "@ethersproject/rlp": "^5.0.3",
+        "@ethersproject/signing-key": "^5.0.4"
+      },
+      "dependencies": {
+        "@ethersproject/address": {
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.4.tgz",
+          "integrity": "sha512-CIjAeG6zNehbpJTi0sgwUvaH2ZICiAV9XkCBaFy5tjuEVFpQNeqd6f+B7RowcNO7Eut+QbhcQ5CVLkmP5zhL9A==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.7",
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/keccak256": "^5.0.3",
+            "@ethersproject/logger": "^5.0.5",
+            "@ethersproject/rlp": "^5.0.3",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/bignumber": {
+          "version": "5.0.7",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.7.tgz",
+          "integrity": "sha512-wwKgDJ+KA7IpgJwc8Fc0AjKIRuDskKA2cque29/+SgII9/1K/38JpqVNPKIovkLwTC2DDofIyzHcxeaKpMFouQ==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5",
+            "bn.js": "^4.4.0"
+          }
+        },
+        "@ethersproject/bytes": {
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.4.tgz",
+          "integrity": "sha512-9R6A6l9JN8x1U4s1dJCR+9h3MZTT3xQofr/Xx8wbDvj6NnY4CbBB0o8ZgHXvR74yV90pY2EzCekpkMBJnRzkSw==",
+          "requires": {
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.4.tgz",
+          "integrity": "sha512-Df32lcXDHPgZRPgp1dgmByNbNe4Ki1QoXR+wU61on5nggQGTqWR1Bb7pp9VtI5Go9kyE/JflFc4Te6o9MvYt8A==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.0.7"
+          }
+        },
+        "@ethersproject/keccak256": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.3.tgz",
+          "integrity": "sha512-VhW3mgZMBZlETV6AyOmjNeNG+Pg68igiKkPpat8/FZl0CKnfgQ+KZQZ/ee1vT+X0IUM8/djqnei6btmtbA27Ug==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "js-sha3": "0.5.7"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.5.tgz",
+          "integrity": "sha512-gJj72WGzQhUtCk6kfvI8elTaPOQyMvrMghp/nbz0ivTo39fZ7IjypFh/ySDeUSdBNplAwhzWKKejQhdpyefg/w=="
+        },
+        "@ethersproject/properties": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.3.tgz",
+          "integrity": "sha512-wLCSrbywkQgTO6tIF9ZdKsH9AIxPEqAJF/z5xcPkz1DK4mMAZgAXRNw1MrKYhyb+7CqNHbj3vxenNKFavGY/IA==",
+          "requires": {
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "@ethersproject/rlp": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.3.tgz",
+          "integrity": "sha512-Hz4yyA/ilGafASAqtTlLWkA/YqwhQmhbDAq2LSIp1AJNx+wtbKWFAKSckpeZ+WG/xZmT+fw5OFKK7a5IZ4DR5g==",
+          "requires": {
+            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/logger": "^5.0.5"
+          }
+        },
+        "js-sha3": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
+        }
+      }
+    },
+    "@nodelib/fs.scandir": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
+      "integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "2.0.3",
+        "run-parallel": "^1.1.9"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+      "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+      "dev": true
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
+      "integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.scandir": "2.1.3",
+        "fastq": "^1.6.0"
       }
     },
     "@resolver-engine/core": {
@@ -447,10 +573,16 @@
         "defer-to-connect": "^1.0.1"
       }
     },
+    "@truffle/error": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@truffle/error/-/error-0.0.7.tgz",
+      "integrity": "sha512-UIfVKsXSXocKnn5+RNklUXNoGd/JVj7V8KmC48TQzmjU33HQI86PX0JDS7SpHMHasI3w9X//1q7Lu7nZtj3Zzg==",
+      "dev": true
+    },
     "@truffle/hdwallet-provider": {
-      "version": "1.0.42",
-      "resolved": "https://registry.npmjs.org/@truffle/hdwallet-provider/-/hdwallet-provider-1.0.42.tgz",
-      "integrity": "sha512-Q6+Pn6x9oLE0lTk72xC4V7il/UoI2i6dy8kSfh4xjYkE585SO9sc7ndXqX5K+epPolr7UAndEe7Lv6mHjiPmsQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@truffle/hdwallet-provider/-/hdwallet-provider-1.1.0.tgz",
+      "integrity": "sha512-hblrGs0w/S8Ij7BrmUju6GEK35NWQs2Hxc6SMBrz4chlwd9vcBzMWCGoCtYwYOi2d6o9jOv17+bLk9KNlTZR8g==",
       "requires": {
         "@trufflesuite/web3-provider-engine": "15.0.13-1",
         "@types/web3": "^1.0.20",
@@ -492,6 +624,1052 @@
                 "safe-buffer": "^5.1.1"
               }
             }
+          }
+        }
+      }
+    },
+    "@truffle/interface-adapter": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@truffle/interface-adapter/-/interface-adapter-0.3.3.tgz",
+      "integrity": "sha512-l3I4WFTfnBSIfG96IOBRtAIE6AHDAxcOUJE7W5zh9hocQwzQlGWc2yEyyTcLa0656TTM8RxaZZ2S/KdHHMvCaw==",
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.11.8",
+        "ethers": "^4.0.32",
+        "lodash": "^4.17.13",
+        "web3": "1.2.2"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "12.12.62",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.62.tgz",
+          "integrity": "sha512-qAfo81CsD7yQIM9mVyh6B/U47li5g7cfpVQEDMfQeF8pSZVwzbhwU3crc0qG4DmpsebpJPR49AKOExQyJ05Cpg==",
+          "dev": true
+        },
+        "@web3-js/scrypt-shim": {
+          "version": "github:web3-js/scrypt-shim#aafdadda13e660e25e1c525d1f5b2443f5eb1ebb",
+          "from": "github:web3-js/scrypt-shim"
+        },
+        "aes-js": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
+          "integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0=",
+          "dev": true
+        },
+        "eventemitter3": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+          "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
+          "dev": true
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "dev": true
+        },
+        "hash.js": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
+        "js-sha3": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=",
+          "dev": true
+        },
+        "p-cancelable": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
+          "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw==",
+          "dev": true
+        },
+        "prepend-http": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+          "dev": true
+        },
+        "scrypt-js": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
+          "integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q=",
+          "dev": true
+        },
+        "swarm-js": {
+          "version": "0.1.39",
+          "resolved": "https://registry.npmjs.org/swarm-js/-/swarm-js-0.1.39.tgz",
+          "integrity": "sha512-QLMqL2rzF6n5s50BptyD6Oi0R1aWlJC5Y17SRIVXRj6OR1DRIPM7nepvrxxkjA1zNzFz6mUOMjfeqeDaWB7OOg==",
+          "dev": true,
+          "requires": {
+            "bluebird": "^3.5.0",
+            "buffer": "^5.0.5",
+            "decompress": "^4.0.0",
+            "eth-lib": "^0.1.26",
+            "fs-extra": "^4.0.2",
+            "got": "^7.1.0",
+            "mime-types": "^2.1.16",
+            "mkdirp-promise": "^5.0.1",
+            "mock-fs": "^4.1.0",
+            "setimmediate": "^1.0.5",
+            "tar": "^4.0.2",
+            "xhr-request-promise": "^0.1.2"
+          },
+          "dependencies": {
+            "got": {
+              "version": "7.1.0",
+              "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
+              "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
+              "dev": true,
+              "requires": {
+                "decompress-response": "^3.2.0",
+                "duplexer3": "^0.1.4",
+                "get-stream": "^3.0.0",
+                "is-plain-obj": "^1.1.0",
+                "is-retry-allowed": "^1.0.0",
+                "is-stream": "^1.0.0",
+                "isurl": "^1.0.0-alpha5",
+                "lowercase-keys": "^1.0.0",
+                "p-cancelable": "^0.3.0",
+                "p-timeout": "^1.1.1",
+                "safe-buffer": "^5.0.1",
+                "timed-out": "^4.0.0",
+                "url-parse-lax": "^1.0.0",
+                "url-to-options": "^1.0.1"
+              }
+            }
+          }
+        },
+        "url-parse-lax": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+          "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+          "dev": true,
+          "requires": {
+            "prepend-http": "^1.0.1"
+          }
+        },
+        "uuid": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
+          "dev": true
+        },
+        "web3": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3/-/web3-1.2.2.tgz",
+          "integrity": "sha512-/ChbmB6qZpfGx6eNpczt5YSUBHEA5V2+iUCbn85EVb3Zv6FVxrOo5Tv7Lw0gE2tW7EEjASbCyp3mZeiZaCCngg==",
+          "dev": true,
+          "requires": {
+            "@types/node": "^12.6.1",
+            "web3-bzz": "1.2.2",
+            "web3-core": "1.2.2",
+            "web3-eth": "1.2.2",
+            "web3-eth-personal": "1.2.2",
+            "web3-net": "1.2.2",
+            "web3-shh": "1.2.2",
+            "web3-utils": "1.2.2"
+          }
+        },
+        "web3-bzz": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.2.2.tgz",
+          "integrity": "sha512-b1O2ObsqUN1lJxmFSjvnEC4TsaCbmh7Owj3IAIWTKqL9qhVgx7Qsu5O9cD13pBiSPNZJ68uJPaKq380QB4NWeA==",
+          "dev": true,
+          "requires": {
+            "@types/node": "^10.12.18",
+            "got": "9.6.0",
+            "swarm-js": "0.1.39",
+            "underscore": "1.9.1"
+          },
+          "dependencies": {
+            "@types/node": {
+              "version": "10.17.35",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.35.tgz",
+              "integrity": "sha512-gXx7jAWpMddu0f7a+L+txMplp3FnHl53OhQIF9puXKq3hDGY/GjH+MF04oWnV/adPSCrbtHumDCFwzq2VhltWA==",
+              "dev": true
+            }
+          }
+        },
+        "web3-core": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.2.tgz",
+          "integrity": "sha512-miHAX3qUgxV+KYfaOY93Hlc3kLW2j5fH8FJy6kSxAv+d4d5aH0wwrU2IIoJylQdT+FeenQ38sgsCnFu9iZ1hCQ==",
+          "dev": true,
+          "requires": {
+            "@types/bn.js": "^4.11.4",
+            "@types/node": "^12.6.1",
+            "web3-core-helpers": "1.2.2",
+            "web3-core-method": "1.2.2",
+            "web3-core-requestmanager": "1.2.2",
+            "web3-utils": "1.2.2"
+          }
+        },
+        "web3-core-helpers": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.2.tgz",
+          "integrity": "sha512-HJrRsIGgZa1jGUIhvGz4S5Yh6wtOIo/TMIsSLe+Xay+KVnbseJpPprDI5W3s7H2ODhMQTbogmmUFquZweW2ImQ==",
+          "dev": true,
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-eth-iban": "1.2.2",
+            "web3-utils": "1.2.2"
+          }
+        },
+        "web3-core-method": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.2.tgz",
+          "integrity": "sha512-szR4fDSBxNHaF1DFqE+j6sFR/afv9Aa36OW93saHZnrh+iXSrYeUUDfugeNcRlugEKeUCkd4CZylfgbK2SKYJA==",
+          "dev": true,
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.2",
+            "web3-core-promievent": "1.2.2",
+            "web3-core-subscriptions": "1.2.2",
+            "web3-utils": "1.2.2"
+          }
+        },
+        "web3-core-promievent": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.2.tgz",
+          "integrity": "sha512-tKvYeT8bkUfKABcQswK6/X79blKTKYGk949urZKcLvLDEaWrM3uuzDwdQT3BNKzQ3vIvTggFPX9BwYh0F1WwqQ==",
+          "dev": true,
+          "requires": {
+            "any-promise": "1.3.0",
+            "eventemitter3": "3.1.2"
+          }
+        },
+        "web3-core-requestmanager": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.2.tgz",
+          "integrity": "sha512-a+gSbiBRHtHvkp78U2bsntMGYGF2eCb6219aMufuZWeAZGXJ63Wc2321PCbA8hF9cQrZI4EoZ4kVLRI4OF15Hw==",
+          "dev": true,
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.2",
+            "web3-providers-http": "1.2.2",
+            "web3-providers-ipc": "1.2.2",
+            "web3-providers-ws": "1.2.2"
+          }
+        },
+        "web3-core-subscriptions": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.2.tgz",
+          "integrity": "sha512-QbTgigNuT4eicAWWr7ahVpJyM8GbICsR1Ys9mJqzBEwpqS+RXTRVSkwZ2IsxO+iqv6liMNwGregbJLq4urMFcQ==",
+          "dev": true,
+          "requires": {
+            "eventemitter3": "3.1.2",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.2"
+          }
+        },
+        "web3-eth": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.2.2.tgz",
+          "integrity": "sha512-UXpC74mBQvZzd4b+baD4Ocp7g+BlwxhBHumy9seyE/LMIcMlePXwCKzxve9yReNpjaU16Mmyya6ZYlyiKKV8UA==",
+          "dev": true,
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core": "1.2.2",
+            "web3-core-helpers": "1.2.2",
+            "web3-core-method": "1.2.2",
+            "web3-core-subscriptions": "1.2.2",
+            "web3-eth-abi": "1.2.2",
+            "web3-eth-accounts": "1.2.2",
+            "web3-eth-contract": "1.2.2",
+            "web3-eth-ens": "1.2.2",
+            "web3-eth-iban": "1.2.2",
+            "web3-eth-personal": "1.2.2",
+            "web3-net": "1.2.2",
+            "web3-utils": "1.2.2"
+          }
+        },
+        "web3-eth-abi": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.2.tgz",
+          "integrity": "sha512-Yn/ZMgoOLxhTVxIYtPJ0eS6pnAnkTAaJgUJh1JhZS4ekzgswMfEYXOwpMaD5eiqPJLpuxmZFnXnBZlnQ1JMXsw==",
+          "dev": true,
+          "requires": {
+            "ethers": "4.0.0-beta.3",
+            "underscore": "1.9.1",
+            "web3-utils": "1.2.2"
+          },
+          "dependencies": {
+            "@types/node": {
+              "version": "10.17.35",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.35.tgz",
+              "integrity": "sha512-gXx7jAWpMddu0f7a+L+txMplp3FnHl53OhQIF9puXKq3hDGY/GjH+MF04oWnV/adPSCrbtHumDCFwzq2VhltWA==",
+              "dev": true
+            },
+            "elliptic": {
+              "version": "6.3.3",
+              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
+              "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
+              "dev": true,
+              "requires": {
+                "bn.js": "^4.4.0",
+                "brorand": "^1.0.1",
+                "hash.js": "^1.0.0",
+                "inherits": "^2.0.1"
+              }
+            },
+            "ethers": {
+              "version": "4.0.0-beta.3",
+              "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.0-beta.3.tgz",
+              "integrity": "sha512-YYPogooSknTwvHg3+Mv71gM/3Wcrx+ZpCzarBj3mqs9njjRkrOo2/eufzhHloOCo3JSoNI4TQJJ6yU5ABm3Uog==",
+              "dev": true,
+              "requires": {
+                "@types/node": "^10.3.2",
+                "aes-js": "3.0.0",
+                "bn.js": "^4.4.0",
+                "elliptic": "6.3.3",
+                "hash.js": "1.1.3",
+                "js-sha3": "0.5.7",
+                "scrypt-js": "2.0.3",
+                "setimmediate": "1.0.4",
+                "uuid": "2.0.1",
+                "xmlhttprequest": "1.8.0"
+              }
+            },
+            "setimmediate": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
+              "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48=",
+              "dev": true
+            }
+          }
+        },
+        "web3-eth-accounts": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.2.2.tgz",
+          "integrity": "sha512-KzHOEyXOEZ13ZOkWN3skZKqSo5f4Z1ogPFNn9uZbKCz+kSp+gCAEKxyfbOsB/JMAp5h7o7pb6eYsPCUBJmFFiA==",
+          "dev": true,
+          "requires": {
+            "any-promise": "1.3.0",
+            "crypto-browserify": "3.12.0",
+            "eth-lib": "0.2.7",
+            "ethereumjs-common": "^1.3.2",
+            "ethereumjs-tx": "^2.1.1",
+            "underscore": "1.9.1",
+            "uuid": "3.3.2",
+            "web3-core": "1.2.2",
+            "web3-core-helpers": "1.2.2",
+            "web3-core-method": "1.2.2",
+            "web3-utils": "1.2.2"
+          },
+          "dependencies": {
+            "@web3-js/scrypt-shim": {
+              "version": "github:web3-js/scrypt-shim#aafdadda13e660e25e1c525d1f5b2443f5eb1ebb",
+              "from": "github:web3-js/scrypt-shim",
+              "requires": {
+                "scryptsy": "^2.1.0",
+                "semver": "^6.3.0"
+              },
+              "dependencies": {
+                "scryptsy": {
+                  "version": "2.1.0",
+                  "resolved": "https://registry.npmjs.org/scryptsy/-/scryptsy-2.1.0.tgz",
+                  "integrity": "sha512-1CdSqHQowJBnMAFyPEBRfqag/YP9OF394FV+4YREIJX4ljD7OxvQRDayyoyyCk+senRjSkP6VnUNQmVQqB6g7w=="
+                },
+                "semver": {
+                  "version": "6.3.0",
+                  "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                  "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+                }
+              }
+            },
+            "eth-lib": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "dev": true,
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            },
+            "uuid": {
+              "version": "3.3.2",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+              "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+              "dev": true
+            }
+          }
+        },
+        "web3-eth-contract": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.2.tgz",
+          "integrity": "sha512-EKT2yVFws3FEdotDQoNsXTYL798+ogJqR2//CaGwx3p0/RvQIgfzEwp8nbgA6dMxCsn9KOQi7OtklzpnJMkjtA==",
+          "dev": true,
+          "requires": {
+            "@types/bn.js": "^4.11.4",
+            "underscore": "1.9.1",
+            "web3-core": "1.2.2",
+            "web3-core-helpers": "1.2.2",
+            "web3-core-method": "1.2.2",
+            "web3-core-promievent": "1.2.2",
+            "web3-core-subscriptions": "1.2.2",
+            "web3-eth-abi": "1.2.2",
+            "web3-utils": "1.2.2"
+          }
+        },
+        "web3-eth-ens": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.2.2.tgz",
+          "integrity": "sha512-CFjkr2HnuyMoMFBoNUWojyguD4Ef+NkyovcnUc/iAb9GP4LHohKrODG4pl76R5u61TkJGobC2ij6TyibtsyVYg==",
+          "dev": true,
+          "requires": {
+            "eth-ens-namehash": "2.0.8",
+            "underscore": "1.9.1",
+            "web3-core": "1.2.2",
+            "web3-core-helpers": "1.2.2",
+            "web3-core-promievent": "1.2.2",
+            "web3-eth-abi": "1.2.2",
+            "web3-eth-contract": "1.2.2",
+            "web3-utils": "1.2.2"
+          }
+        },
+        "web3-eth-iban": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.2.tgz",
+          "integrity": "sha512-gxKXBoUhaTFHr0vJB/5sd4i8ejF/7gIsbM/VvemHT3tF5smnmY6hcwSMmn7sl5Gs+83XVb/BngnnGkf+I/rsrQ==",
+          "dev": true,
+          "requires": {
+            "bn.js": "4.11.8",
+            "web3-utils": "1.2.2"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.11.8",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+              "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+              "dev": true
+            }
+          }
+        },
+        "web3-eth-personal": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.2.tgz",
+          "integrity": "sha512-4w+GLvTlFqW3+q4xDUXvCEMU7kRZ+xm/iJC8gm1Li1nXxwwFbs+Y+KBK6ZYtoN1qqAnHR+plYpIoVo27ixI5Rg==",
+          "dev": true,
+          "requires": {
+            "@types/node": "^12.6.1",
+            "web3-core": "1.2.2",
+            "web3-core-helpers": "1.2.2",
+            "web3-core-method": "1.2.2",
+            "web3-net": "1.2.2",
+            "web3-utils": "1.2.2"
+          }
+        },
+        "web3-net": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.2.tgz",
+          "integrity": "sha512-K07j2DXq0x4UOJgae65rWZKraOznhk8v5EGSTdFqASTx7vWE/m+NqBijBYGEsQY1lSMlVaAY9UEQlcXK5HzXTw==",
+          "dev": true,
+          "requires": {
+            "web3-core": "1.2.2",
+            "web3-core-method": "1.2.2",
+            "web3-utils": "1.2.2"
+          }
+        },
+        "web3-providers-http": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.2.tgz",
+          "integrity": "sha512-BNZ7Hguy3eBszsarH5gqr9SIZNvqk9eKwqwmGH1LQS1FL3NdoOn7tgPPdddrXec4fL94CwgNk4rCU+OjjZRNDg==",
+          "dev": true,
+          "requires": {
+            "web3-core-helpers": "1.2.2",
+            "xhr2-cookies": "1.1.0"
+          }
+        },
+        "web3-providers-ipc": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.2.tgz",
+          "integrity": "sha512-t97w3zi5Kn/LEWGA6D9qxoO0LBOG+lK2FjlEdCwDQatffB/+vYrzZ/CLYVQSoyFZAlsDoBasVoYSWZK1n39aHA==",
+          "dev": true,
+          "requires": {
+            "oboe": "2.1.4",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.2"
+          }
+        },
+        "web3-providers-ws": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.2.tgz",
+          "integrity": "sha512-Wb1mrWTGMTXOpJkL0yGvL/WYLt8fUIXx8k/l52QB2IiKzvyd42dTWn4+j8IKXGSYYzOm7NMqv6nhA5VDk12VfA==",
+          "dev": true,
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.2",
+            "websocket": "github:web3-js/WebSocket-Node#ef5ea2f41daf4a2113b80c9223df884b4d56c400"
+          }
+        },
+        "web3-shh": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.2.2.tgz",
+          "integrity": "sha512-og258NPhlBn8yYrDWjoWBBb6zo1OlBgoWGT+LL5/LPqRbjPe09hlOYHgscAAr9zZGtohTOty7RrxYw6Z6oDWCg==",
+          "dev": true,
+          "requires": {
+            "web3-core": "1.2.2",
+            "web3-core-method": "1.2.2",
+            "web3-core-subscriptions": "1.2.2",
+            "web3-net": "1.2.2"
+          }
+        },
+        "web3-utils": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.2.tgz",
+          "integrity": "sha512-joF+s3243TY5cL7Z7y4h1JsJpUCf/kmFmj+eJar7Y2yNIGVcW961VyrAms75tjUysSuHaUQ3eQXjBEUJueT52A==",
+          "dev": true,
+          "requires": {
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.7",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.11.8",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+              "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+              "dev": true
+            },
+            "eth-lib": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "dev": true,
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            }
+          }
+        },
+        "websocket": {
+          "version": "github:web3-js/WebSocket-Node#ef5ea2f41daf4a2113b80c9223df884b4d56c400",
+          "from": "github:web3-js/WebSocket-Node#polyfill/globalThis",
+          "dev": true,
+          "requires": {
+            "debug": "^2.2.0",
+            "es5-ext": "^0.10.50",
+            "nan": "^2.14.0",
+            "typedarray-to-buffer": "^3.1.5",
+            "yaeti": "^0.0.6"
+          }
+        }
+      }
+    },
+    "@truffle/provider": {
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/@truffle/provider/-/provider-0.1.19.tgz",
+      "integrity": "sha512-ke8iQmzW4Y99+8iff8xQcc+mCNU4AkwtaZ/iSpmVD8qpLytw8/DSNCm0RiEz9/+I93Q1zqI4Jnij/rXnkS2Njw==",
+      "dev": true,
+      "requires": {
+        "@truffle/error": "^0.0.7",
+        "@truffle/interface-adapter": "^0.3.0",
+        "web3": "1.2.1"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "10.17.35",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.35.tgz",
+          "integrity": "sha512-gXx7jAWpMddu0f7a+L+txMplp3FnHl53OhQIF9puXKq3hDGY/GjH+MF04oWnV/adPSCrbtHumDCFwzq2VhltWA==",
+          "dev": true
+        },
+        "aes-js": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
+          "integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0=",
+          "dev": true
+        },
+        "bn.js": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+          "dev": true
+        },
+        "ethers": {
+          "version": "4.0.0-beta.3",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.0-beta.3.tgz",
+          "integrity": "sha512-YYPogooSknTwvHg3+Mv71gM/3Wcrx+ZpCzarBj3mqs9njjRkrOo2/eufzhHloOCo3JSoNI4TQJJ6yU5ABm3Uog==",
+          "dev": true,
+          "requires": {
+            "@types/node": "^10.3.2",
+            "aes-js": "3.0.0",
+            "bn.js": "^4.4.0",
+            "elliptic": "6.3.3",
+            "hash.js": "1.1.3",
+            "js-sha3": "0.5.7",
+            "scrypt-js": "2.0.3",
+            "setimmediate": "1.0.4",
+            "uuid": "2.0.1",
+            "xmlhttprequest": "1.8.0"
+          },
+          "dependencies": {
+            "elliptic": {
+              "version": "6.3.3",
+              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
+              "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
+              "dev": true,
+              "requires": {
+                "bn.js": "^4.4.0",
+                "brorand": "^1.0.1",
+                "hash.js": "^1.0.0",
+                "inherits": "^2.0.1"
+              }
+            },
+            "setimmediate": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
+              "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48=",
+              "dev": true
+            }
+          }
+        },
+        "eventemitter3": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+          "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
+          "dev": true
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "dev": true
+        },
+        "hash.js": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
+        "js-sha3": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=",
+          "dev": true
+        },
+        "p-cancelable": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
+          "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw==",
+          "dev": true
+        },
+        "prepend-http": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+          "dev": true
+        },
+        "scrypt-js": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
+          "integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q=",
+          "dev": true
+        },
+        "scryptsy": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/scryptsy/-/scryptsy-2.1.0.tgz",
+          "integrity": "sha512-1CdSqHQowJBnMAFyPEBRfqag/YP9OF394FV+4YREIJX4ljD7OxvQRDayyoyyCk+senRjSkP6VnUNQmVQqB6g7w==",
+          "dev": true
+        },
+        "semver": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.2.0.tgz",
+          "integrity": "sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A==",
+          "dev": true
+        },
+        "swarm-js": {
+          "version": "0.1.39",
+          "resolved": "https://registry.npmjs.org/swarm-js/-/swarm-js-0.1.39.tgz",
+          "integrity": "sha512-QLMqL2rzF6n5s50BptyD6Oi0R1aWlJC5Y17SRIVXRj6OR1DRIPM7nepvrxxkjA1zNzFz6mUOMjfeqeDaWB7OOg==",
+          "dev": true,
+          "requires": {
+            "bluebird": "^3.5.0",
+            "buffer": "^5.0.5",
+            "decompress": "^4.0.0",
+            "eth-lib": "^0.1.26",
+            "fs-extra": "^4.0.2",
+            "got": "^7.1.0",
+            "mime-types": "^2.1.16",
+            "mkdirp-promise": "^5.0.1",
+            "mock-fs": "^4.1.0",
+            "setimmediate": "^1.0.5",
+            "tar": "^4.0.2",
+            "xhr-request-promise": "^0.1.2"
+          },
+          "dependencies": {
+            "got": {
+              "version": "7.1.0",
+              "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
+              "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
+              "dev": true,
+              "requires": {
+                "decompress-response": "^3.2.0",
+                "duplexer3": "^0.1.4",
+                "get-stream": "^3.0.0",
+                "is-plain-obj": "^1.1.0",
+                "is-retry-allowed": "^1.0.0",
+                "is-stream": "^1.0.0",
+                "isurl": "^1.0.0-alpha5",
+                "lowercase-keys": "^1.0.0",
+                "p-cancelable": "^0.3.0",
+                "p-timeout": "^1.1.1",
+                "safe-buffer": "^5.0.1",
+                "timed-out": "^4.0.0",
+                "url-parse-lax": "^1.0.0",
+                "url-to-options": "^1.0.1"
+              }
+            }
+          }
+        },
+        "url-parse-lax": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+          "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+          "dev": true,
+          "requires": {
+            "prepend-http": "^1.0.1"
+          }
+        },
+        "uuid": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
+          "dev": true
+        },
+        "web3": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3/-/web3-1.2.1.tgz",
+          "integrity": "sha512-nNMzeCK0agb5i/oTWNdQ1aGtwYfXzHottFP2Dz0oGIzavPMGSKyVlr8ibVb1yK5sJBjrWVnTdGaOC2zKDFuFRw==",
+          "dev": true,
+          "requires": {
+            "web3-bzz": "1.2.1",
+            "web3-core": "1.2.1",
+            "web3-eth": "1.2.1",
+            "web3-eth-personal": "1.2.1",
+            "web3-net": "1.2.1",
+            "web3-shh": "1.2.1",
+            "web3-utils": "1.2.1"
+          }
+        },
+        "web3-bzz": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.2.1.tgz",
+          "integrity": "sha512-LdOO44TuYbGIPfL4ilkuS89GQovxUpmLz6C1UC7VYVVRILeZS740FVB3j9V4P4FHUk1RenaDfKhcntqgVCHtjw==",
+          "dev": true,
+          "requires": {
+            "got": "9.6.0",
+            "swarm-js": "0.1.39",
+            "underscore": "1.9.1"
+          }
+        },
+        "web3-core": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.1.tgz",
+          "integrity": "sha512-5ODwIqgl8oIg/0+Ai4jsLxkKFWJYE0uLuE1yUKHNVCL4zL6n3rFjRMpKPokd6id6nJCNgeA64KdWQ4XfpnjdMg==",
+          "dev": true,
+          "requires": {
+            "web3-core-helpers": "1.2.1",
+            "web3-core-method": "1.2.1",
+            "web3-core-requestmanager": "1.2.1",
+            "web3-utils": "1.2.1"
+          }
+        },
+        "web3-core-helpers": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.1.tgz",
+          "integrity": "sha512-Gx3sTEajD5r96bJgfuW377PZVFmXIH4TdqDhgGwd2lZQCcMi+DA4TgxJNJGxn0R3aUVzyyE76j4LBrh412mXrw==",
+          "dev": true,
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-eth-iban": "1.2.1",
+            "web3-utils": "1.2.1"
+          }
+        },
+        "web3-core-method": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.1.tgz",
+          "integrity": "sha512-Ghg2WS23qi6Xj8Od3VCzaImLHseEA7/usvnOItluiIc5cKs00WYWsNy2YRStzU9a2+z8lwQywPYp0nTzR/QXdQ==",
+          "dev": true,
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.1",
+            "web3-core-promievent": "1.2.1",
+            "web3-core-subscriptions": "1.2.1",
+            "web3-utils": "1.2.1"
+          }
+        },
+        "web3-core-promievent": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.1.tgz",
+          "integrity": "sha512-IVUqgpIKoeOYblwpex4Hye6npM0aMR+kU49VP06secPeN0rHMyhGF0ZGveWBrGvf8WDPI7jhqPBFIC6Jf3Q3zw==",
+          "dev": true,
+          "requires": {
+            "any-promise": "1.3.0",
+            "eventemitter3": "3.1.2"
+          }
+        },
+        "web3-core-requestmanager": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.1.tgz",
+          "integrity": "sha512-xfknTC69RfYmLKC+83Jz73IC3/sS2ZLhGtX33D4Q5nQ8yc39ElyAolxr9sJQS8kihOcM6u4J+8gyGMqsLcpIBg==",
+          "dev": true,
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.1",
+            "web3-providers-http": "1.2.1",
+            "web3-providers-ipc": "1.2.1",
+            "web3-providers-ws": "1.2.1"
+          }
+        },
+        "web3-core-subscriptions": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.1.tgz",
+          "integrity": "sha512-nmOwe3NsB8V8UFsY1r+sW6KjdOS68h8nuh7NzlWxBQT/19QSUGiERRTaZXWu5BYvo1EoZRMxCKyCQpSSXLc08g==",
+          "dev": true,
+          "requires": {
+            "eventemitter3": "3.1.2",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.1"
+          }
+        },
+        "web3-eth": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.2.1.tgz",
+          "integrity": "sha512-/2xly4Yry5FW1i+uygPjhfvgUP/MS/Dk+PDqmzp5M88tS86A+j8BzKc23GrlA8sgGs0645cpZK/999LpEF5UdA==",
+          "dev": true,
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core": "1.2.1",
+            "web3-core-helpers": "1.2.1",
+            "web3-core-method": "1.2.1",
+            "web3-core-subscriptions": "1.2.1",
+            "web3-eth-abi": "1.2.1",
+            "web3-eth-accounts": "1.2.1",
+            "web3-eth-contract": "1.2.1",
+            "web3-eth-ens": "1.2.1",
+            "web3-eth-iban": "1.2.1",
+            "web3-eth-personal": "1.2.1",
+            "web3-net": "1.2.1",
+            "web3-utils": "1.2.1"
+          }
+        },
+        "web3-eth-abi": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.1.tgz",
+          "integrity": "sha512-jI/KhU2a/DQPZXHjo2GW0myEljzfiKOn+h1qxK1+Y9OQfTcBMxrQJyH5AP89O6l6NZ1QvNdq99ThAxBFoy5L+g==",
+          "dev": true,
+          "requires": {
+            "ethers": "4.0.0-beta.3",
+            "underscore": "1.9.1",
+            "web3-utils": "1.2.1"
+          }
+        },
+        "web3-eth-accounts": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.2.1.tgz",
+          "integrity": "sha512-26I4qq42STQ8IeKUyur3MdQ1NzrzCqPsmzqpux0j6X/XBD7EjZ+Cs0lhGNkSKH5dI3V8CJasnQ5T1mNKeWB7nQ==",
+          "dev": true,
+          "requires": {
+            "any-promise": "1.3.0",
+            "crypto-browserify": "3.12.0",
+            "eth-lib": "0.2.7",
+            "scryptsy": "2.1.0",
+            "semver": "6.2.0",
+            "underscore": "1.9.1",
+            "uuid": "3.3.2",
+            "web3-core": "1.2.1",
+            "web3-core-helpers": "1.2.1",
+            "web3-core-method": "1.2.1",
+            "web3-utils": "1.2.1"
+          },
+          "dependencies": {
+            "eth-lib": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "dev": true,
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            },
+            "uuid": {
+              "version": "3.3.2",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+              "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+              "dev": true
+            }
+          }
+        },
+        "web3-eth-contract": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.1.tgz",
+          "integrity": "sha512-kYFESbQ3boC9bl2rYVghj7O8UKMiuKaiMkxvRH5cEDHil8V7MGEGZNH0slSdoyeftZVlaWSMqkRP/chfnKND0g==",
+          "dev": true,
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core": "1.2.1",
+            "web3-core-helpers": "1.2.1",
+            "web3-core-method": "1.2.1",
+            "web3-core-promievent": "1.2.1",
+            "web3-core-subscriptions": "1.2.1",
+            "web3-eth-abi": "1.2.1",
+            "web3-utils": "1.2.1"
+          }
+        },
+        "web3-eth-ens": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.2.1.tgz",
+          "integrity": "sha512-lhP1kFhqZr2nnbu3CGIFFrAnNxk2veXpOXBY48Tub37RtobDyHijHgrj+xTh+mFiPokyrapVjpFsbGa+Xzye4Q==",
+          "dev": true,
+          "requires": {
+            "eth-ens-namehash": "2.0.8",
+            "underscore": "1.9.1",
+            "web3-core": "1.2.1",
+            "web3-core-helpers": "1.2.1",
+            "web3-core-promievent": "1.2.1",
+            "web3-eth-abi": "1.2.1",
+            "web3-eth-contract": "1.2.1",
+            "web3-utils": "1.2.1"
+          }
+        },
+        "web3-eth-iban": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.1.tgz",
+          "integrity": "sha512-9gkr4QPl1jCU+wkgmZ8EwODVO3ovVj6d6JKMos52ggdT2YCmlfvFVF6wlGLwi0VvNa/p+0BjJzaqxnnG/JewjQ==",
+          "dev": true,
+          "requires": {
+            "bn.js": "4.11.8",
+            "web3-utils": "1.2.1"
+          }
+        },
+        "web3-eth-personal": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.1.tgz",
+          "integrity": "sha512-RNDVSiaSoY4aIp8+Hc7z+X72H7lMb3fmAChuSBADoEc7DsJrY/d0R5qQDK9g9t2BO8oxgLrLNyBP/9ub2Hc6Bg==",
+          "dev": true,
+          "requires": {
+            "web3-core": "1.2.1",
+            "web3-core-helpers": "1.2.1",
+            "web3-core-method": "1.2.1",
+            "web3-net": "1.2.1",
+            "web3-utils": "1.2.1"
+          }
+        },
+        "web3-net": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.1.tgz",
+          "integrity": "sha512-Yt1Bs7WgnLESPe0rri/ZoPWzSy55ovioaP35w1KZydrNtQ5Yq4WcrAdhBzcOW7vAkIwrsLQsvA+hrOCy7mNauw==",
+          "dev": true,
+          "requires": {
+            "web3-core": "1.2.1",
+            "web3-core-method": "1.2.1",
+            "web3-utils": "1.2.1"
+          }
+        },
+        "web3-providers-http": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.1.tgz",
+          "integrity": "sha512-BDtVUVolT9b3CAzeGVA/np1hhn7RPUZ6YYGB/sYky+GjeO311Yoq8SRDUSezU92x8yImSC2B+SMReGhd1zL+bQ==",
+          "dev": true,
+          "requires": {
+            "web3-core-helpers": "1.2.1",
+            "xhr2-cookies": "1.1.0"
+          }
+        },
+        "web3-providers-ipc": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.1.tgz",
+          "integrity": "sha512-oPEuOCwxVx8L4CPD0TUdnlOUZwGBSRKScCz/Ws2YHdr9Ium+whm+0NLmOZjkjQp5wovQbyBzNa6zJz1noFRvFA==",
+          "dev": true,
+          "requires": {
+            "oboe": "2.1.4",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.1"
+          }
+        },
+        "web3-providers-ws": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.1.tgz",
+          "integrity": "sha512-oqsQXzu+ejJACVHy864WwIyw+oB21nw/pI65/sD95Zi98+/HQzFfNcIFneF1NC4bVF3VNX4YHTNq2I2o97LAiA==",
+          "dev": true,
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.1",
+            "websocket": "github:web3-js/WebSocket-Node#ef5ea2f41daf4a2113b80c9223df884b4d56c400"
+          }
+        },
+        "web3-shh": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.2.1.tgz",
+          "integrity": "sha512-/3Cl04nza5kuFn25bV3FJWa0s3Vafr5BlT933h26xovQ6HIIz61LmvNQlvX1AhFL+SNJOTcQmK1SM59vcyC8bA==",
+          "dev": true,
+          "requires": {
+            "web3-core": "1.2.1",
+            "web3-core-method": "1.2.1",
+            "web3-core-subscriptions": "1.2.1",
+            "web3-net": "1.2.1"
+          }
+        },
+        "web3-utils": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
+          "integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
+          "dev": true,
+          "requires": {
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.7",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randomhex": "0.1.5",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          },
+          "dependencies": {
+            "eth-lib": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "dev": true,
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            }
+          }
+        },
+        "websocket": {
+          "version": "github:web3-js/WebSocket-Node#ef5ea2f41daf4a2113b80c9223df884b4d56c400",
+          "from": "github:web3-js/WebSocket-Node#polyfill/globalThis",
+          "dev": true,
+          "requires": {
+            "debug": "^2.2.0",
+            "es5-ext": "^0.10.50",
+            "nan": "^2.14.0",
+            "typedarray-to-buffer": "^3.1.5",
+            "yaeti": "^0.0.6"
           }
         }
       }
@@ -684,8 +1862,7 @@
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
-      "dev": true
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
     },
     "@types/concat-stream": {
       "version": "1.6.0",
@@ -704,6 +1881,22 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/glob": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
+      "dev": true,
+      "requires": {
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/minimatch": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+      "dev": true
     },
     "@types/node": {
       "version": "14.6.0",
@@ -740,6 +1933,48 @@
         "web3": "*"
       }
     },
+    "@web3-js/scrypt-shim": {
+      "version": "0.1.0",
+      "resolved": "github:web3-js/scrypt-shim#aafdadda13e660e25e1c525d1f5b2443f5eb1ebb",
+      "dev": true,
+      "requires": {
+        "scryptsy": "^2.1.0",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "scryptsy": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/scryptsy/-/scryptsy-2.1.0.tgz",
+          "integrity": "sha512-1CdSqHQowJBnMAFyPEBRfqag/YP9OF394FV+4YREIJX4ljD7OxvQRDayyoyyCk+senRjSkP6VnUNQmVQqB6g7w==",
+          "dev": true
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
+    "@web3-js/websocket": {
+      "version": "1.0.30",
+      "resolved": "https://registry.npmjs.org/@web3-js/websocket/-/websocket-1.0.30.tgz",
+      "integrity": "sha512-fDwrD47MiDrzcJdSeTLF75aCcxVVt8B1N74rA+vh2XCAvFy4tEWJjtnUtj2QG7/zlQ6g9cQ88bZFBxwd9/FmtA==",
+      "dev": true,
+      "requires": {
+        "debug": "^2.2.0",
+        "es5-ext": "^0.10.50",
+        "nan": "^2.14.0",
+        "typedarray-to-buffer": "^3.1.5",
+        "yaeti": "^0.0.6"
+      }
+    },
+    "abbrev": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+      "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
+      "dev": true
+    },
     "abstract-leveldown": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
@@ -769,6 +2004,12 @@
       "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
       "dev": true
     },
+    "address": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/address/-/address-1.1.2.tgz",
+      "integrity": "sha512-aT6camzM4xEA54YVJYSqxz1kv4IHnQZRtThJJHhUMRExaU5spC7jX5ugSwTaTgJliIgs4VhZOk7htClvQ/LmRA==",
+      "dev": true
+    },
     "aes-js": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.1.2.tgz",
@@ -784,6 +2025,13 @@
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
       }
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "dev": true,
+      "optional": true
     },
     "ansi-colors": {
       "version": "4.1.1",
@@ -872,6 +2120,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+    },
+    "array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true
     },
     "array-unique": {
       "version": "0.2.1",
@@ -1127,6 +2381,16 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "bl": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
+      "integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
+      }
+    },
     "blakejs": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.0.tgz",
@@ -1309,6 +2573,34 @@
         "ieee754": "^1.1.4"
       }
     },
+    "buffer-alloc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+      "dev": true,
+      "requires": {
+        "buffer-alloc-unsafe": "^1.1.0",
+        "buffer-fill": "^1.0.0"
+      }
+    },
+    "buffer-alloc-unsafe": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
+      "dev": true
+    },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+      "dev": true
+    },
+    "buffer-fill": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
+      "dev": true
+    },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -1323,6 +2615,21 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
+    },
+    "bufferutil": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.1.tgz",
+      "integrity": "sha512-xowrxvpxojqkagPcWRQVXZl0YXhRhAtBEIq3VoER1NH5Mw1n1o0ojdspp+GS2J//2gCVyrzQDApQ4unGF+QOoA==",
+      "requires": {
+        "node-gyp-build": "~3.7.0"
+      },
+      "dependencies": {
+        "node-gyp-build": {
+          "version": "3.7.0",
+          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.7.0.tgz",
+          "integrity": "sha512-L/Eg02Epx6Si2NXmedx+Okg+4UHqmaf3TNcxd50SF9NQGcJaON3AtU++kax69XV7YWz4tUspqZSAsVofhFKG2w=="
+        }
+      }
     },
     "bytes": {
       "version": "3.1.0",
@@ -1403,6 +2710,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -1413,6 +2721,7 @@
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -1440,9 +2749,9 @@
       }
     },
     "chokidar": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.1.tgz",
-      "integrity": "sha512-4QYCEWOcK3OJrxwvyyAOxFuhpvOVCYkr33LPfFNBjAD/w3sEzWsp2BUOkI4l9bHvWioAd0rc6NlHUOEaWkTeqg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.2.tgz",
+      "integrity": "sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==",
       "requires": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
@@ -1451,7 +2760,7 @@
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
-        "readdirp": "~3.3.0"
+        "readdirp": "~3.4.0"
       }
     },
     "chownr": {
@@ -1874,6 +3183,12 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "death": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/death/-/death-1.1.0.tgz",
+      "integrity": "sha1-AaqcQB7dknUFFEcLgmY5DGbGcxg=",
+      "dev": true
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -1892,12 +3207,115 @@
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
+    "decompress": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.1.tgz",
+      "integrity": "sha512-e48kc2IjU+2Zw8cTb6VZcJQ3lgVbS4uuB1TfCHbiZIP/haNXm+SVyhu+87jts5/3ROpd82GSVCoNs/z8l4ZOaQ==",
+      "dev": true,
+      "requires": {
+        "decompress-tar": "^4.0.0",
+        "decompress-tarbz2": "^4.0.0",
+        "decompress-targz": "^4.0.0",
+        "decompress-unzip": "^4.0.1",
+        "graceful-fs": "^4.1.10",
+        "make-dir": "^1.0.0",
+        "pify": "^2.3.0",
+        "strip-dirs": "^2.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
+      }
+    },
     "decompress-response": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
       "requires": {
         "mimic-response": "^1.0.0"
+      }
+    },
+    "decompress-tar": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
+      "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
+      "dev": true,
+      "requires": {
+        "file-type": "^5.2.0",
+        "is-stream": "^1.1.0",
+        "tar-stream": "^1.5.2"
+      }
+    },
+    "decompress-tarbz2": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
+      "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
+      "dev": true,
+      "requires": {
+        "decompress-tar": "^4.1.0",
+        "file-type": "^6.1.0",
+        "is-stream": "^1.1.0",
+        "seek-bzip": "^1.0.5",
+        "unbzip2-stream": "^1.0.9"
+      },
+      "dependencies": {
+        "file-type": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
+          "integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg==",
+          "dev": true
+        }
+      }
+    },
+    "decompress-targz": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
+      "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
+      "dev": true,
+      "requires": {
+        "decompress-tar": "^4.1.1",
+        "file-type": "^5.2.0",
+        "is-stream": "^1.1.0"
+      }
+    },
+    "decompress-unzip": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
+      "integrity": "sha1-3qrM39FK6vhVePczroIQ+bSEj2k=",
+      "dev": true,
+      "requires": {
+        "file-type": "^3.8.0",
+        "get-stream": "^2.2.0",
+        "pify": "^2.3.0",
+        "yauzl": "^2.4.2"
+      },
+      "dependencies": {
+        "file-type": {
+          "version": "3.9.0",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+          "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
+          "dev": true
+        },
+        "get-stream": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+          "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.0.1",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
       }
     },
     "deep-is": {
@@ -2011,6 +3429,16 @@
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
+    "detect-port": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.3.0.tgz",
+      "integrity": "sha512-E+B1gzkl2gqxt1IhUzwjrxBKRqx1UzC3WLONHinn8S3T6lwV/agVCyitiFOsGJ/eYuEUBvD71MZHy3Pv1G9doQ==",
+      "dev": true,
+      "requires": {
+        "address": "^1.0.1",
+        "debug": "^2.6.0"
+      }
+    },
     "diff": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
@@ -2024,6 +3452,15 @@
         "bn.js": "^4.1.0",
         "miller-rabin": "^4.0.0",
         "randombytes": "^2.0.0"
+      }
+    },
+    "dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "requires": {
+        "path-type": "^4.0.0"
       }
     },
     "dir-to-object": {
@@ -2234,7 +3671,45 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "escodegen": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+      "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
+      "dev": true,
+      "requires": {
+        "esprima": "^2.7.1",
+        "estraverse": "^1.9.1",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.2.0"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "2.7.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+          "dev": true
+        },
+        "estraverse": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+          "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+          "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "amdefine": ">=0.0.4"
+          }
+        }
+      }
     },
     "eslint": {
       "version": "6.8.0",
@@ -2707,61 +4182,36 @@
       }
     },
     "eth-json-rpc-filters": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/eth-json-rpc-filters/-/eth-json-rpc-filters-4.1.1.tgz",
-      "integrity": "sha512-GkXb2h6STznD+AmMzblwXgm1JMvjdK9PTIXG7BvIkTlXQ9g0QOxuU1iQRYHoslF9S30BYBSoLSisAYPdLggW+A==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eth-json-rpc-filters/-/eth-json-rpc-filters-4.2.1.tgz",
+      "integrity": "sha512-tPfohezq8mSmwa47xvq6PGzBDLZ0njWJMB1J+OPuv+n+1WkWDlf3l3tqJXpq96RxhrzK2q7wiweRS5aGIzpq4Q==",
       "requires": {
         "await-semaphore": "^0.1.3",
-        "eth-json-rpc-middleware": "^4.1.4",
+        "eth-json-rpc-middleware": "^6.0.0",
         "eth-query": "^2.1.2",
-        "json-rpc-engine": "^5.1.3",
+        "json-rpc-engine": "^5.3.0",
         "lodash.flatmap": "^4.5.0",
         "safe-event-emitter": "^1.0.1"
       }
     },
     "eth-json-rpc-middleware": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/eth-json-rpc-middleware/-/eth-json-rpc-middleware-4.4.1.tgz",
-      "integrity": "sha512-yoSuRgEYYGFdVeZg3poWOwAlRI+MoBIltmOB86MtpoZjvLbou9EB/qWMOWSmH2ryCWLW97VYY6NWsmWm3OAA7A==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/eth-json-rpc-middleware/-/eth-json-rpc-middleware-6.0.0.tgz",
+      "integrity": "sha512-qqBfLU2Uq1Ou15Wox1s+NX05S9OcAEL4JZ04VZox2NS0U+RtCMjSxzXhLFWekdShUPZ+P8ax3zCO2xcPrp6XJQ==",
       "requires": {
         "btoa": "^1.2.1",
         "clone": "^2.1.1",
-        "eth-json-rpc-errors": "^1.0.1",
         "eth-query": "^2.1.2",
+        "eth-rpc-errors": "^3.0.0",
         "eth-sig-util": "^1.4.2",
-        "ethereumjs-block": "^1.6.0",
-        "ethereumjs-tx": "^1.3.7",
         "ethereumjs-util": "^5.1.2",
-        "ethereumjs-vm": "^2.6.0",
-        "fetch-ponyfill": "^4.0.0",
-        "json-rpc-engine": "^5.1.3",
+        "json-rpc-engine": "^5.3.0",
         "json-stable-stringify": "^1.0.1",
+        "node-fetch": "^2.6.1",
         "pify": "^3.0.0",
         "safe-event-emitter": "^1.0.1"
       },
       "dependencies": {
-        "eth-json-rpc-errors": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/eth-json-rpc-errors/-/eth-json-rpc-errors-1.1.1.tgz",
-          "integrity": "sha512-WT5shJ5KfNqHi9jOZD+ID8I1kuYWNrigtZat7GOQkvwo99f8SzAVaEcWhJUv656WiZOAg3P1RiJQANtUmDmbIg==",
-          "requires": {
-            "fast-safe-stringify": "^2.0.6"
-          }
-        },
-        "ethereum-common": {
-          "version": "0.0.18",
-          "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
-          "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8="
-        },
-        "ethereumjs-tx": {
-          "version": "1.3.7",
-          "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.7.tgz",
-          "integrity": "sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==",
-          "requires": {
-            "ethereum-common": "^0.0.18",
-            "ethereumjs-util": "^5.0.0"
-          }
-        },
         "ethereumjs-util": {
           "version": "5.2.1",
           "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
@@ -2775,6 +4225,11 @@
             "rlp": "^2.0.0",
             "safe-buffer": "^5.1.1"
           }
+        },
+        "node-fetch": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
         }
       }
     },
@@ -2830,12 +4285,12 @@
       "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
       "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
       "requires": {
-        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
+        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1ce6a1d64235fabe2aaf827fd606def55693508f",
         "ethereumjs-util": "^5.1.1"
       },
       "dependencies": {
         "ethereumjs-abi": {
-          "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1cfbb13862f90f0b391d8a699544d5fe4dfb8c7b",
+          "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1ce6a1d64235fabe2aaf827fd606def55693508f",
           "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
           "requires": {
             "bn.js": "^4.11.8",
@@ -3872,6 +5327,32 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
+    "fast-glob": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
+      "integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.0",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.2",
+        "picomatch": "^2.2.1"
+      },
+      "dependencies": {
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        }
+      }
+    },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -3887,6 +5368,24 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
       "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
+    },
+    "fastq": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.8.0.tgz",
+      "integrity": "sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==",
+      "dev": true,
+      "requires": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+      "dev": true,
+      "requires": {
+        "pend": "~1.2.0"
+      }
     },
     "fetch-ponyfill": {
       "version": "4.1.0",
@@ -3913,6 +5412,12 @@
       "requires": {
         "flat-cache": "^2.0.1"
       }
+    },
+    "file-type": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
+      "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY=",
+      "dev": true
     },
     "file-uri-to-path": {
       "version": "1.0.0",
@@ -3948,11 +5453,11 @@
       }
     },
     "find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "requires": {
-        "locate-path": "^5.0.0",
+        "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
       }
     },
@@ -4030,6 +5535,12 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true
+    },
     "fs-extra": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
@@ -4076,9 +5587,9 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
     },
     "ganache-cli": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/ganache-cli/-/ganache-cli-6.10.1.tgz",
-      "integrity": "sha512-3lpBxILtJBxkNVo+U8ad2qbkzB6nZ53gXhXH6NiS0Pauqur86rGbhXz6fNASjBosZm9iJ8Nr71fJd331QODFkQ==",
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/ganache-cli/-/ganache-cli-6.10.2.tgz",
+      "integrity": "sha512-wCuQjy7k040J8hii1KQ/dYHv8qjdHIcP3fw331AWPqQjeqNquf5HVVQNJOYXINTDofMDkCMQv3ru4ze/A+WyPQ==",
       "requires": {
         "ethereumjs-util": "6.1.0",
         "scrypt": "6.0.3",
@@ -4714,6 +6225,16 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "ghost-testrpc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/ghost-testrpc/-/ghost-testrpc-0.0.2.tgz",
+      "integrity": "sha512-i08dAEgJ2g8z5buJIrCTduwPIhih3DP+hOCTyyryikfV8T0bNvHnGXO67i0DD1H4GBDETTclPy9njZbfluQYrQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.2",
+        "node-emoji": "^1.10.0"
+      }
+    },
     "glob": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
@@ -4780,11 +6301,72 @@
         "process": "~0.5.1"
       }
     },
+    "global-modules": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
+      "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
+      "dev": true,
+      "requires": {
+        "global-prefix": "^3.0.0"
+      }
+    },
+    "global-prefix": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
+      "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
+      "dev": true,
+      "requires": {
+        "ini": "^1.3.5",
+        "kind-of": "^6.0.2",
+        "which": "^1.3.1"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+          "dev": true
+        },
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true
+    },
+    "globby": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.2.tgz",
+      "integrity": "sha512-7dUi7RvCoT/xast/o/dLN53oqND4yk0nsHkhRgn9w65C4PofCLOoJ39iSOg+qVDdWQPIEj+eszMHQ+aLVwwQSg==",
+      "dev": true,
+      "requires": {
+        "@types/glob": "^7.1.1",
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.0.3",
+        "glob": "^7.1.3",
+        "ignore": "^5.1.1",
+        "merge2": "^1.2.3",
+        "slash": "^3.0.0"
+      },
+      "dependencies": {
+        "ignore": {
+          "version": "5.1.8",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+          "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+          "dev": true
+        }
+      }
     },
     "got": {
       "version": "9.6.0",
@@ -4814,6 +6396,19 @@
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA=="
     },
+    "handlebars": {
+      "version": "4.7.6",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
+      "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
+        "wordwrap": "^1.0.0"
+      }
+    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -4839,7 +6434,8 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
     },
     "has-symbol-support-x": {
       "version": "1.4.2",
@@ -5114,6 +6710,12 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "dev": true
+    },
     "inquirer": {
       "version": "7.3.3",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
@@ -5209,6 +6811,12 @@
           }
         }
       }
+    },
+    "interpret": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "dev": true
     },
     "invert-kv": {
       "version": "1.0.0",
@@ -5344,6 +6952,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.1.tgz",
       "integrity": "sha512-T/S49scO8plUiAOA2DBTBG3JHpn1yiw0kRp6dgiZ0v2/6twi5eiB0rHtHFH9ZIrvlWc6+4O+m4zg5+Z833aXgw=="
+    },
+    "is-natural-number": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
+      "integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg=",
+      "dev": true
     },
     "is-number": {
       "version": "7.0.0",
@@ -5512,6 +7126,7 @@
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
       "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -5588,6 +7203,12 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+    },
+    "jsonschema": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.7.tgz",
+      "integrity": "sha512-3dFMg9hmI9LdHag/BRIhMefCfbq1hicvYMy8YhZQorAdzOzWz7NjniSpn39yjpzUAMIWtGyyZuH2KNBloH7ZLw==",
+      "dev": true
     },
     "jsprim": {
       "version": "1.4.1",
@@ -5754,11 +7375,11 @@
       }
     },
     "locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "requires": {
-        "p-locate": "^4.1.0"
+        "p-locate": "^5.0.0"
       }
     },
     "lodash": {
@@ -5771,10 +7392,17 @@
       "resolved": "https://registry.npmjs.org/lodash.flatmap/-/lodash.flatmap-4.5.0.tgz",
       "integrity": "sha1-74y/QI9uSCaGYzRTBcaswLd4cC4="
     },
+    "lodash.toarray": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
+      "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE=",
+      "dev": true
+    },
     "log-symbols": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
       "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+      "dev": true,
       "requires": {
         "chalk": "^2.4.2"
       }
@@ -5806,6 +7434,15 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
       "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU="
+    },
+    "make-dir": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+      "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+      "dev": true,
+      "requires": {
+        "pify": "^3.0.0"
+      }
     },
     "map-cache": {
       "version": "0.2.2",
@@ -5904,6 +7541,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+    },
+    "merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true
     },
     "merkle-patricia-tree": {
       "version": "2.3.2",
@@ -6125,27 +7768,27 @@
       }
     },
     "mocha": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.0.1.tgz",
-      "integrity": "sha512-vefaXfdYI8+Yo8nPZQQi0QO2o+5q9UIMX1jZ1XMmK3+4+CQjc7+B0hPdUeglXiTlr8IHMVRo63IhO9Mzt6fxOg==",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.1.2.tgz",
+      "integrity": "sha512-I8FRAcuACNMLQn3lS4qeWLxXqLvGf6r2CaLstDpZmMUUSmvW6Cnm1AuHxgbc7ctZVRcfwspCRbDHymPsi3dkJw==",
       "requires": {
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
-        "chokidar": "3.3.1",
-        "debug": "3.2.6",
+        "chokidar": "3.4.2",
+        "debug": "4.1.1",
         "diff": "4.0.2",
-        "escape-string-regexp": "1.0.5",
-        "find-up": "4.1.0",
+        "escape-string-regexp": "4.0.0",
+        "find-up": "5.0.0",
         "glob": "7.1.6",
         "growl": "1.10.5",
         "he": "1.2.0",
-        "js-yaml": "3.13.1",
-        "log-symbols": "3.0.0",
+        "js-yaml": "3.14.0",
+        "log-symbols": "4.0.0",
         "minimatch": "3.0.4",
         "ms": "2.1.2",
         "object.assign": "4.1.0",
         "promise.allsettled": "1.0.2",
-        "serialize-javascript": "3.0.0",
+        "serialize-javascript": "4.0.0",
         "strip-json-comments": "3.0.1",
         "supports-color": "7.1.0",
         "which": "2.0.2",
@@ -6153,21 +7796,168 @@
         "workerpool": "6.0.0",
         "yargs": "13.3.2",
         "yargs-parser": "13.1.2",
-        "yargs-unparser": "1.6.0"
+        "yargs-unparser": "1.6.1"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "requires": {
             "ms": "^2.1.1"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+        },
+        "js-yaml": {
+          "version": "3.14.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+          "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "log-symbols": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
+          "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
+          "requires": {
+            "chalk": "^4.0.0"
           }
         },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "yargs-unparser": {
+          "version": "1.6.1",
+          "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.1.tgz",
+          "integrity": "sha512-qZV14lK9MWsGCmcr7u5oXGH0dbGqZAIxTDrWXZDo5zUr6b6iUmelNKO6x6R1dQT24AH3LgRxJpr8meWy2unolA==",
+          "requires": {
+            "camelcase": "^5.3.1",
+            "decamelize": "^1.2.0",
+            "flat": "^4.1.0",
+            "is-plain-obj": "^1.1.0",
+            "yargs": "^14.2.3"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+              "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+              "requires": {
+                "locate-path": "^3.0.0"
+              }
+            },
+            "yargs": {
+              "version": "14.2.3",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
+              "integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
+              "requires": {
+                "cliui": "^5.0.0",
+                "decamelize": "^1.2.0",
+                "find-up": "^3.0.0",
+                "get-caller-file": "^2.0.1",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^2.0.0",
+                "set-blocking": "^2.0.0",
+                "string-width": "^3.0.0",
+                "which-module": "^2.0.0",
+                "y18n": "^4.0.0",
+                "yargs-parser": "^15.0.1"
+              }
+            },
+            "yargs-parser": {
+              "version": "15.0.1",
+              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
+              "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
+              "requires": {
+                "camelcase": "^5.0.0",
+                "decamelize": "^1.2.0"
+              }
+            }
+          }
         }
       }
     },
@@ -6285,6 +8075,12 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
       "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
     },
+    "neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true
+    },
     "next-tick": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
@@ -6300,6 +8096,15 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
       "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
+    },
+    "node-emoji": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.10.0.tgz",
+      "integrity": "sha512-Yt3384If5H6BYGVHiHwTL+99OzJKHhgp82S8/dktEK73T26BazdgZ4JZh92xSVtGNJvz9UbXdNAc5hcrXV42vw==",
+      "dev": true,
+      "requires": {
+        "lodash.toarray": "^4.4.0"
+      }
     },
     "node-environment-flags": {
       "version": "1.0.6",
@@ -6349,7 +8154,16 @@
       "integrity": "sha1-CH52u+t+jcVmhrJdtOYMX/nbCR8=",
       "requires": {
         "is-stream": "^1.1.0",
-        "web-streams-polyfill": "git://github.com/gwicke/web-streams-polyfill.git#spec_performance_improvements"
+        "web-streams-polyfill": "git://github.com/gwicke/web-streams-polyfill.git#42c488428adea1dc0c0245014e4896ad456b1ded"
+      }
+    },
+    "nopt": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "dev": true,
+      "requires": {
+        "abbrev": "1"
       }
     },
     "normalize-path": {
@@ -6511,6 +8325,7 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.4.tgz",
       "integrity": "sha1-IMiM2wwVNxuwQRklfU/dNLCqSfY=",
+      "dev": true,
       "requires": {
         "http-https": "^1.0.0"
       }
@@ -6595,11 +8410,21 @@
       }
     },
     "p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "requires": {
-        "p-limit": "^2.2.0"
+        "p-limit": "^3.0.2"
+      },
+      "dependencies": {
+        "p-limit": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.0.2.tgz",
+          "integrity": "sha512-iwqZSOoWIW+Ew4kAGUlN16J4M7OB3ysMLSZtnhmqx7njIHFPlxWBX8xo3lVTyFVq6mI/lL9qt2IsN1sHwaxJkg==",
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        }
       }
     },
     "p-timeout": {
@@ -6719,6 +8544,12 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
+    "path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true
+    },
     "pbkdf2": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.1.tgz",
@@ -6737,6 +8568,12 @@
       "integrity": "sha1-z4uvrm7d/0tafvsYUmnqr0YQ3b0=",
       "dev": true
     },
+    "pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+      "dev": true
+    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -6751,6 +8588,21 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
       "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "^2.0.0"
+      }
     },
     "posix-character-classes": {
       "version": "0.1.1",
@@ -6787,12 +8639,12 @@
       "dev": true
     },
     "prettier-plugin-solidity": {
-      "version": "1.0.0-alpha.56",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-solidity/-/prettier-plugin-solidity-1.0.0-alpha.56.tgz",
-      "integrity": "sha512-+RtJCTQEgHSfOZ3ehHeIElvzVjnYz1qy/mzgiNL4MobInUgXS+hi1iVNiU21KcSVR8Z75DApfofzEt0heddsmg==",
+      "version": "1.0.0-alpha.58",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-solidity/-/prettier-plugin-solidity-1.0.0-alpha.58.tgz",
+      "integrity": "sha512-G2xj98uEtfTcSc4qZcQ+MLwibpDNhBmOJk9ezTJ7uQLtTMGP1X9PqRnRlJW/vxbStPw/TVvnYD5rXwd1KZbTsg==",
       "dev": true,
       "requires": {
-        "@solidity-parser/parser": "^0.7.0",
+        "@solidity-parser/parser": "^0.8.1",
         "dir-to-object": "^2.0.0",
         "emoji-regex": "^9.0.0",
         "escape-string-regexp": "^4.0.0",
@@ -6802,6 +8654,12 @@
         "string-width": "^4.2.0"
       },
       "dependencies": {
+        "@solidity-parser/parser": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.8.1.tgz",
+          "integrity": "sha512-DF7H6T8I4lo2IZOE2NZwt3631T8j1gjpQLjmvY2xBNK50c4ltslR4XPKwT6RkeSd4+xCAK0GHC/k7sbRDBE4Yw==",
+          "dev": true
+        },
         "ansi-regex": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
@@ -6827,9 +8685,9 @@
           "dev": true
         },
         "prettier": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.1.0.tgz",
-          "integrity": "sha512-lz28cCbA1cDFHVuY8vvj6QuqOwIpyIfPUYkSl8AZ/vxH8qBXMMjE2knfLHCrZCmUsK/H1bg1P0tOo0dJkTJHvw==",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.1.2.tgz",
+          "integrity": "sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==",
           "dev": true
         },
         "semver": {
@@ -7023,6 +8881,12 @@
         "safe-buffer": "^5.1.0"
       }
     },
+    "randomhex": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/randomhex/-/randomhex-0.1.5.tgz",
+      "integrity": "sha1-us7vmCMpCRQA8qKRLGzQLxCU9YU=",
+      "dev": true
+    },
     "range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -7084,11 +8948,29 @@
       }
     },
     "readdirp": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.3.0.tgz",
-      "integrity": "sha512-zz0pAkSPOXXm1viEwygWIPSPkcBYjW1xU5j/JBh5t9bGCJwa6f9+BJa6VaB2g+b55yVrmXzqkyLf4xaWYM0IkQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
+      "integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
       "requires": {
-        "picomatch": "^2.0.7"
+        "picomatch": "^2.2.1"
+      }
+    },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "^1.1.6"
+      }
+    },
+    "recursive-readdir": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.2.tgz",
+      "integrity": "sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==",
+      "dev": true,
+      "requires": {
+        "minimatch": "3.0.4"
       }
     },
     "regenerator-runtime": {
@@ -7272,6 +9154,12 @@
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
     },
+    "reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true
+    },
     "rimraf": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -7302,6 +9190,12 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
       "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "dev": true
+    },
+    "run-parallel": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
+      "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
       "dev": true
     },
     "rustbn.js": {
@@ -7345,6 +9239,94 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "sc-istanbul": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/sc-istanbul/-/sc-istanbul-0.4.5.tgz",
+      "integrity": "sha512-7wR5EZFLsC4w0wSm9BUuCgW+OGKAU7PNlW5L0qwVPbh+Q1sfVn2fyzfMXYCm6rkNA5ipaCOt94nApcguQwF5Gg==",
+      "dev": true,
+      "requires": {
+        "abbrev": "1.0.x",
+        "async": "1.x",
+        "escodegen": "1.8.x",
+        "esprima": "2.7.x",
+        "glob": "^5.0.15",
+        "handlebars": "^4.0.1",
+        "js-yaml": "3.x",
+        "mkdirp": "0.5.x",
+        "nopt": "3.x",
+        "once": "1.x",
+        "resolve": "1.1.x",
+        "supports-color": "^3.1.0",
+        "which": "^1.1.1",
+        "wordwrap": "^1.0.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "dev": true
+        },
+        "esprima": {
+          "version": "2.7.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+          "dev": true
+        },
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "dev": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
+        "resolve": {
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^1.0.0"
+          }
+        },
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "scrypt": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/scrypt/-/scrypt-6.0.3.tgz",
@@ -7375,6 +9357,15 @@
         "elliptic": "^6.5.2",
         "node-addon-api": "^2.0.0",
         "node-gyp-build": "^4.2.0"
+      }
+    },
+    "seek-bzip": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.6.tgz",
+      "integrity": "sha512-e1QtP3YL5tWww8uKaOCQ18UxIT2laNBXHjV/S2WYCiK4udiv8lkG89KRIoCjUagnAmCBurjF4zEVX2ByBbnCjQ==",
+      "dev": true,
+      "requires": {
+        "commander": "^2.8.1"
       }
     },
     "semaphore": {
@@ -7415,9 +9406,12 @@
       }
     },
     "serialize-javascript": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-3.0.0.tgz",
-      "integrity": "sha512-skZcHYw2vEX4bw90nAr2iTTsz6x2SrHEnfxgKYmZlvJYBEZrvbKtobJWlQ20zczKb3bsHHXXTYt48zBA7ni9cw=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+      "requires": {
+        "randombytes": "^2.1.0"
+      }
     },
     "serve-static": {
       "version": "1.14.1",
@@ -7519,6 +9513,17 @@
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
+    "shelljs": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
+      "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
+    },
     "signal-exit": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
@@ -7539,6 +9544,12 @@
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
       }
+    },
+    "slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true
     },
     "slice-ansi": {
       "version": "2.1.0",
@@ -7726,6 +9737,1222 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
           "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
+        }
+      }
+    },
+    "solidity-coverage": {
+      "version": "0.7.10",
+      "resolved": "https://registry.npmjs.org/solidity-coverage/-/solidity-coverage-0.7.10.tgz",
+      "integrity": "sha512-F98rYoD3bscB9qIJJrqkk+o93GbOWTT54VgfO97PrcWAenOFIC1EI5DzGJSrMvmFFfr8fsMPR89on6JR0Xf/Ig==",
+      "dev": true,
+      "requires": {
+        "@solidity-parser/parser": "^0.7.0",
+        "@truffle/provider": "^0.1.17",
+        "chalk": "^2.4.2",
+        "death": "^1.1.0",
+        "detect-port": "^1.3.0",
+        "fs-extra": "^8.1.0",
+        "ganache-cli": "6.9.0",
+        "ghost-testrpc": "^0.0.2",
+        "global-modules": "^2.0.0",
+        "globby": "^10.0.1",
+        "jsonschema": "^1.2.4",
+        "lodash": "^4.17.15",
+        "node-emoji": "^1.10.0",
+        "pify": "^4.0.1",
+        "recursive-readdir": "^2.2.2",
+        "sc-istanbul": "^0.4.5",
+        "shelljs": "^0.8.3",
+        "web3": "1.2.6"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "12.12.62",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.62.tgz",
+          "integrity": "sha512-qAfo81CsD7yQIM9mVyh6B/U47li5g7cfpVQEDMfQeF8pSZVwzbhwU3crc0qG4DmpsebpJPR49AKOExQyJ05Cpg==",
+          "dev": true
+        },
+        "aes-js": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
+          "integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0=",
+          "dev": true
+        },
+        "bn.js": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+          "dev": true
+        },
+        "ethers": {
+          "version": "4.0.0-beta.3",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.0-beta.3.tgz",
+          "integrity": "sha512-YYPogooSknTwvHg3+Mv71gM/3Wcrx+ZpCzarBj3mqs9njjRkrOo2/eufzhHloOCo3JSoNI4TQJJ6yU5ABm3Uog==",
+          "dev": true,
+          "requires": {
+            "@types/node": "^10.3.2",
+            "aes-js": "3.0.0",
+            "bn.js": "^4.4.0",
+            "elliptic": "6.3.3",
+            "hash.js": "1.1.3",
+            "js-sha3": "0.5.7",
+            "scrypt-js": "2.0.3",
+            "setimmediate": "1.0.4",
+            "uuid": "2.0.1",
+            "xmlhttprequest": "1.8.0"
+          },
+          "dependencies": {
+            "@types/node": {
+              "version": "10.17.35",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.35.tgz",
+              "integrity": "sha512-gXx7jAWpMddu0f7a+L+txMplp3FnHl53OhQIF9puXKq3hDGY/GjH+MF04oWnV/adPSCrbtHumDCFwzq2VhltWA==",
+              "dev": true
+            },
+            "elliptic": {
+              "version": "6.3.3",
+              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
+              "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
+              "dev": true,
+              "requires": {
+                "bn.js": "^4.4.0",
+                "brorand": "^1.0.1",
+                "hash.js": "^1.0.0",
+                "inherits": "^2.0.1"
+              }
+            },
+            "setimmediate": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
+              "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48=",
+              "dev": true
+            }
+          }
+        },
+        "eventemitter3": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+          "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
+          "dev": true
+        },
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "ganache-cli": {
+          "version": "6.9.0",
+          "resolved": "https://registry.npmjs.org/ganache-cli/-/ganache-cli-6.9.0.tgz",
+          "integrity": "sha512-ZdL6kPrApXF/O+f6uU431OJcwxMk69H3KPDSHHrMP82ZvZRNpDHbR+rVv7XX/YUeoQ5q6nZ2AFiGiFAVn9pfzA==",
+          "dev": true,
+          "requires": {
+            "ethereumjs-util": "6.1.0",
+            "source-map-support": "0.5.12",
+            "yargs": "13.2.4"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "4.1.0",
+              "bundled": true,
+              "dev": true
+            },
+            "ansi-styles": {
+              "version": "3.2.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "color-convert": "^1.9.0"
+              }
+            },
+            "bindings": {
+              "version": "1.5.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "file-uri-to-path": "1.0.0"
+              }
+            },
+            "bip66": {
+              "version": "1.1.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "safe-buffer": "^5.0.1"
+              }
+            },
+            "bn.js": {
+              "version": "4.11.8",
+              "bundled": true,
+              "dev": true
+            },
+            "brorand": {
+              "version": "1.1.0",
+              "bundled": true,
+              "dev": true
+            },
+            "browserify-aes": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "buffer-xor": "^1.0.3",
+                "cipher-base": "^1.0.0",
+                "create-hash": "^1.1.0",
+                "evp_bytestokey": "^1.0.3",
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
+              }
+            },
+            "buffer-from": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true
+            },
+            "buffer-xor": {
+              "version": "1.0.3",
+              "bundled": true,
+              "dev": true
+            },
+            "camelcase": {
+              "version": "5.3.1",
+              "bundled": true,
+              "dev": true
+            },
+            "cipher-base": {
+              "version": "1.0.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
+              }
+            },
+            "cliui": {
+              "version": "5.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "string-width": "^3.1.0",
+                "strip-ansi": "^5.2.0",
+                "wrap-ansi": "^5.1.0"
+              }
+            },
+            "color-convert": {
+              "version": "1.9.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "color-name": "1.1.3"
+              }
+            },
+            "color-name": {
+              "version": "1.1.3",
+              "bundled": true,
+              "dev": true
+            },
+            "create-hash": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "cipher-base": "^1.0.1",
+                "inherits": "^2.0.1",
+                "md5.js": "^1.3.4",
+                "ripemd160": "^2.0.1",
+                "sha.js": "^2.4.0"
+              }
+            },
+            "create-hmac": {
+              "version": "1.1.7",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "cipher-base": "^1.0.3",
+                "create-hash": "^1.1.0",
+                "inherits": "^2.0.1",
+                "ripemd160": "^2.0.0",
+                "safe-buffer": "^5.0.1",
+                "sha.js": "^2.4.8"
+              }
+            },
+            "cross-spawn": {
+              "version": "6.0.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "nice-try": "^1.0.4",
+                "path-key": "^2.0.1",
+                "semver": "^5.5.0",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
+              }
+            },
+            "decamelize": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true
+            },
+            "drbg.js": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "browserify-aes": "^1.0.6",
+                "create-hash": "^1.1.2",
+                "create-hmac": "^1.1.4"
+              }
+            },
+            "elliptic": {
+              "version": "6.5.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "bn.js": "^4.4.0",
+                "brorand": "^1.0.1",
+                "hash.js": "^1.0.0",
+                "hmac-drbg": "^1.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.0"
+              }
+            },
+            "emoji-regex": {
+              "version": "7.0.3",
+              "bundled": true,
+              "dev": true
+            },
+            "end-of-stream": {
+              "version": "1.4.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "once": "^1.4.0"
+              }
+            },
+            "ethereumjs-util": {
+              "version": "6.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "bn.js": "^4.11.0",
+                "create-hash": "^1.1.2",
+                "ethjs-util": "0.1.6",
+                "keccak": "^1.0.2",
+                "rlp": "^2.0.0",
+                "safe-buffer": "^5.1.1",
+                "secp256k1": "^3.0.1"
+              }
+            },
+            "ethjs-util": {
+              "version": "0.1.6",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-hex-prefixed": "1.0.0",
+                "strip-hex-prefix": "1.0.0"
+              }
+            },
+            "evp_bytestokey": {
+              "version": "1.0.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "md5.js": "^1.3.4",
+                "safe-buffer": "^5.1.1"
+              }
+            },
+            "execa": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "cross-spawn": "^6.0.0",
+                "get-stream": "^4.0.0",
+                "is-stream": "^1.1.0",
+                "npm-run-path": "^2.0.0",
+                "p-finally": "^1.0.0",
+                "signal-exit": "^3.0.0",
+                "strip-eof": "^1.0.0"
+              }
+            },
+            "file-uri-to-path": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "find-up": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "locate-path": "^3.0.0"
+              }
+            },
+            "get-caller-file": {
+              "version": "2.0.5",
+              "bundled": true,
+              "dev": true
+            },
+            "get-stream": {
+              "version": "4.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "pump": "^3.0.0"
+              }
+            },
+            "hash-base": {
+              "version": "3.0.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
+              }
+            },
+            "hash.js": {
+              "version": "1.1.7",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "inherits": "^2.0.3",
+                "minimalistic-assert": "^1.0.1"
+              }
+            },
+            "hmac-drbg": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "hash.js": "^1.0.3",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.1"
+              }
+            },
+            "inherits": {
+              "version": "2.0.4",
+              "bundled": true,
+              "dev": true
+            },
+            "invert-kv": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "is-hex-prefixed": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "is-stream": {
+              "version": "1.1.0",
+              "bundled": true,
+              "dev": true
+            },
+            "isexe": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "keccak": {
+              "version": "1.4.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "bindings": "^1.2.1",
+                "inherits": "^2.0.3",
+                "nan": "^2.2.1",
+                "safe-buffer": "^5.1.0"
+              }
+            },
+            "lcid": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "invert-kv": "^2.0.0"
+              }
+            },
+            "locate-path": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "p-locate": "^3.0.0",
+                "path-exists": "^3.0.0"
+              }
+            },
+            "map-age-cleaner": {
+              "version": "0.1.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "p-defer": "^1.0.0"
+              }
+            },
+            "md5.js": {
+              "version": "1.3.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "hash-base": "^3.0.0",
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.1.2"
+              }
+            },
+            "mem": {
+              "version": "4.3.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "map-age-cleaner": "^0.1.1",
+                "mimic-fn": "^2.0.0",
+                "p-is-promise": "^2.0.0"
+              }
+            },
+            "mimic-fn": {
+              "version": "2.1.0",
+              "bundled": true,
+              "dev": true
+            },
+            "minimalistic-assert": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "minimalistic-crypto-utils": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "nan": {
+              "version": "2.14.0",
+              "bundled": true,
+              "dev": true
+            },
+            "nice-try": {
+              "version": "1.0.5",
+              "bundled": true,
+              "dev": true
+            },
+            "npm-run-path": {
+              "version": "2.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "path-key": "^2.0.0"
+              }
+            },
+            "once": {
+              "version": "1.4.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "wrappy": "1"
+              }
+            },
+            "os-locale": {
+              "version": "3.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "execa": "^1.0.0",
+                "lcid": "^2.0.0",
+                "mem": "^4.0.0"
+              }
+            },
+            "p-defer": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "p-finally": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "p-is-promise": {
+              "version": "2.1.0",
+              "bundled": true,
+              "dev": true
+            },
+            "p-limit": {
+              "version": "2.2.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "p-try": "^2.0.0"
+              }
+            },
+            "p-locate": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "p-limit": "^2.0.0"
+              }
+            },
+            "p-try": {
+              "version": "2.2.0",
+              "bundled": true,
+              "dev": true
+            },
+            "path-exists": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "path-key": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "pump": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+              }
+            },
+            "require-directory": {
+              "version": "2.1.1",
+              "bundled": true,
+              "dev": true
+            },
+            "require-main-filename": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "ripemd160": {
+              "version": "2.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "hash-base": "^3.0.0",
+                "inherits": "^2.0.1"
+              }
+            },
+            "rlp": {
+              "version": "2.2.3",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "bn.js": "^4.11.1",
+                "safe-buffer": "^5.1.1"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.2.0",
+              "bundled": true,
+              "dev": true
+            },
+            "secp256k1": {
+              "version": "3.7.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "bindings": "^1.5.0",
+                "bip66": "^1.1.5",
+                "bn.js": "^4.11.8",
+                "create-hash": "^1.2.0",
+                "drbg.js": "^1.0.1",
+                "elliptic": "^6.4.1",
+                "nan": "^2.14.0",
+                "safe-buffer": "^5.1.2"
+              }
+            },
+            "semver": {
+              "version": "5.7.0",
+              "bundled": true,
+              "dev": true
+            },
+            "set-blocking": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "sha.js": {
+              "version": "2.4.11",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
+              }
+            },
+            "shebang-command": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "shebang-regex": "^1.0.0"
+              }
+            },
+            "shebang-regex": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "signal-exit": {
+              "version": "3.0.2",
+              "bundled": true,
+              "dev": true
+            },
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true,
+              "dev": true
+            },
+            "source-map-support": {
+              "version": "0.5.12",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
+              }
+            },
+            "string-width": {
+              "version": "3.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "emoji-regex": "^7.0.1",
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^5.1.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "5.2.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^4.1.0"
+              }
+            },
+            "strip-eof": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "strip-hex-prefix": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-hex-prefixed": "1.0.0"
+              }
+            },
+            "which": {
+              "version": "1.3.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "isexe": "^2.0.0"
+              }
+            },
+            "which-module": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "wrap-ansi": {
+              "version": "5.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^3.2.0",
+                "string-width": "^3.0.0",
+                "strip-ansi": "^5.0.0"
+              }
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true
+            },
+            "y18n": {
+              "version": "4.0.0",
+              "bundled": true,
+              "dev": true
+            },
+            "yargs": {
+              "version": "13.2.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "cliui": "^5.0.0",
+                "find-up": "^3.0.0",
+                "get-caller-file": "^2.0.1",
+                "os-locale": "^3.1.0",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^2.0.0",
+                "set-blocking": "^2.0.0",
+                "string-width": "^3.0.0",
+                "which-module": "^2.0.0",
+                "y18n": "^4.0.0",
+                "yargs-parser": "^13.1.0"
+              }
+            },
+            "yargs-parser": {
+              "version": "13.1.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "camelcase": "^5.0.0",
+                "decamelize": "^1.2.0"
+              }
+            }
+          }
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "dev": true
+        },
+        "hash.js": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
+        "js-sha3": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=",
+          "dev": true
+        },
+        "p-cancelable": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
+          "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw==",
+          "dev": true
+        },
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "dev": true
+        },
+        "prepend-http": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+          "dev": true
+        },
+        "scrypt-js": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
+          "integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q=",
+          "dev": true
+        },
+        "swarm-js": {
+          "version": "0.1.39",
+          "resolved": "https://registry.npmjs.org/swarm-js/-/swarm-js-0.1.39.tgz",
+          "integrity": "sha512-QLMqL2rzF6n5s50BptyD6Oi0R1aWlJC5Y17SRIVXRj6OR1DRIPM7nepvrxxkjA1zNzFz6mUOMjfeqeDaWB7OOg==",
+          "dev": true,
+          "requires": {
+            "bluebird": "^3.5.0",
+            "buffer": "^5.0.5",
+            "decompress": "^4.0.0",
+            "eth-lib": "^0.1.26",
+            "fs-extra": "^4.0.2",
+            "got": "^7.1.0",
+            "mime-types": "^2.1.16",
+            "mkdirp-promise": "^5.0.1",
+            "mock-fs": "^4.1.0",
+            "setimmediate": "^1.0.5",
+            "tar": "^4.0.2",
+            "xhr-request-promise": "^0.1.2"
+          },
+          "dependencies": {
+            "fs-extra": {
+              "version": "4.0.3",
+              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+              "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+              "dev": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
+              }
+            },
+            "got": {
+              "version": "7.1.0",
+              "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
+              "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
+              "dev": true,
+              "requires": {
+                "decompress-response": "^3.2.0",
+                "duplexer3": "^0.1.4",
+                "get-stream": "^3.0.0",
+                "is-plain-obj": "^1.1.0",
+                "is-retry-allowed": "^1.0.0",
+                "is-stream": "^1.0.0",
+                "isurl": "^1.0.0-alpha5",
+                "lowercase-keys": "^1.0.0",
+                "p-cancelable": "^0.3.0",
+                "p-timeout": "^1.1.1",
+                "safe-buffer": "^5.0.1",
+                "timed-out": "^4.0.0",
+                "url-parse-lax": "^1.0.0",
+                "url-to-options": "^1.0.1"
+              }
+            }
+          }
+        },
+        "url-parse-lax": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+          "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+          "dev": true,
+          "requires": {
+            "prepend-http": "^1.0.1"
+          }
+        },
+        "uuid": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
+          "dev": true
+        },
+        "web3": {
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/web3/-/web3-1.2.6.tgz",
+          "integrity": "sha512-tpu9fLIComgxGrFsD8LUtA4s4aCZk7px8UfcdEy6kS2uDi/ZfR07KJqpXZMij7Jvlq+cQrTAhsPSiBVvoMaivA==",
+          "dev": true,
+          "requires": {
+            "@types/node": "^12.6.1",
+            "web3-bzz": "1.2.6",
+            "web3-core": "1.2.6",
+            "web3-eth": "1.2.6",
+            "web3-eth-personal": "1.2.6",
+            "web3-net": "1.2.6",
+            "web3-shh": "1.2.6",
+            "web3-utils": "1.2.6"
+          }
+        },
+        "web3-bzz": {
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.2.6.tgz",
+          "integrity": "sha512-9NiHLlxdI1XeFtbPJAmi2jnnIHVF+GNy517wvOS72P7ZfuJTPwZaSNXfT01vWgPPE9R96/uAHDWHOg+T4WaDQQ==",
+          "dev": true,
+          "requires": {
+            "@types/node": "^10.12.18",
+            "got": "9.6.0",
+            "swarm-js": "0.1.39",
+            "underscore": "1.9.1"
+          },
+          "dependencies": {
+            "@types/node": {
+              "version": "10.17.35",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.35.tgz",
+              "integrity": "sha512-gXx7jAWpMddu0f7a+L+txMplp3FnHl53OhQIF9puXKq3hDGY/GjH+MF04oWnV/adPSCrbtHumDCFwzq2VhltWA==",
+              "dev": true
+            }
+          }
+        },
+        "web3-core": {
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.6.tgz",
+          "integrity": "sha512-y/QNBFtr5cIR8vxebnotbjWJpOnO8LDYEAzZjeRRUJh2ijmhjoYk7dSNx9ExgC0UCfNFRoNCa9dGRu/GAxwRlw==",
+          "dev": true,
+          "requires": {
+            "@types/bn.js": "^4.11.4",
+            "@types/node": "^12.6.1",
+            "web3-core-helpers": "1.2.6",
+            "web3-core-method": "1.2.6",
+            "web3-core-requestmanager": "1.2.6",
+            "web3-utils": "1.2.6"
+          }
+        },
+        "web3-core-helpers": {
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.6.tgz",
+          "integrity": "sha512-gYKWmC2HmO7RcDzpo4L1K8EIoy5L8iubNDuTC6q69UxczwqKF/Io0kbK/1Z10Av++NlzOSiuyGp2gc4t4UOsDw==",
+          "dev": true,
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-eth-iban": "1.2.6",
+            "web3-utils": "1.2.6"
+          }
+        },
+        "web3-core-method": {
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.6.tgz",
+          "integrity": "sha512-r2dzyPEonqkBg7Mugq5dknhV5PGaZTHBZlS/C+aMxNyQs3T3eaAsCTqlQDitwNUh/sUcYPEGF0Vo7ahYK4k91g==",
+          "dev": true,
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.6",
+            "web3-core-promievent": "1.2.6",
+            "web3-core-subscriptions": "1.2.6",
+            "web3-utils": "1.2.6"
+          }
+        },
+        "web3-core-promievent": {
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.6.tgz",
+          "integrity": "sha512-km72kJef/qtQNiSjDJJVHIZvoVOm6ytW3FCYnOcCs7RIkviAb5JYlPiye0o4pJOLzCXYID7DK7Q9bhY8qWb1lw==",
+          "dev": true,
+          "requires": {
+            "any-promise": "1.3.0",
+            "eventemitter3": "3.1.2"
+          }
+        },
+        "web3-core-requestmanager": {
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.6.tgz",
+          "integrity": "sha512-QU2cbsj9Dm0r6om40oSwk8Oqbp3wTa08tXuMpSmeOTkGZ3EMHJ1/4LiJ8shwg1AvPMrKVU0Nri6+uBNCdReZ+g==",
+          "dev": true,
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.6",
+            "web3-providers-http": "1.2.6",
+            "web3-providers-ipc": "1.2.6",
+            "web3-providers-ws": "1.2.6"
+          }
+        },
+        "web3-core-subscriptions": {
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.6.tgz",
+          "integrity": "sha512-M0PzRrP2Ct13x3wPulFtc5kENH4UtnPxO9YxkfQlX2WRKENWjt4Rfq+BCVGYEk3rTutDfWrjfzjmqMRvXqEY5Q==",
+          "dev": true,
+          "requires": {
+            "eventemitter3": "3.1.2",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.6"
+          }
+        },
+        "web3-eth": {
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.2.6.tgz",
+          "integrity": "sha512-ROWlDPzh4QX6tlGGGlAK6X4kA2n0/cNj/4kb0nNVWkRouGmYO0R8k6s47YxYHvGiXt0s0++FUUv5vAbWovtUQw==",
+          "dev": true,
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core": "1.2.6",
+            "web3-core-helpers": "1.2.6",
+            "web3-core-method": "1.2.6",
+            "web3-core-subscriptions": "1.2.6",
+            "web3-eth-abi": "1.2.6",
+            "web3-eth-accounts": "1.2.6",
+            "web3-eth-contract": "1.2.6",
+            "web3-eth-ens": "1.2.6",
+            "web3-eth-iban": "1.2.6",
+            "web3-eth-personal": "1.2.6",
+            "web3-net": "1.2.6",
+            "web3-utils": "1.2.6"
+          }
+        },
+        "web3-eth-abi": {
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.6.tgz",
+          "integrity": "sha512-w9GAyyikn8nSifSDZxAvU9fxtQSX+W2xQWMmrtTXmBGCaE4/ywKOSPAO78gq8AoU4Wq5yqVGKZLLbfpt7/sHlA==",
+          "dev": true,
+          "requires": {
+            "ethers": "4.0.0-beta.3",
+            "underscore": "1.9.1",
+            "web3-utils": "1.2.6"
+          }
+        },
+        "web3-eth-accounts": {
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.2.6.tgz",
+          "integrity": "sha512-cDVtonHRgzqi/ZHOOf8kfCQWFEipcfQNAMzXIaKZwc0UUD9mgSI5oJrN45a89Ze+E6Lz9m77cDG5Ax9zscSkcw==",
+          "dev": true,
+          "requires": {
+            "@web3-js/scrypt-shim": "^0.1.0",
+            "any-promise": "1.3.0",
+            "crypto-browserify": "3.12.0",
+            "eth-lib": "^0.2.8",
+            "ethereumjs-common": "^1.3.2",
+            "ethereumjs-tx": "^2.1.1",
+            "underscore": "1.9.1",
+            "uuid": "3.3.2",
+            "web3-core": "1.2.6",
+            "web3-core-helpers": "1.2.6",
+            "web3-core-method": "1.2.6",
+            "web3-utils": "1.2.6"
+          },
+          "dependencies": {
+            "eth-lib": {
+              "version": "0.2.8",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+              "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+              "dev": true,
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            },
+            "uuid": {
+              "version": "3.3.2",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+              "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+              "dev": true
+            }
+          }
+        },
+        "web3-eth-contract": {
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.6.tgz",
+          "integrity": "sha512-ak4xbHIhWgsbdPCkSN+HnQc1SH4c856y7Ly+S57J/DQVzhFZemK5HvWdpwadJrQTcHET3ZeId1vq3kmW7UYodw==",
+          "dev": true,
+          "requires": {
+            "@types/bn.js": "^4.11.4",
+            "underscore": "1.9.1",
+            "web3-core": "1.2.6",
+            "web3-core-helpers": "1.2.6",
+            "web3-core-method": "1.2.6",
+            "web3-core-promievent": "1.2.6",
+            "web3-core-subscriptions": "1.2.6",
+            "web3-eth-abi": "1.2.6",
+            "web3-utils": "1.2.6"
+          }
+        },
+        "web3-eth-ens": {
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.2.6.tgz",
+          "integrity": "sha512-8UEqt6fqR/dji/jBGPFAyBs16OJjwi0t2dPWXPyGXmty/fH+osnXwWXE4HRUyj4xuafiM5P1YkXMsPhKEadjiw==",
+          "dev": true,
+          "requires": {
+            "eth-ens-namehash": "2.0.8",
+            "underscore": "1.9.1",
+            "web3-core": "1.2.6",
+            "web3-core-helpers": "1.2.6",
+            "web3-core-promievent": "1.2.6",
+            "web3-eth-abi": "1.2.6",
+            "web3-eth-contract": "1.2.6",
+            "web3-utils": "1.2.6"
+          }
+        },
+        "web3-eth-iban": {
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.6.tgz",
+          "integrity": "sha512-TPMc3BW9Iso7H+9w+ytbqHK9wgOmtocyCD3PaAe5Eie50KQ/j7ThA60dGJnxItVo6yyRv5pZAYxPVob9x/fJlg==",
+          "dev": true,
+          "requires": {
+            "bn.js": "4.11.8",
+            "web3-utils": "1.2.6"
+          }
+        },
+        "web3-eth-personal": {
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.6.tgz",
+          "integrity": "sha512-T2NUkh1plY8d7wePXSoHnaiKOd8dLNFaQfgBl9JHU6S7IJrG9jnYD9bVxLEgRUfHs9gKf9tQpDf7AcPFdq/A8g==",
+          "dev": true,
+          "requires": {
+            "@types/node": "^12.6.1",
+            "web3-core": "1.2.6",
+            "web3-core-helpers": "1.2.6",
+            "web3-core-method": "1.2.6",
+            "web3-net": "1.2.6",
+            "web3-utils": "1.2.6"
+          }
+        },
+        "web3-net": {
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.6.tgz",
+          "integrity": "sha512-hsNHAPddrhgjWLmbESW0KxJi2GnthPcow0Sqpnf4oB6+/+ZnQHU9OsIyHb83bnC1OmunrK2vf9Ye2mLPdFIu3A==",
+          "dev": true,
+          "requires": {
+            "web3-core": "1.2.6",
+            "web3-core-method": "1.2.6",
+            "web3-utils": "1.2.6"
+          }
+        },
+        "web3-providers-http": {
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.6.tgz",
+          "integrity": "sha512-2+SaFCspb5f82QKuHB3nEPQOF9iSWxRf7c18fHtmnLNVkfG9SwLN1zh67bYn3tZGUdOI3gj8aX4Uhfpwx9Ezpw==",
+          "dev": true,
+          "requires": {
+            "web3-core-helpers": "1.2.6",
+            "xhr2-cookies": "1.1.0"
+          }
+        },
+        "web3-providers-ipc": {
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.6.tgz",
+          "integrity": "sha512-b0Es+/GTZyk5FG3SgUDW+2/mBwJAXWt5LuppODptiOas8bB2khLjG6+Gm1K4uwOb+1NJGPt5mZZ8Wi7vibtQ+A==",
+          "dev": true,
+          "requires": {
+            "oboe": "2.1.4",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.6"
+          }
+        },
+        "web3-providers-ws": {
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.6.tgz",
+          "integrity": "sha512-20waSYX+gb5M5yKhug5FIwxBBvkKzlJH7sK6XEgdOx6BZ9YYamLmvg9wcRVtnSZO8hV/3cWenO/tRtTrHVvIgQ==",
+          "dev": true,
+          "requires": {
+            "@web3-js/websocket": "^1.0.29",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.6"
+          }
+        },
+        "web3-shh": {
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.2.6.tgz",
+          "integrity": "sha512-rouWyOOM6YMbLQd65grpj8BBezQfgNeRRX+cGyW4xsn6Xgu+B73Zvr6OtA/ftJwwa9bqHGpnLrrLMeWyy4YLUw==",
+          "dev": true,
+          "requires": {
+            "web3-core": "1.2.6",
+            "web3-core-method": "1.2.6",
+            "web3-core-subscriptions": "1.2.6",
+            "web3-net": "1.2.6"
+          }
+        },
+        "web3-utils": {
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.6.tgz",
+          "integrity": "sha512-8/HnqG/l7dGmKMgEL9JeKPTtjScxOePTzopv5aaKFExPfaBrYRkgoMqhoowCiAl/s16QaTn4DoIF1QC4YsT7Mg==",
+          "dev": true,
+          "requires": {
+            "bn.js": "4.11.8",
+            "eth-lib": "0.2.7",
+            "ethereum-bloom-filters": "^1.0.6",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randombytes": "^2.1.0",
+            "underscore": "1.9.1",
+            "utf8": "3.0.0"
+          },
+          "dependencies": {
+            "eth-lib": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "dev": true,
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            }
+          }
         }
       }
     },
@@ -8594,6 +11821,15 @@
         "ansi-regex": "^3.0.0"
       }
     },
+    "strip-dirs": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
+      "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
+      "dev": true,
+      "requires": {
+        "is-natural-number": "^4.0.1"
+      }
+    },
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
@@ -8776,6 +12012,21 @@
         }
       }
     },
+    "tar-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
+      "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
+      "dev": true,
+      "requires": {
+        "bl": "^1.0.0",
+        "buffer-alloc": "^1.2.0",
+        "end-of-stream": "^1.0.0",
+        "fs-constants": "^1.0.0",
+        "readable-stream": "^2.3.0",
+        "to-buffer": "^1.1.1",
+        "xtend": "^4.0.0"
+      }
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -8828,6 +12079,12 @@
       "requires": {
         "os-tmpdir": "~1.0.2"
       }
+    },
+    "to-buffer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
+      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
+      "dev": true
     },
     "to-fast-properties": {
       "version": "2.0.0",
@@ -8883,32 +12140,32 @@
       }
     },
     "truffle": {
-      "version": "5.1.41",
-      "resolved": "https://registry.npmjs.org/truffle/-/truffle-5.1.41.tgz",
-      "integrity": "sha512-6vphA82Os7HvrzqkMy0o2kxP0SYsf7glHE8U8jk15lbUNOy76SrBLmTi7at7xFkIq6LMgv03YRf0EFEN/qwAxg==",
+      "version": "5.1.46",
+      "resolved": "https://registry.npmjs.org/truffle/-/truffle-5.1.46.tgz",
+      "integrity": "sha512-lhd8pfO5bOIwmiZf0+RyLcdWtrmeoA9JkdH9o0uQxZabisa6IxfoACRBpBez3r3w+LGPnl9/K1stE3Z9aBNK0A==",
       "requires": {
         "app-module-path": "^2.2.0",
-        "mocha": "8.0.1",
+        "mocha": "8.1.2",
         "original-require": "1.0.1"
       }
     },
     "truffle-flattener": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/truffle-flattener/-/truffle-flattener-1.4.4.tgz",
-      "integrity": "sha512-S/WmvubzlUj1mn56wEI6yo1bmPpKDNdEe5rtyVC1C5iNfZWobD/V69pAYI15IBDJrDqUyh+iXgpTkzov50zpQw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/truffle-flattener/-/truffle-flattener-1.5.0.tgz",
+      "integrity": "sha512-vmzWG/L5OXoNruMV6u2l2IaheI091e+t+fFCOR9sl46EE3epkSRIwGCmIP/EYDtPsFBIG7e6exttC9/GlfmxEQ==",
       "dev": true,
       "requires": {
         "@resolver-engine/imports-fs": "^0.2.2",
-        "@solidity-parser/parser": "^0.6.0",
+        "@solidity-parser/parser": "^0.8.0",
         "find-up": "^2.1.0",
         "mkdirp": "^1.0.4",
         "tsort": "0.0.1"
       },
       "dependencies": {
         "@solidity-parser/parser": {
-          "version": "0.6.2",
-          "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.6.2.tgz",
-          "integrity": "sha512-kUVUvrqttndeprLoXjI5arWHeiP3uh4XODAKbG+ZaWHCVQeelxCbnXBeWxZ2BPHdXgH0xR9dU1b916JhDhbgAA==",
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.8.1.tgz",
+          "integrity": "sha512-DF7H6T8I4lo2IZOE2NZwt3631T8j1gjpQLjmvY2xBNK50c4ltslR4XPKwT6RkeSd4+xCAK0GHC/k7sbRDBE4Yw==",
           "dev": true
         },
         "find-up": {
@@ -9030,10 +12287,27 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "uglify-js": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.11.0.tgz",
+      "integrity": "sha512-e1KQFRCpOxnrJsJVqDUCjURq+wXvIn7cK2sRAx9XL3HYLL9aezOP4Pb1+Y3/o693EPk111Yj2Q+IUXxcpHlygQ==",
+      "dev": true,
+      "optional": true
+    },
     "ultron": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
       "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
+    },
+    "unbzip2-stream": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+      "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.2.1",
+        "through": "^2.3.8"
+      }
     },
     "underscore": {
       "version": "1.9.1",
@@ -9152,6 +12426,21 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
     },
+    "utf-8-validate": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.2.tgz",
+      "integrity": "sha512-SwV++i2gTD5qh2XqaPzBnNX88N6HdyhQrNNRykvcS0QKvItV9u3vPEJr+X5Hhfb1JC0r0e1alL0iB09rY8+nmw==",
+      "requires": {
+        "node-gyp-build": "~3.7.0"
+      },
+      "dependencies": {
+        "node-gyp-build": {
+          "version": "3.7.0",
+          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.7.0.tgz",
+          "integrity": "sha512-L/Eg02Epx6Si2NXmedx+Okg+4UHqmaf3TNcxd50SF9NQGcJaON3AtU++kax69XV7YWz4tUspqZSAsVofhFKG2w=="
+        }
+      }
+    },
     "utf8": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
@@ -9179,9 +12468,9 @@
       "dev": true
     },
     "varint": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.0.tgz",
-      "integrity": "sha1-2Ca4n3SQcy+rwMDtaT7Uddyynr8="
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
+      "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
     },
     "vary": {
       "version": "1.1.2",
@@ -9203,23 +12492,23 @@
       "from": "git://github.com/gwicke/web-streams-polyfill.git#spec_performance_improvements"
     },
     "web3": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3/-/web3-1.2.11.tgz",
-      "integrity": "sha512-mjQ8HeU41G6hgOYm1pmeH0mRAeNKJGnJEUzDMoerkpw7QUQT4exVREgF1MYPvL/z6vAshOXei25LE/t/Bxl8yQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/web3/-/web3-1.3.0.tgz",
+      "integrity": "sha512-4q9dna0RecnrlgD/bD1C5S+81Untbd6Z/TBD7rb+D5Bvvc0Wxjr4OP70x+LlnwuRDjDtzBwJbNUblh2grlVArw==",
       "requires": {
-        "web3-bzz": "1.2.11",
-        "web3-core": "1.2.11",
-        "web3-eth": "1.2.11",
-        "web3-eth-personal": "1.2.11",
-        "web3-net": "1.2.11",
-        "web3-shh": "1.2.11",
-        "web3-utils": "1.2.11"
+        "web3-bzz": "1.3.0",
+        "web3-core": "1.3.0",
+        "web3-eth": "1.3.0",
+        "web3-eth-personal": "1.3.0",
+        "web3-net": "1.3.0",
+        "web3-shh": "1.3.0",
+        "web3-utils": "1.3.0"
       }
     },
     "web3-bzz": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.2.11.tgz",
-      "integrity": "sha512-XGpWUEElGypBjeFyUhTkiPXFbDVD6Nr/S5jznE3t8cWUA0FxRf1n3n/NuIZeb0H9RkN2Ctd/jNma/k8XGa3YKg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.3.0.tgz",
+      "integrity": "sha512-ibYAnKab+sgTo/UdfbrvYfWblXjjgSMgyy9/FHa6WXS14n/HVB+HfWqGz2EM3fok8Wy5XoKGMvdqvERQ/mzq1w==",
       "requires": {
         "@types/node": "^12.12.6",
         "got": "9.6.0",
@@ -9228,120 +12517,120 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.12.54",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.54.tgz",
-          "integrity": "sha512-ge4xZ3vSBornVYlDnk7yZ0gK6ChHf/CHB7Gl1I0Jhah8DDnEQqBzgohYG4FX4p81TNirSETOiSyn+y1r9/IR6w=="
+          "version": "12.12.62",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.62.tgz",
+          "integrity": "sha512-qAfo81CsD7yQIM9mVyh6B/U47li5g7cfpVQEDMfQeF8pSZVwzbhwU3crc0qG4DmpsebpJPR49AKOExQyJ05Cpg=="
         }
       }
     },
     "web3-core": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.11.tgz",
-      "integrity": "sha512-CN7MEYOY5ryo5iVleIWRE3a3cZqVaLlIbIzDPsvQRUfzYnvzZQRZBm9Mq+ttDi2STOOzc1MKylspz/o3yq/LjQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.3.0.tgz",
+      "integrity": "sha512-BwWvAaKJf4KFG9QsKRi3MNoNgzjI6szyUlgme1qNPxUdCkaS3Rdpa0VKYNHP7M/YTk82/59kNE66mH5vmoaXjA==",
       "requires": {
         "@types/bn.js": "^4.11.5",
         "@types/node": "^12.12.6",
         "bignumber.js": "^9.0.0",
-        "web3-core-helpers": "1.2.11",
-        "web3-core-method": "1.2.11",
-        "web3-core-requestmanager": "1.2.11",
-        "web3-utils": "1.2.11"
+        "web3-core-helpers": "1.3.0",
+        "web3-core-method": "1.3.0",
+        "web3-core-requestmanager": "1.3.0",
+        "web3-utils": "1.3.0"
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.12.54",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.54.tgz",
-          "integrity": "sha512-ge4xZ3vSBornVYlDnk7yZ0gK6ChHf/CHB7Gl1I0Jhah8DDnEQqBzgohYG4FX4p81TNirSETOiSyn+y1r9/IR6w=="
+          "version": "12.12.62",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.62.tgz",
+          "integrity": "sha512-qAfo81CsD7yQIM9mVyh6B/U47li5g7cfpVQEDMfQeF8pSZVwzbhwU3crc0qG4DmpsebpJPR49AKOExQyJ05Cpg=="
         }
       }
     },
     "web3-core-helpers": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.11.tgz",
-      "integrity": "sha512-PEPoAoZd5ME7UfbnCZBdzIerpe74GEvlwT4AjOmHeCVZoIFk7EqvOZDejJHt+feJA6kMVTdd0xzRNN295UhC1A==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.3.0.tgz",
+      "integrity": "sha512-+MFb1kZCrRctf7UYE7NCG4rGhSXaQJ/KF07di9GVK1pxy1K0+rFi61ZobuV1ky9uQp+uhhSPts4Zp55kRDB5sw==",
       "requires": {
         "underscore": "1.9.1",
-        "web3-eth-iban": "1.2.11",
-        "web3-utils": "1.2.11"
+        "web3-eth-iban": "1.3.0",
+        "web3-utils": "1.3.0"
       }
     },
     "web3-core-method": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.11.tgz",
-      "integrity": "sha512-ff0q76Cde94HAxLDZ6DbdmKniYCQVtvuaYh+rtOUMB6kssa5FX0q3vPmixi7NPooFnbKmmZCM6NvXg4IreTPIw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.3.0.tgz",
+      "integrity": "sha512-h0yFDrYVzy5WkLxC/C3q+hiMnzxdWm9p1T1rslnuHgOp6nYfqzu/6mUIXrsS4h/OWiGJt+BZ0xVZmtC31HDWtg==",
       "requires": {
         "@ethersproject/transactions": "^5.0.0-beta.135",
         "underscore": "1.9.1",
-        "web3-core-helpers": "1.2.11",
-        "web3-core-promievent": "1.2.11",
-        "web3-core-subscriptions": "1.2.11",
-        "web3-utils": "1.2.11"
+        "web3-core-helpers": "1.3.0",
+        "web3-core-promievent": "1.3.0",
+        "web3-core-subscriptions": "1.3.0",
+        "web3-utils": "1.3.0"
       }
     },
     "web3-core-promievent": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.11.tgz",
-      "integrity": "sha512-il4McoDa/Ox9Agh4kyfQ8Ak/9ABYpnF8poBLL33R/EnxLsJOGQG2nZhkJa3I067hocrPSjEdlPt/0bHXsln4qA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.3.0.tgz",
+      "integrity": "sha512-blv69wrXw447TP3iPvYJpllkhW6B18nfuEbrfcr3n2Y0v1Jx8VJacNZFDFsFIcgXcgUIVCtOpimU7w9v4+rtaw==",
       "requires": {
         "eventemitter3": "4.0.4"
       }
     },
     "web3-core-requestmanager": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.11.tgz",
-      "integrity": "sha512-oFhBtLfOiIbmfl6T6gYjjj9igOvtyxJ+fjS+byRxiwFJyJ5BQOz4/9/17gWR1Cq74paTlI7vDGxYfuvfE/mKvA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.3.0.tgz",
+      "integrity": "sha512-3yMbuGcomtzlmvTVqNRydxsx7oPlw3ioRL6ReF9PeNYDkUsZaUib+6Dp5eBt7UXh5X+SIn/xa1smhDHz5/HpAw==",
       "requires": {
         "underscore": "1.9.1",
-        "web3-core-helpers": "1.2.11",
-        "web3-providers-http": "1.2.11",
-        "web3-providers-ipc": "1.2.11",
-        "web3-providers-ws": "1.2.11"
+        "web3-core-helpers": "1.3.0",
+        "web3-providers-http": "1.3.0",
+        "web3-providers-ipc": "1.3.0",
+        "web3-providers-ws": "1.3.0"
       }
     },
     "web3-core-subscriptions": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.11.tgz",
-      "integrity": "sha512-qEF/OVqkCvQ7MPs1JylIZCZkin0aKK9lDxpAtQ1F8niEDGFqn7DT8E/vzbIa0GsOjL2fZjDhWJsaW+BSoAW1gg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.3.0.tgz",
+      "integrity": "sha512-MUUQUAhJDb+Nz3S97ExVWveH4utoUnsbPWP+q1HJH437hEGb4vunIb9KvN3hFHLB+aHJfPeStM/4yYTz5PeuyQ==",
       "requires": {
         "eventemitter3": "4.0.4",
         "underscore": "1.9.1",
-        "web3-core-helpers": "1.2.11"
+        "web3-core-helpers": "1.3.0"
       }
     },
     "web3-eth": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.2.11.tgz",
-      "integrity": "sha512-REvxW1wJ58AgHPcXPJOL49d1K/dPmuw4LjPLBPStOVkQjzDTVmJEIsiLwn2YeuNDd4pfakBwT8L3bz1G1/wVsQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.3.0.tgz",
+      "integrity": "sha512-/bzJcxXPM9EM18JM5kO2JjZ3nEqVo3HxqU93aWAEgJNqaP/Lltmufl2GpvIB2Hvj+FXAjAXquxUdQ2/xP7BzHQ==",
       "requires": {
         "underscore": "1.9.1",
-        "web3-core": "1.2.11",
-        "web3-core-helpers": "1.2.11",
-        "web3-core-method": "1.2.11",
-        "web3-core-subscriptions": "1.2.11",
-        "web3-eth-abi": "1.2.11",
-        "web3-eth-accounts": "1.2.11",
-        "web3-eth-contract": "1.2.11",
-        "web3-eth-ens": "1.2.11",
-        "web3-eth-iban": "1.2.11",
-        "web3-eth-personal": "1.2.11",
-        "web3-net": "1.2.11",
-        "web3-utils": "1.2.11"
+        "web3-core": "1.3.0",
+        "web3-core-helpers": "1.3.0",
+        "web3-core-method": "1.3.0",
+        "web3-core-subscriptions": "1.3.0",
+        "web3-eth-abi": "1.3.0",
+        "web3-eth-accounts": "1.3.0",
+        "web3-eth-contract": "1.3.0",
+        "web3-eth-ens": "1.3.0",
+        "web3-eth-iban": "1.3.0",
+        "web3-eth-personal": "1.3.0",
+        "web3-net": "1.3.0",
+        "web3-utils": "1.3.0"
       }
     },
     "web3-eth-abi": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.11.tgz",
-      "integrity": "sha512-PkRYc0+MjuLSgg03QVWqWlQivJqRwKItKtEpRUaxUAeLE7i/uU39gmzm2keHGcQXo3POXAbOnMqkDvOep89Crg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.3.0.tgz",
+      "integrity": "sha512-1OrZ9+KGrBeBRd3lO8upkpNua9+7cBsQAgor9wbA25UrcUYSyL8teV66JNRu9gFxaTbkpdrGqM7J/LXpraXWrg==",
       "requires": {
         "@ethersproject/abi": "5.0.0-beta.153",
         "underscore": "1.9.1",
-        "web3-utils": "1.2.11"
+        "web3-utils": "1.3.0"
       }
     },
     "web3-eth-accounts": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.2.11.tgz",
-      "integrity": "sha512-6FwPqEpCfKIh3nSSGeo3uBm2iFSnFJDfwL3oS9pyegRBXNsGRVpgiW63yhNzL0796StsvjHWwQnQHsZNxWAkGw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.3.0.tgz",
+      "integrity": "sha512-/Q7EVW4L2wWUbNRtOTwAIrYvJid/5UnKMw67x/JpvRMwYC+e+744P536Ja6SG4X3MnzFvd3E/jruV4qa6k+zIw==",
       "requires": {
         "crypto-browserify": "3.12.0",
         "eth-lib": "0.2.8",
@@ -9350,10 +12639,10 @@
         "scrypt-js": "^3.0.1",
         "underscore": "1.9.1",
         "uuid": "3.3.2",
-        "web3-core": "1.2.11",
-        "web3-core-helpers": "1.2.11",
-        "web3-core-method": "1.2.11",
-        "web3-utils": "1.2.11"
+        "web3-core": "1.3.0",
+        "web3-core-helpers": "1.3.0",
+        "web3-core-method": "1.3.0",
+        "web3-utils": "1.3.0"
       },
       "dependencies": {
         "eth-lib": {
@@ -9374,121 +12663,131 @@
       }
     },
     "web3-eth-contract": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.11.tgz",
-      "integrity": "sha512-MzYuI/Rq2o6gn7vCGcnQgco63isPNK5lMAan2E51AJLknjSLnOxwNY3gM8BcKoy4Z+v5Dv00a03Xuk78JowFow==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.3.0.tgz",
+      "integrity": "sha512-3SCge4SRNCnzLxf0R+sXk6vyTOl05g80Z5+9/B5pERwtPpPWaQGw8w01vqYqsYBKC7zH+dxhMaUgVzU2Dgf7bQ==",
       "requires": {
         "@types/bn.js": "^4.11.5",
         "underscore": "1.9.1",
-        "web3-core": "1.2.11",
-        "web3-core-helpers": "1.2.11",
-        "web3-core-method": "1.2.11",
-        "web3-core-promievent": "1.2.11",
-        "web3-core-subscriptions": "1.2.11",
-        "web3-eth-abi": "1.2.11",
-        "web3-utils": "1.2.11"
+        "web3-core": "1.3.0",
+        "web3-core-helpers": "1.3.0",
+        "web3-core-method": "1.3.0",
+        "web3-core-promievent": "1.3.0",
+        "web3-core-subscriptions": "1.3.0",
+        "web3-eth-abi": "1.3.0",
+        "web3-utils": "1.3.0"
       }
     },
     "web3-eth-ens": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.2.11.tgz",
-      "integrity": "sha512-dbW7dXP6HqT1EAPvnniZVnmw6TmQEKF6/1KgAxbo8iBBYrVTMDGFQUUnZ+C4VETGrwwaqtX4L9d/FrQhZ6SUiA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.3.0.tgz",
+      "integrity": "sha512-WnOru+EcuM5dteiVYJcHXo/I7Wq+ei8RrlS2nir49M0QpYvUPGbCGgTbifcjJQTWamgORtWdljSA1s2Asdb74w==",
       "requires": {
         "content-hash": "^2.5.2",
         "eth-ens-namehash": "2.0.8",
         "underscore": "1.9.1",
-        "web3-core": "1.2.11",
-        "web3-core-helpers": "1.2.11",
-        "web3-core-promievent": "1.2.11",
-        "web3-eth-abi": "1.2.11",
-        "web3-eth-contract": "1.2.11",
-        "web3-utils": "1.2.11"
+        "web3-core": "1.3.0",
+        "web3-core-helpers": "1.3.0",
+        "web3-core-promievent": "1.3.0",
+        "web3-eth-abi": "1.3.0",
+        "web3-eth-contract": "1.3.0",
+        "web3-utils": "1.3.0"
       }
     },
     "web3-eth-iban": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.11.tgz",
-      "integrity": "sha512-ozuVlZ5jwFC2hJY4+fH9pIcuH1xP0HEFhtWsR69u9uDIANHLPQQtWYmdj7xQ3p2YT4bQLq/axKhZi7EZVetmxQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.3.0.tgz",
+      "integrity": "sha512-v9mZWhR4fPF17/KhHLiWir4YHWLe09O3B/NTdhWqw3fdAMJNztzMHGzgHxA/4fU+rhrs/FhDzc4yt32zMEXBZw==",
       "requires": {
         "bn.js": "^4.11.9",
-        "web3-utils": "1.2.11"
+        "web3-utils": "1.3.0"
       }
     },
     "web3-eth-personal": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.11.tgz",
-      "integrity": "sha512-42IzUtKq9iHZ8K9VN0vAI50iSU9tOA1V7XU2BhF/tb7We2iKBVdkley2fg26TxlOcKNEHm7o6HRtiiFsVK4Ifw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.3.0.tgz",
+      "integrity": "sha512-2czUhElsJdLpuNfun9GeLiClo5O6Xw+bLSjl3f4bNG5X2V4wcIjX2ygep/nfstLLtkz8jSkgl/bV7esANJyeRA==",
       "requires": {
         "@types/node": "^12.12.6",
-        "web3-core": "1.2.11",
-        "web3-core-helpers": "1.2.11",
-        "web3-core-method": "1.2.11",
-        "web3-net": "1.2.11",
-        "web3-utils": "1.2.11"
+        "web3-core": "1.3.0",
+        "web3-core-helpers": "1.3.0",
+        "web3-core-method": "1.3.0",
+        "web3-net": "1.3.0",
+        "web3-utils": "1.3.0"
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.12.54",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.54.tgz",
-          "integrity": "sha512-ge4xZ3vSBornVYlDnk7yZ0gK6ChHf/CHB7Gl1I0Jhah8DDnEQqBzgohYG4FX4p81TNirSETOiSyn+y1r9/IR6w=="
+          "version": "12.12.62",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.62.tgz",
+          "integrity": "sha512-qAfo81CsD7yQIM9mVyh6B/U47li5g7cfpVQEDMfQeF8pSZVwzbhwU3crc0qG4DmpsebpJPR49AKOExQyJ05Cpg=="
         }
       }
     },
     "web3-net": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.11.tgz",
-      "integrity": "sha512-sjrSDj0pTfZouR5BSTItCuZ5K/oZPVdVciPQ6981PPPIwJJkCMeVjD7I4zO3qDPCnBjBSbWvVnLdwqUBPtHxyg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.3.0.tgz",
+      "integrity": "sha512-Xz02KylOyrB2YZzCkysEDrY7RbKxb7LADzx3Zlovfvuby7HBwtXVexXKtoGqksa+ns1lvjQLLQGb+OeLi7Sr7w==",
       "requires": {
-        "web3-core": "1.2.11",
-        "web3-core-method": "1.2.11",
-        "web3-utils": "1.2.11"
+        "web3-core": "1.3.0",
+        "web3-core-method": "1.3.0",
+        "web3-utils": "1.3.0"
       }
     },
     "web3-providers-http": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.11.tgz",
-      "integrity": "sha512-psh4hYGb1+ijWywfwpB2cvvOIMISlR44F/rJtYkRmQ5jMvG4FOCPlQJPiHQZo+2cc3HbktvvSJzIhkWQJdmvrA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.3.0.tgz",
+      "integrity": "sha512-cMKhUI6PqlY/EC+ZDacAxajySBu8AzW8jOjt1Pe/mbRQgS0rcZyvLePGTTuoyaA8C21F8UW+EE5jj7YsNgOuqA==",
       "requires": {
-        "web3-core-helpers": "1.2.11",
+        "web3-core-helpers": "1.3.0",
         "xhr2-cookies": "1.1.0"
       }
     },
     "web3-providers-ipc": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.11.tgz",
-      "integrity": "sha512-yhc7Y/k8hBV/KlELxynWjJDzmgDEDjIjBzXK+e0rHBsYEhdCNdIH5Psa456c+l0qTEU2YzycF8VAjYpWfPnBpQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.3.0.tgz",
+      "integrity": "sha512-0CrLuRofR+1J38nEj4WsId/oolwQEM6Yl1sOt41S/6bNI7htdkwgVhSloFIMJMDFHtRw229QIJ6wIaKQz0X1Og==",
       "requires": {
-        "oboe": "2.1.4",
+        "oboe": "2.1.5",
         "underscore": "1.9.1",
-        "web3-core-helpers": "1.2.11"
+        "web3-core-helpers": "1.3.0"
+      },
+      "dependencies": {
+        "oboe": {
+          "version": "2.1.5",
+          "resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.5.tgz",
+          "integrity": "sha1-VVQoTFQ6ImbXo48X4HOCH73jk80=",
+          "requires": {
+            "http-https": "^1.0.0"
+          }
+        }
       }
     },
     "web3-providers-ws": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.11.tgz",
-      "integrity": "sha512-ZxnjIY1Er8Ty+cE4migzr43zA/+72AF1myzsLaU5eVgdsfV7Jqx7Dix1hbevNZDKFlSoEyq/3j/jYalh3So1Zg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.3.0.tgz",
+      "integrity": "sha512-Im5MthhJnJst8nSoq0TgbyOdaiFQFa5r6sHPOVllhgIgViDqzbnlAFW9sNzQ0Q8VXPNfPIQKi9cOrHlSRNPjRw==",
       "requires": {
         "eventemitter3": "4.0.4",
         "underscore": "1.9.1",
-        "web3-core-helpers": "1.2.11",
-        "websocket": "^1.0.31"
+        "web3-core-helpers": "1.3.0",
+        "websocket": "^1.0.32"
       }
     },
     "web3-shh": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.2.11.tgz",
-      "integrity": "sha512-B3OrO3oG1L+bv3E1sTwCx66injW1A8hhwpknDUbV+sw3fehFazA06z9SGXUefuFI1kVs4q2vRi0n4oCcI4dZDg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.3.0.tgz",
+      "integrity": "sha512-IZTojA4VCwVq+7eEIHuL1tJXtU+LJDhO8Y2QmuwetEWW1iBgWCGPHZasipWP+7kDpSm/5lo5GRxL72FF/Os/tA==",
       "requires": {
-        "web3-core": "1.2.11",
-        "web3-core-method": "1.2.11",
-        "web3-core-subscriptions": "1.2.11",
-        "web3-net": "1.2.11"
+        "web3-core": "1.3.0",
+        "web3-core-method": "1.3.0",
+        "web3-core-subscriptions": "1.3.0",
+        "web3-net": "1.3.0"
       }
     },
     "web3-utils": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.11.tgz",
-      "integrity": "sha512-3Tq09izhD+ThqHEaWYX4VOT7dNPdZiO+c/1QMA0s5X2lDFKK/xHJb7cyTRRVzN2LvlHbR7baS1tmQhSua51TcQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.3.0.tgz",
+      "integrity": "sha512-2mS5axFCbkhicmoDRuJeuo0TVGQDgC2sPi/5dblfVC+PMtX0efrb8Xlttv/eGkq7X4E83Pds34FH98TP2WOUZA==",
       "requires": {
         "bn.js": "^4.11.9",
         "eth-lib": "0.2.8",
@@ -9513,14 +12812,15 @@
       }
     },
     "websocket": {
-      "version": "1.0.31",
-      "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.31.tgz",
-      "integrity": "sha512-VAouplvGKPiKFDTeCCO65vYHsyay8DqoBSlzIO3fayrfOgU94lQN5a1uWVnFrMLceTJw/+fQXR5PGbUVRaHshQ==",
+      "version": "1.0.32",
+      "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.32.tgz",
+      "integrity": "sha512-i4yhcllSP4wrpoPMU2N0TQ/q0O94LRG/eUQjEAamRltjQ1oT1PFFKOG4i877OlJgCG8rw6LrrowJp+TYCEWF7Q==",
       "requires": {
+        "bufferutil": "^4.0.1",
         "debug": "^2.2.0",
         "es5-ext": "^0.10.50",
-        "nan": "^2.14.0",
         "typedarray-to-buffer": "^3.1.5",
+        "utf-8-validate": "^5.0.2",
         "yaeti": "^0.0.6"
       }
     },
@@ -9554,6 +12854,12 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
     },
     "workerpool": {
@@ -9781,10 +13087,21 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
       "integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
+      "dev": true,
       "requires": {
         "flat": "^4.1.0",
         "lodash": "^4.17.15",
         "yargs": "^13.3.0"
+      }
+    },
+    "yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+      "dev": true,
+      "requires": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -12,20 +12,21 @@
     "eth-gas-reporter": "^0.2.17",
     "ethlint": "^1.2.5",
     "prettier": "^1.18.2",
-    "prettier-plugin-solidity": "^1.0.0-alpha.34",
+    "prettier-plugin-solidity": "^1.0.0-alpha.58",
     "solc": "^0.5.11",
+    "solidity-coverage": "^0.7.10",
     "solium": "^1.2.5",
-    "truffle-flattener": "^1.3.0"
+    "truffle-flattener": "^1.5.0"
   },
   "dependencies": {
-    "@truffle/hdwallet-provider": "^1.0.38-next.0",
+    "@truffle/hdwallet-provider": "^1.1.0",
     "contract": "^0.1.2",
-    "eth-json-rpc-filters": "^4.1.1",
+    "eth-json-rpc-filters": "^4.2.1",
     "ethereumjs-tx": "^2.1.1",
-    "ganache-cli": "^6.5.1",
+    "ganache-cli": "^6.10.2",
     "node-fetch-polyfill": "^2.0.6",
-    "truffle": "^5.0.34",
-    "web3": "^1.0.0-beta.36"
+    "truffle": "^5.1.46",
+    "web3": "^1.3.0"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/test/furtherTests.js
+++ b/test/furtherTests.js
@@ -1,265 +1,697 @@
-// /** 
-// * This contract tests the Tellor functions
-// */ 
+/**
+ * This contract tests the Tellor functions
+ */
 
-// const Web3 = require('web3')
-// const web3 = new Web3(new Web3.providers.WebsocketProvider('ws://localhost:8545'));
-// const BN = require('bn.js');
-// const helper = require("./helpers/test_helpers");
-// //const ethers = require('ethers');
-// const Utilities = artifacts.require("./libraries/Utilities.sol");
-// const UtilitiesTests = artifacts.require("./UtilitiesTests.sol");
-// const TellorMaster = artifacts.require("./TellorMaster.sol");
-// const Tellor = artifacts.require("./Tellor.sol"); // globally injected artifacts helper
+const Web3 = require("web3");
+const web3 = new Web3(
+  new Web3.providers.WebsocketProvider("ws://localhost:8545")
+);
+const BN = require("bn.js");
+const helper = require("./helpers/test_helpers");
+//const ethers = require('ethers');
+const Utilities = artifacts.require("./libraries/Utilities.sol");
+const UtilitiesTests = artifacts.require("./UtilitiesTests.sol");
+const TellorMaster = artifacts.require("./TellorMaster.sol");
+const Tellor = artifacts.require("./Tellor.sol"); // globally injected artifacts helper
 
-// var oracleAbi = Tellor.abi;
-// var masterAbi = TellorMaster.abi;
+var oracleAbi = Tellor.abi;
+var masterAbi = TellorMaster.abi;
 
+contract("Further Tests", function(accounts) {
+  let oracle;
+  let oracle2;
+  let oracleBase;
+  let master;
+  let utilities;
 
-// contract('Further Tests', function(accounts) {
-//   let oracle;
-//   let oracle2;
-//   let oracleBase;
-//   let master;
-//   let utilities;
+  beforeEach("Setup contract for each test", async function() {
+    oracleBase = await Tellor.new();
+    oracle = await TellorMaster.new(oracleBase.address);
+    master = await new web3.eth.Contract(masterAbi, oracle.address);
+    oracle2 = await new web3.eth.Contract(oracleAbi, oracleBase.address);
+  });
 
-//     beforeEach('Setup contract for each test', async function () {
-//         oracleBase = await Tellor.new();
-//         oracle = await TellorMaster.new(oracleBase.address);
-//         master = await new web3.eth.Contract(masterAbi,oracle.address);
-//         oracle2 = await new web3.eth.Contract(oracleAbi,oracleBase.address);
-//    });  
-   
-//    it("transferOwnership", async function () {
-//    	    let checkowner = await oracle.getAddressVars(web3.utils.keccak256("_owner"));
-//         assert(checkowner == accounts[0], "initial owner acct 0");
-//         await web3.eth.sendTransaction({to: oracle.address,from:accounts[0],gas:7000000,data:oracle2.methods.proposeOwnership(accounts[2]).encodeABI()});
-//         let pendingOwner = await oracle.getAddressVars(web3.utils.keccak256("pending_owner"));
-//         assert(pendingOwner == accounts[2], "pending owner acct 2");
-//         checkowner = await oracle.getAddressVars(web3.utils.keccak256("_owner"));
-//         assert(checkowner == accounts[0], "initial owner acct 0");
-//         await web3.eth.sendTransaction({to: oracle.address,from:accounts[2],gas:7000000,data:oracle2.methods.claimOwnership().encodeABI()});
-//         checkowner = await oracle.getAddressVars(web3.utils.keccak256("_owner"));
-//         assert(checkowner == accounts[2], "new owner acct 2");
-//    });
-//     it("Stake miner", async function (){
-//          await web3.eth.sendTransaction({to:oracle.address,from:accounts[0],gas:7000000,data:oracle2.methods.theLazyCoon(accounts[6],web3.utils.toWei('5000', 'ether')).encodeABI()})
-//         await web3.eth.sendTransaction({to: oracle.address,from:accounts[6],gas:7000000,data:oracle2.methods.depositStake().encodeABI()})
-//        	let s =  await oracle.getStakerInfo(accounts[6])
-//         assert(s[0] == 1, "Staked" );
-//     });
-//     it("Test New Tellor Storage Contract", async function () {
-//         let oracleBase2 = await Tellor.new();
-//          await web3.eth.sendTransaction({to:oracle.address,from:accounts[0],gas:7000000,data:oracle2.methods.theLazyCoon(accounts[2],web3.utils.toWei('5000', 'ether')).encodeABI()})
-//         await web3.eth.sendTransaction({to: oracle.address,from:accounts[2],gas:7000000,data:oracle2.methods.proposeFork(oracleBase2.address).encodeABI()})
-//         for(var i = 1;i<5;i++){
-//             await web3.eth.sendTransaction({to: oracle.address,from:accounts[i],gas:7000000,data:oracle2.methods.vote(1,true).encodeABI()})
-//         }
-//         await helper.advanceTime(86400 * 8);
-//         await web3.eth.sendTransaction({to: oracle.address,from:accounts[i],gas:7000000,data:oracle2.methods.tallyVotes(1).encodeABI()})
-// 		await helper.advanceTime(86400 * 2);
-//         await web3.eth.sendTransaction({to: oracle.address,from:accounts[0],gas:7000000,data:oracle2.methods.updateTellor(1).encodeABI()})
-//         assert(await oracle.getAddressVars(web3.utils.keccak256("tellorContract")) == oracleBase2.address);
-//     });
-//     it("Test Failed Vote - New Tellor Storage Contract", async function () {
-//         let oracleBase2 = await Tellor.new();
-//         await web3.eth.sendTransaction({to:oracle.address,from:accounts[0],gas:7000000,data:oracle2.methods.theLazyCoon(accounts[2],web3.utils.toWei('5000', 'ether')).encodeABI()})
-        
-//         await web3.eth.sendTransaction({to: oracle.address,from:accounts[2],gas:7000000,data:oracle2.methods.proposeFork(oracleBase2.address).encodeABI()})
-//         for(var i = 1;i<5;i++){
-//             await web3.eth.sendTransaction({to: oracle.address,from:accounts[i],gas:7000000,data:oracle2.methods.vote(1,false).encodeABI()})
-//         }
-//         await helper.advanceTime(86400 * 8);
-//         await web3.eth.sendTransaction({to: oracle.address,from:accounts[i],gas:7000000,data:oracle2.methods.tallyVotes(1).encodeABI()})
-//         assert(await oracle.getAddressVars(web3.utils.keccak256("tellorContract")) == oracleBase.address, "vote should have failed");
-//     });
-//     it("Test Failed Vote - New Tellor Storage Contract--vote fail by 10% quorum", async function () {
-//         let oracleBase2 = await Tellor.new();
-//         await web3.eth.sendTransaction({to:oracle.address,from:accounts[5],gas:7000000,data:oracle2.methods.theLazyCoon(accounts[4],web3.utils.toWei('2000', 'ether')).encodeABI()})
-//         await web3.eth.sendTransaction({to: oracle.address,from:accounts[4],gas:7000000,data:oracle2.methods.proposeFork(oracleBase2.address).encodeABI()})
-//         vars = await oracle.getAllDisputeVars(1);
-//         await helper.advanceTime(86400 * 8);
-//         await web3.eth.sendTransaction({to: oracle.address,from:accounts[0],gas:7000000,data:oracle2.methods.tallyVotes(1).encodeABI()})
-//         assert(await oracle.getAddressVars(web3.utils.keccak256("tellorContract")) == oracleBase.address, "vote should have failed");
-//     });
-//     it("Test Failed Vote - New Tellor Storage Contract--vote fail to fail because 10% diff in quorum is not reached", async function () {
-//         let oracleBase2 = await Tellor.new();
-//         await web3.eth.sendTransaction({to:oracle.address,from:accounts[5],gas:7000000,data:oracle2.methods.theLazyCoon(accounts[4],web3.utils.toWei('4000', 'ether')).encodeABI()})
-//         initTotalSupply = await oracle.totalSupply();
-//         await web3.eth.sendTransaction({to: oracle.address,from:accounts[4],gas:7000000,data:oracle2.methods.proposeFork(oracleBase2.address).encodeABI()})
-//         vars = await oracle.getAllDisputeVars(1);
-//         await web3.eth.sendTransaction({to: oracle.address,from:accounts[0],gas:7000000,data:oracle2.methods.vote(1,false).encodeABI()})
-//         await web3.eth.sendTransaction({to: oracle.address,from:accounts[5],gas:7000000,data:oracle2.methods.vote(1,false).encodeABI()})
-//         await web3.eth.sendTransaction({to: oracle.address,from:accounts[1],gas:7000000,data:oracle2.methods.vote(1,false).encodeABI()})
-//         await web3.eth.sendTransaction({to: oracle.address,from:accounts[2],gas:7000000,data:oracle2.methods.vote(1,false).encodeABI()})
-//         vars = await oracle.getAllDisputeVars(1);
-//         newTotalSupply = await oracle.totalSupply();
-//         it= await web3.utils.fromWei(initTotalSupply, 'ether');
-//         ts= await web3.utils.fromWei(newTotalSupply, 'ether');         
-//         await helper.advanceTime(86400 * 8);
-//         assert(await oracle.getAddressVars(web3.utils.keccak256("tellorContract")) == oracleBase.address, "vote should have failed");
-//     });
+  it("transferOwnership", async function() {
+    let checkowner = await oracle.getAddressVars(
+      web3.utils.keccak256("_owner")
+    );
+    assert(checkowner == accounts[0], "initial owner acct 0");
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods.proposeOwnership(accounts[2]).encodeABI(),
+    });
+    let pendingOwner = await oracle.getAddressVars(
+      web3.utils.keccak256("pending_owner")
+    );
+    assert(pendingOwner == accounts[2], "pending owner acct 2");
+    checkowner = await oracle.getAddressVars(web3.utils.keccak256("_owner"));
+    assert(checkowner == accounts[0], "initial owner acct 0");
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[2],
+      gas: 7000000,
+      data: oracle2.methods.claimOwnership().encodeABI(),
+    });
+    checkowner = await oracle.getAddressVars(web3.utils.keccak256("_owner"));
+    assert(checkowner == accounts[2], "new owner acct 2");
+  });
+  it("Stake miner", async function() {
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods
+        .theLazyCoon(accounts[6], web3.utils.toWei("5000", "ether"))
+        .encodeABI(),
+    });
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[6],
+      gas: 7000000,
+      data: oracle2.methods.depositStake().encodeABI(),
+    });
+    let s = await oracle.getStakerInfo(accounts[6]);
+    assert(s[0] == 1, "Staked");
+  });
+  it("Test New Tellor Storage Contract", async function() {
+    let oracleBase2 = await Tellor.new();
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods
+        .theLazyCoon(accounts[2], web3.utils.toWei("5000", "ether"))
+        .encodeABI(),
+    });
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[2],
+      gas: 7000000,
+      data: oracle2.methods.proposeFork(oracleBase2.address).encodeABI(),
+    });
+    for (var i = 1; i < 5; i++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods.vote(1, true).encodeABI(),
+      });
+    }
+    await helper.advanceTime(86400 * 8);
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[i],
+      gas: 7000000,
+      data: oracle2.methods.tallyVotes(1).encodeABI(),
+    });
+    await helper.advanceTime(86400 * 2);
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods.updateTellor(1).encodeABI(),
+    });
+    assert(
+      (await oracle.getAddressVars(web3.utils.keccak256("tellorContract"))) ==
+        oracleBase2.address
+    );
+  });
+  it("Test Failed Vote - New Tellor Storage Contract", async function() {
+    let oracleBase2 = await Tellor.new();
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods
+        .theLazyCoon(accounts[2], web3.utils.toWei("5000", "ether"))
+        .encodeABI(),
+    });
 
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[2],
+      gas: 7000000,
+      data: oracle2.methods.proposeFork(oracleBase2.address).encodeABI(),
+    });
+    for (var i = 1; i < 5; i++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods.vote(1, false).encodeABI(),
+      });
+    }
+    await helper.advanceTime(86400 * 8);
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[i],
+      gas: 7000000,
+      data: oracle2.methods.tallyVotes(1).encodeABI(),
+    });
+    assert(
+      (await oracle.getAddressVars(web3.utils.keccak256("tellorContract"))) ==
+        oracleBase.address,
+      "vote should have failed"
+    );
+  });
+  it("Test Failed Vote - New Tellor Storage Contract--vote fail by 10% quorum", async function() {
+    let oracleBase2 = await Tellor.new();
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[5],
+      gas: 7000000,
+      data: oracle2.methods
+        .theLazyCoon(accounts[4], web3.utils.toWei("2000", "ether"))
+        .encodeABI(),
+    });
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[4],
+      gas: 7000000,
+      data: oracle2.methods.proposeFork(oracleBase2.address).encodeABI(),
+    });
+    vars = await oracle.getAllDisputeVars(1);
+    await helper.advanceTime(86400 * 8);
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods.tallyVotes(1).encodeABI(),
+    });
+    assert(
+      (await oracle.getAddressVars(web3.utils.keccak256("tellorContract"))) ==
+        oracleBase.address,
+      "vote should have failed"
+    );
+  });
+  it("Test Failed Vote - New Tellor Storage Contract--vote fail to fail because 10% diff in quorum is not reached", async function() {
+    let oracleBase2 = await Tellor.new();
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[5],
+      gas: 7000000,
+      data: oracle2.methods
+        .theLazyCoon(accounts[4], web3.utils.toWei("4000", "ether"))
+        .encodeABI(),
+    });
+    initTotalSupply = await oracle.totalSupply();
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[4],
+      gas: 7000000,
+      data: oracle2.methods.proposeFork(oracleBase2.address).encodeABI(),
+    });
+    vars = await oracle.getAllDisputeVars(1);
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods.vote(1, false).encodeABI(),
+    });
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[5],
+      gas: 7000000,
+      data: oracle2.methods.vote(1, false).encodeABI(),
+    });
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[1],
+      gas: 7000000,
+      data: oracle2.methods.vote(1, false).encodeABI(),
+    });
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[2],
+      gas: 7000000,
+      data: oracle2.methods.vote(1, false).encodeABI(),
+    });
+    vars = await oracle.getAllDisputeVars(1);
+    newTotalSupply = await oracle.totalSupply();
+    it = await web3.utils.fromWei(initTotalSupply, "ether");
+    ts = await web3.utils.fromWei(newTotalSupply, "ether");
+    await helper.advanceTime(86400 * 8);
+    assert(
+      (await oracle.getAddressVars(web3.utils.keccak256("tellorContract"))) ==
+        oracleBase.address,
+      "vote should have failed"
+    );
+  });
 
-//       it("Test Vote - New Tellor Storage Contract--vote passed by 10% quorum", async function () {
-//         let oracleBase2 = await Tellor.new();
-//         //print some TRB tokens
-//         await web3.eth.sendTransaction({to:oracle.address,from:accounts[5],gas:7000000,data:oracle2.methods.theLazyCoon(accounts[4],web3.utils.toWei('4000', 'ether')).encodeABI()})
-//         await web3.eth.sendTransaction({to: oracle.address,from:accounts[4],gas:7000000,data:oracle2.methods.proposeFork(oracleBase2.address).encodeABI()})
-//         //get the initial dispute variables--should be zeros
-//         await web3.eth.sendTransaction({to: oracle.address,from:accounts[0],gas:7000000,data:oracle2.methods.vote(1,false).encodeABI()})
-//         await web3.eth.sendTransaction({to: oracle.address,from:accounts[1],gas:7000000,data:oracle2.methods.vote(1,true).encodeABI()})
-//         await web3.eth.sendTransaction({to: oracle.address,from:accounts[3],gas:7000000,data:oracle2.methods.vote(1,true).encodeABI()})
-//         await helper.advanceTime(86400 * 8);
-//         await web3.eth.sendTransaction({to: oracle.address,from:accounts[0],gas:7000000,data:oracle2.methods.tallyVotes(1).encodeABI()})
-//         await helper.advanceTime(86400 * 2);
-//                 await web3.eth.sendTransaction({to: oracle.address,from:accounts[0],gas:7000000,data:oracle2.methods.updateTellor(1).encodeABI()})
-//         assert(await oracle.getAddressVars(web3.utils.keccak256("tellorContract")) == oracleBase2.address, "vote should have passed");
-//     });
+  it("Test Vote - New Tellor Storage Contract--vote passed by 10% quorum", async function() {
+    let oracleBase2 = await Tellor.new();
+    //print some TRB tokens
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[5],
+      gas: 7000000,
+      data: oracle2.methods
+        .theLazyCoon(accounts[4], web3.utils.toWei("4000", "ether"))
+        .encodeABI(),
+    });
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[4],
+      gas: 7000000,
+      data: oracle2.methods.proposeFork(oracleBase2.address).encodeABI(),
+    });
+    //get the initial dispute variables--should be zeros
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods.vote(1, false).encodeABI(),
+    });
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[1],
+      gas: 7000000,
+      data: oracle2.methods.vote(1, true).encodeABI(),
+    });
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[3],
+      gas: 7000000,
+      data: oracle2.methods.vote(1, true).encodeABI(),
+    });
+    await helper.advanceTime(86400 * 8);
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods.tallyVotes(1).encodeABI(),
+    });
+    await helper.advanceTime(86400 * 2);
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods.updateTellor(1).encodeABI(),
+    });
+    assert(
+      (await oracle.getAddressVars(web3.utils.keccak256("tellorContract"))) ==
+        oracleBase2.address,
+      "vote should have passed"
+    );
+  });
 
-//     it("Test Deity Functions", async function () {
-//     	let owner = await oracle.getAddressVars(web3.utils.keccak256("_deity"));
-//     	assert(owner == accounts[0])
-//     	await web3.eth.sendTransaction({to: oracle.address,from:accounts[0],gas:7000000,data:master.methods.changeDeity(accounts[1]).encodeABI()})
-// 		owner = await oracle.getAddressVars(web3.utils.keccak256("_deity"));
-// 		assert(owner == accounts[1])
-// 		newOracle = await Tellor.new();
-// 		await web3.eth.sendTransaction({to: oracle.address,from:accounts[1],gas:7000000,data:master.methods.changeTellorContract(newOracle.address).encodeABI()})
-// 		assert(await oracle.getAddressVars(web3.utils.keccak256("tellorContract")) == newOracle.address);
-//     });
-//        it("Get Symbol and decimals", async function(){
-//         let symbol =await oracle2.methods.symbol().call()
-//         assert.equal(symbol,"TRB","the Symbol should be TT");
-//         data3 =  await oracle2.methods.decimals().call()
-//         assert(data3 - 0 == 18)
-//     });
-//     it("Get name", async function(){
-//         let name = await oracle2.methods.name().call()
-//         assert.equal(name,"Tellor Tributes","the Name should be Tellor Tributes");
-//     });
-//     it("getStakersCount", async function(){
-//         let count = await oracle.getUintVar(web3.utils.keccak256("stakerCount"))
-//         assert(web3.utils.hexToNumberString(count)==6, "count is 6");//added miner
-//     });
-//     it("getStakersInfo", async function(){
-//         let info = await oracle.getStakerInfo(accounts[1])
-//         let stake = web3.utils.hexToNumberString(info['0']);
-//         let startDate = web3.utils.hexToNumberString(info['1']);
-//         let _date = new Date();
-//         let d = (_date - (_date % 86400000))/1000;
-//         assert(startDate >= d*1, "startDate is today");
-//         assert(stake*1 == 1, "Should be 1 for staked address");
-//      });
-//     it("Total Supply", async function(){
-//         supply = await master.methods.totalSupply().call()
-//         assert.equal(web3.utils.fromWei(supply),6000,"Supply should be 6000");//added miner
-//     });
-//     it("Test Changing Dispute Fee", async function () {
-//         await web3.eth.sendTransaction({to:oracle.address,from:accounts[0],gas:7000000,data:oracle2.methods.theLazyCoon(accounts[6],web3.utils.toWei('5000', 'ether')).encodeABI()})
-//         await web3.eth.sendTransaction({to:oracle.address,from:accounts[0],gas:7000000,data:oracle2.methods.theLazyCoon(accounts[7],web3.utils.toWei('5000', 'ether')).encodeABI()})
-//         var disputeFee1 = await oracle.getUintVar(web3.utils.keccak256("disputeFee"))
-//                             newOracle = await Tellor.new();
-//         await web3.eth.sendTransaction({to: oracle.address,from:accounts[0],gas:7000000,data:master.methods.changeTellorContract(newOracle.address).encodeABI()})
-//         await web3.eth.sendTransaction({to:oracle.address,from:accounts[6],gas:7000000,data:oracle2.methods.depositStake().encodeABI()})
-//         await web3.eth.sendTransaction({to:oracle.address,from:accounts[7],gas:7000000,data:oracle2.methods.depositStake().encodeABI()})
-//         assert(await oracle.getUintVar(web3.utils.keccak256("disputeFee")) < disputeFee1,"disputeFee should change");
-
-//     });
-//     it("Staking, requestStakingWithdraw, withdraw stake", async function(){
-//         let withdrawreq = await web3.eth.sendTransaction({to:oracle.address,from:accounts[1],gas:7000000,data:oracle2.methods.requestStakingWithdraw().encodeABI()})
-//         let weSender =  await web3.eth.abi.decodeParameter('address',withdrawreq.logs[0].topics[1])
-//         assert(weSender == accounts[1], "withdraw request by account 1");
-//         await helper.advanceTime(86400 * 8);
-//                 s =  await oracle.getStakerInfo(accounts[1])
-//         assert(s !=1, " Staked" );
-//         await web3.eth.sendTransaction({to:oracle.address,from:accounts[1],gas:7000000,data:oracle2.methods.withdrawStake().encodeABI()})
-//                 s =  await oracle.getStakerInfo(accounts[1])
-//         assert(s !=1, "not Staked" );
-//     });
-//     it("Attempt to Allow and transferFrom more than balance - stake", async function(){
-//         await web3.eth.sendTransaction({to:oracle.address,from:accounts[0],gas:7000000,data:oracle2.methods.theLazyCoon(accounts[2],web3.utils.toWei('5000', 'ether')).encodeABI()})
-//         var tokens = web3.utils.toWei('2', 'ether');
-//         var tokens2 = web3.utils.toWei('3', 'ether');
-//         await web3.eth.sendTransaction({to:oracle.address,from:accounts[2],gas:7000000,data:oracle2.methods.transfer(accounts[1],tokens).encodeABI()})
-//         balance1 = await web3.eth.call({to:oracle.address,data:master.methods.balanceOf(accounts[1]).encodeABI()});
-//         await web3.eth.sendTransaction({to:oracle.address,from:accounts[1],gas:1000000,data:oracle2.methods.approve(accounts[6],tokens2).encodeABI()});
-//         await helper.expectThrow(web3.eth.sendTransaction({to:oracle.address,from:accounts[6],gas:7000000,data:oracle2.methods.transferFrom(accounts[1], accounts[8],tokens2).encodeABI()}));
-//         balance1b = await web3.eth.call({to:oracle.address,data:master.methods.balanceOf(accounts[1]).encodeABI()}); 
-//         assert((1000 + web3.utils.fromWei(tokens)*1) == web3.utils.fromWei(balance1)*1, "Balance for acct 1 should == 1000 + transferred amt ");
-//     });
-//     it("Attempt to withdraw unnaproved", async function(){ 
-//         balance1b = await ( web3.eth.call({to:oracle.address,data:master.methods.balanceOf(accounts[1]).encodeABI()}));
-//         await helper.expectThrow(web3.eth.sendTransaction({to:oracle.address,from:accounts[1],gas:7000000,data:oracle2.methods.withdrawStake().encodeABI()}) );
-//         s =  await oracle.getStakerInfo(accounts[1])
-//         assert(s[0] ==1, " Staked" );
-//         assert(web3.utils.fromWei(balance1b) == 1000, "Balance should equal transferred amt");
-//     });
-//     it("Attempt to transfer more than balance - stake", async function(){
-//         await web3.eth.sendTransaction({to:oracle.address,from:accounts[0],gas:7000000,data:oracle2.methods.theLazyCoon(accounts[2],web3.utils.toWei('5000', 'ether')).encodeABI()})
-//         var tokens = web3.utils.toWei('1', 'ether');
-//         var tokens2 = web3.utils.toWei('2000000', 'ether');
-//         await web3.eth.sendTransaction({to:oracle.address,from:accounts[2],gas:7000000,data:oracle2.methods.transfer(accounts[1],tokens).encodeABI()})
-//         balance1 = await web3.eth.call({to:oracle.address,data:master.methods.balanceOf(accounts[1]).encodeABI()});
-//         await helper.expectThrow(web3.eth.sendTransaction({to:oracle.address,from:accounts[1],gas:7000000,data:oracle2.methods.transfer(accounts[1],tokens2).encodeABI()}));
-//         balance1b = await web3.eth.call({to:oracle.address,data:master.methods.balanceOf(accounts[1]).encodeABI()});
-//         assert( web3.utils.fromWei(balance1b) == 1001, "Balance should == (1000 + tokens)");
-//     });
-//     it("re-Staking without withdraw ", async function(){
-//         await helper.advanceTime(86400 * 10);
-//         let withdrawreq = await web3.eth.sendTransaction({to:oracle.address,from:accounts[1],gas:7000000,data:oracle2.methods.requestStakingWithdraw().encodeABI()})
-//         let weSender =  await web3.eth.abi.decodeParameter('address',withdrawreq.logs[0].topics[1]);
-//         assert(weSender == accounts[1], "withdraw request by account 1");
-//         await helper.advanceTime(86400 * 10);
-//         let s =  await oracle.getStakerInfo(accounts[1])
-//         assert(s[0] !=1 , "is not Staked" );
-//         await web3.eth.sendTransaction({to:oracle.address,from:accounts[1],gas:7000000,data:oracle2.methods.depositStake().encodeABI()})
-//         s =  await oracle.getStakerInfo(accounts[1])
-//         assert(s[0] == 1, "is not Staked" );
-//     });    
-//     it("withdraw and re-stake", async function(){
-//         await helper.advanceTime(86400 * 10);
-//         let withdrawreq = await web3.eth.sendTransaction({to:oracle.address,from:accounts[1],gas:7000000,data:oracle2.methods.requestStakingWithdraw().encodeABI()})
-//         let weSender =  await web3.eth.abi.decodeParameter('address',withdrawreq.logs[0].topics[1]);
-//         assert(weSender == accounts[1], "withdraw request by account 1");
-//         await helper.advanceTime(86400 * 10);
-//         let s =  await oracle.getStakerInfo(accounts[1])
-//         assert(s[0] !=1, "is not Staked" );
-//         await web3.eth.sendTransaction({to:oracle.address,from:accounts[1],gas:7000000,data:oracle2.methods.withdrawStake().encodeABI()})
-//         s =  await oracle.getStakerInfo(accounts[1])
-//         assert(s[0] != 1, " not Staked" );
-//         await web3.eth.sendTransaction({to:oracle.address,from:accounts[1],gas:7000000,data:oracle2.methods.depositStake().encodeABI()}) 
-//         s =  await oracle.getStakerInfo(accounts[1])
-//         assert(s[0] ==1, " Staked" );
-//     }); 
-//     it("Token transfer", async function(){
-//         await web3.eth.sendTransaction({to:oracle.address,from:accounts[0],gas:7000000,data:oracle2.methods.theLazyCoon(accounts[2],web3.utils.toWei('5000', 'ether')).encodeABI()})
-//         balance2 =  await web3.eth.call({to:oracle.address,data:master.methods.balanceOf(accounts[2]).encodeABI()})
-//         t = web3.utils.toWei('5', 'ether');
-//         await web3.eth.sendTransaction({to:oracle.address,from:accounts[2],gas:700000,data:oracle2.methods.transfer(accounts[5], t).encodeABI()})
-//         balance2a = await web3.eth.call({to:oracle.address,data:master.methods.balanceOf(accounts[2]).encodeABI()})
-//         balance5 = await web3.eth.call({to:oracle.address,data:master.methods.balanceOf(accounts[5]).encodeABI()})
-//         assert(web3.utils.fromWei(balance2a, 'ether') == 4995, web3.utils.fromWei(balance2a, 'ether') + "should be 995");
-//         assert(web3.utils.fromWei(balance5) == 1005, "balance for acct 5 is 1005");
-//     });
-//    it("Approve and transferFrom", async function(){
-//     await web3.eth.sendTransaction({to:oracle.address,from:accounts[0],gas:7000000,data:oracle2.methods.theLazyCoon(accounts[2],web3.utils.toWei('5000', 'ether')).encodeABI()})
-//         t = web3.utils.toWei('7', 'ether');
-//         await web3.eth.sendTransaction({to:oracle.address,from:accounts[2],gas:700000,data:oracle2.methods.approve(accounts[1], t).encodeABI()})
-//         balance0a = await web3.eth.call({to:oracle.address,data:master.methods.balanceOf(accounts[2]).encodeABI()})
-//          await web3.eth.sendTransaction({to:oracle.address,from:accounts[1],gas:700000,data:oracle2.methods.transferFrom(accounts[2], accounts[5], t).encodeABI()})
-//         balance5a = await web3.eth.call({to:oracle.address,data:master.methods.balanceOf(accounts[5]).encodeABI()});
-//         assert(web3.utils.fromWei(balance5a) == 1007, "balance for acct 5 is 1007");
-//     });
-//     it("Allowance after approve and transferFrom", async function(){
-//         await web3.eth.sendTransaction({to:oracle.address,from:accounts[0],gas:7000000,data:oracle2.methods.theLazyCoon(accounts[2],web3.utils.toWei('5000', 'ether')).encodeABI()}) 
-//         t = web3.utils.toWei('7', 'ether');
-//         t2 = web3.utils.toWei('6', 'ether');
-//          await web3.eth.sendTransaction({to:oracle.address,from:accounts[2],gas:700000,data:oracle2.methods.approve(accounts[1], t).encodeABI()})
-//         balance0a = await web3.eth.call({to:oracle.address,data:master.methods.balanceOf(accounts[2]).encodeABI()})
-//         await web3.eth.sendTransaction({to:oracle.address,from:accounts[1],gas:700000,data:oracle2.methods.transferFrom(accounts[2], accounts[5], t2).encodeABI()})
-//         balance5a = await web3.eth.call({to:oracle.address,data:master.methods.balanceOf(accounts[5]).encodeABI()});
-//         assert.equal(web3.utils.fromWei(balance5a), 1006, "balance for acct 5 is 1006");
-//         allow = await web3.eth.call({to:oracle.address,data:master.methods.allowance(accounts[2],accounts[1]).encodeABI()});
-//         assert.equal(web3.utils.fromWei(allow, 'ether'), 1, "Allowance shoudl be 1 eth");
-//     });
-//  });
+  it("Test Deity Functions", async function() {
+    let owner = await oracle.getAddressVars(web3.utils.keccak256("_deity"));
+    assert(owner == accounts[0]);
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: master.methods.changeDeity(accounts[1]).encodeABI(),
+    });
+    owner = await oracle.getAddressVars(web3.utils.keccak256("_deity"));
+    assert(owner == accounts[1]);
+    newOracle = await Tellor.new();
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[1],
+      gas: 7000000,
+      data: master.methods.changeTellorContract(newOracle.address).encodeABI(),
+    });
+    assert(
+      (await oracle.getAddressVars(web3.utils.keccak256("tellorContract"))) ==
+        newOracle.address
+    );
+  });
+  it("Get Symbol and decimals", async function() {
+    let symbol = await oracle2.methods.symbol().call();
+    assert.equal(symbol, "TRB", "the Symbol should be TT");
+    data3 = await oracle2.methods.decimals().call();
+    assert(data3 - 0 == 18);
+  });
+  it("Get name", async function() {
+    let name = await oracle2.methods.name().call();
+    assert.equal(name, "Tellor Tributes", "the Name should be Tellor Tributes");
+  });
+  it("getStakersCount", async function() {
+    let count = await oracle.getUintVar(web3.utils.keccak256("stakerCount"));
+    assert(web3.utils.hexToNumberString(count) == 6, "count is 6"); //added miner
+  });
+  it("getStakersInfo", async function() {
+    let info = await oracle.getStakerInfo(accounts[1]);
+    let stake = web3.utils.hexToNumberString(info["0"]);
+    let startDate = web3.utils.hexToNumberString(info["1"]);
+    let _date = new Date();
+    let d = (_date - (_date % 86400000)) / 1000;
+    assert(startDate >= d * 1, "startDate is today");
+    assert(stake * 1 == 1, "Should be 1 for staked address");
+  });
+  it("Total Supply", async function() {
+    supply = await master.methods.totalSupply().call();
+    assert.equal(web3.utils.fromWei(supply), 6000, "Supply should be 6000"); //added miner
+  });
+  it("Test Changing Dispute Fee", async function() {
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods
+        .theLazyCoon(accounts[6], web3.utils.toWei("5000", "ether"))
+        .encodeABI(),
+    });
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods
+        .theLazyCoon(accounts[7], web3.utils.toWei("5000", "ether"))
+        .encodeABI(),
+    });
+    var disputeFee1 = await oracle.getUintVar(
+      web3.utils.keccak256("disputeFee")
+    );
+    newOracle = await Tellor.new();
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: master.methods.changeTellorContract(newOracle.address).encodeABI(),
+    });
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[6],
+      gas: 7000000,
+      data: oracle2.methods.depositStake().encodeABI(),
+    });
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[7],
+      gas: 7000000,
+      data: oracle2.methods.depositStake().encodeABI(),
+    });
+    assert(
+      (await oracle.getUintVar(web3.utils.keccak256("disputeFee"))) <
+        disputeFee1,
+      "disputeFee should change"
+    );
+  });
+  it("Staking, requestStakingWithdraw, withdraw stake", async function() {
+    let withdrawreq = await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[1],
+      gas: 7000000,
+      data: oracle2.methods.requestStakingWithdraw().encodeABI(),
+    });
+    let weSender = await web3.eth.abi.decodeParameter(
+      "address",
+      withdrawreq.logs[0].topics[1]
+    );
+    assert(weSender == accounts[1], "withdraw request by account 1");
+    await helper.advanceTime(86400 * 8);
+    s = await oracle.getStakerInfo(accounts[1]);
+    assert(s != 1, " Staked");
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[1],
+      gas: 7000000,
+      data: oracle2.methods.withdrawStake().encodeABI(),
+    });
+    s = await oracle.getStakerInfo(accounts[1]);
+    assert(s != 1, "not Staked");
+  });
+  it("Attempt to Allow and transferFrom more than balance - stake", async function() {
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods
+        .theLazyCoon(accounts[2], web3.utils.toWei("5000", "ether"))
+        .encodeABI(),
+    });
+    var tokens = web3.utils.toWei("2", "ether");
+    var tokens2 = web3.utils.toWei("3", "ether");
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[2],
+      gas: 7000000,
+      data: oracle2.methods.transfer(accounts[1], tokens).encodeABI(),
+    });
+    balance1 = await web3.eth.call({
+      to: oracle.address,
+      data: master.methods.balanceOf(accounts[1]).encodeABI(),
+    });
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[1],
+      gas: 1000000,
+      data: oracle2.methods.approve(accounts[6], tokens2).encodeABI(),
+    });
+    await helper.expectThrow(
+      web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[6],
+        gas: 7000000,
+        data: oracle2.methods
+          .transferFrom(accounts[1], accounts[8], tokens2)
+          .encodeABI(),
+      })
+    );
+    balance1b = await web3.eth.call({
+      to: oracle.address,
+      data: master.methods.balanceOf(accounts[1]).encodeABI(),
+    });
+    assert(
+      1000 + web3.utils.fromWei(tokens) * 1 == web3.utils.fromWei(balance1) * 1,
+      "Balance for acct 1 should == 1000 + transferred amt "
+    );
+  });
+  it("Attempt to withdraw unnaproved", async function() {
+    balance1b = await web3.eth.call({
+      to: oracle.address,
+      data: master.methods.balanceOf(accounts[1]).encodeABI(),
+    });
+    await helper.expectThrow(
+      web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[1],
+        gas: 7000000,
+        data: oracle2.methods.withdrawStake().encodeABI(),
+      })
+    );
+    s = await oracle.getStakerInfo(accounts[1]);
+    assert(s[0] == 1, " Staked");
+    assert(
+      web3.utils.fromWei(balance1b) == 1000,
+      "Balance should equal transferred amt"
+    );
+  });
+  it("Attempt to transfer more than balance - stake", async function() {
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods
+        .theLazyCoon(accounts[2], web3.utils.toWei("5000", "ether"))
+        .encodeABI(),
+    });
+    var tokens = web3.utils.toWei("1", "ether");
+    var tokens2 = web3.utils.toWei("2000000", "ether");
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[2],
+      gas: 7000000,
+      data: oracle2.methods.transfer(accounts[1], tokens).encodeABI(),
+    });
+    balance1 = await web3.eth.call({
+      to: oracle.address,
+      data: master.methods.balanceOf(accounts[1]).encodeABI(),
+    });
+    await helper.expectThrow(
+      web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[1],
+        gas: 7000000,
+        data: oracle2.methods.transfer(accounts[1], tokens2).encodeABI(),
+      })
+    );
+    balance1b = await web3.eth.call({
+      to: oracle.address,
+      data: master.methods.balanceOf(accounts[1]).encodeABI(),
+    });
+    assert(
+      web3.utils.fromWei(balance1b) == 1001,
+      "Balance should == (1000 + tokens)"
+    );
+  });
+  it("re-Staking without withdraw ", async function() {
+    await helper.advanceTime(86400 * 10);
+    let withdrawreq = await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[1],
+      gas: 7000000,
+      data: oracle2.methods.requestStakingWithdraw().encodeABI(),
+    });
+    let weSender = await web3.eth.abi.decodeParameter(
+      "address",
+      withdrawreq.logs[0].topics[1]
+    );
+    assert(weSender == accounts[1], "withdraw request by account 1");
+    await helper.advanceTime(86400 * 10);
+    let s = await oracle.getStakerInfo(accounts[1]);
+    assert(s[0] != 1, "is not Staked");
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[1],
+      gas: 7000000,
+      data: oracle2.methods.depositStake().encodeABI(),
+    });
+    s = await oracle.getStakerInfo(accounts[1]);
+    assert(s[0] == 1, "is not Staked");
+  });
+  it("withdraw and re-stake", async function() {
+    await helper.advanceTime(86400 * 10);
+    let withdrawreq = await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[1],
+      gas: 7000000,
+      data: oracle2.methods.requestStakingWithdraw().encodeABI(),
+    });
+    let weSender = await web3.eth.abi.decodeParameter(
+      "address",
+      withdrawreq.logs[0].topics[1]
+    );
+    assert(weSender == accounts[1], "withdraw request by account 1");
+    await helper.advanceTime(86400 * 10);
+    let s = await oracle.getStakerInfo(accounts[1]);
+    assert(s[0] != 1, "is not Staked");
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[1],
+      gas: 7000000,
+      data: oracle2.methods.withdrawStake().encodeABI(),
+    });
+    s = await oracle.getStakerInfo(accounts[1]);
+    assert(s[0] != 1, " not Staked");
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[1],
+      gas: 7000000,
+      data: oracle2.methods.depositStake().encodeABI(),
+    });
+    s = await oracle.getStakerInfo(accounts[1]);
+    assert(s[0] == 1, " Staked");
+  });
+  it("Token transfer", async function() {
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods
+        .theLazyCoon(accounts[2], web3.utils.toWei("5000", "ether"))
+        .encodeABI(),
+    });
+    balance2 = await web3.eth.call({
+      to: oracle.address,
+      data: master.methods.balanceOf(accounts[2]).encodeABI(),
+    });
+    t = web3.utils.toWei("5", "ether");
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[2],
+      gas: 700000,
+      data: oracle2.methods.transfer(accounts[5], t).encodeABI(),
+    });
+    balance2a = await web3.eth.call({
+      to: oracle.address,
+      data: master.methods.balanceOf(accounts[2]).encodeABI(),
+    });
+    balance5 = await web3.eth.call({
+      to: oracle.address,
+      data: master.methods.balanceOf(accounts[5]).encodeABI(),
+    });
+    assert(
+      web3.utils.fromWei(balance2a, "ether") == 4995,
+      web3.utils.fromWei(balance2a, "ether") + "should be 995"
+    );
+    assert(web3.utils.fromWei(balance5) == 1005, "balance for acct 5 is 1005");
+  });
+  it("Approve and transferFrom", async function() {
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods
+        .theLazyCoon(accounts[2], web3.utils.toWei("5000", "ether"))
+        .encodeABI(),
+    });
+    t = web3.utils.toWei("7", "ether");
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[2],
+      gas: 700000,
+      data: oracle2.methods.approve(accounts[1], t).encodeABI(),
+    });
+    balance0a = await web3.eth.call({
+      to: oracle.address,
+      data: master.methods.balanceOf(accounts[2]).encodeABI(),
+    });
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[1],
+      gas: 700000,
+      data: oracle2.methods
+        .transferFrom(accounts[2], accounts[5], t)
+        .encodeABI(),
+    });
+    balance5a = await web3.eth.call({
+      to: oracle.address,
+      data: master.methods.balanceOf(accounts[5]).encodeABI(),
+    });
+    assert(web3.utils.fromWei(balance5a) == 1007, "balance for acct 5 is 1007");
+  });
+  it("Allowance after approve and transferFrom", async function() {
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods
+        .theLazyCoon(accounts[2], web3.utils.toWei("5000", "ether"))
+        .encodeABI(),
+    });
+    t = web3.utils.toWei("7", "ether");
+    t2 = web3.utils.toWei("6", "ether");
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[2],
+      gas: 700000,
+      data: oracle2.methods.approve(accounts[1], t).encodeABI(),
+    });
+    balance0a = await web3.eth.call({
+      to: oracle.address,
+      data: master.methods.balanceOf(accounts[2]).encodeABI(),
+    });
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[1],
+      gas: 700000,
+      data: oracle2.methods
+        .transferFrom(accounts[2], accounts[5], t2)
+        .encodeABI(),
+    });
+    balance5a = await web3.eth.call({
+      to: oracle.address,
+      data: master.methods.balanceOf(accounts[5]).encodeABI(),
+    });
+    assert.equal(
+      web3.utils.fromWei(balance5a),
+      1006,
+      "balance for acct 5 is 1006"
+    );
+    allow = await web3.eth.call({
+      to: oracle.address,
+      data: master.methods.allowance(accounts[2], accounts[1]).encodeABI(),
+    });
+    assert.equal(
+      web3.utils.fromWei(allow, "ether"),
+      1,
+      "Allowance shoudl be 1 eth"
+    );
+  });
+});

--- a/test/furtherTests.js
+++ b/test/furtherTests.js
@@ -12,7 +12,7 @@ const helper = require("./helpers/test_helpers");
 const Utilities = artifacts.require("./libraries/Utilities.sol");
 const UtilitiesTests = artifacts.require("./UtilitiesTests.sol");
 const TellorMaster = artifacts.require("./TellorMaster.sol");
-const Tellor = artifacts.require("./Tellor.sol"); // globally injected artifacts helper
+const Tellor = artifacts.require("./TellorTest.sol"); // globally injected artifacts helper
 
 var oracleAbi = Tellor.abi;
 var masterAbi = TellorMaster.abi;

--- a/test/furtherTestswUpgrade.js
+++ b/test/furtherTestswUpgrade.js
@@ -4,7 +4,7 @@ const web3 = new Web3(
 );
 const helper = require("./helpers/test_helpers");
 const TellorMaster = artifacts.require("./TellorMaster.sol");
-const Tellor = artifacts.require("./Tellor.sol"); // globally injected artifacts helper
+const Tellor = artifacts.require("./TellorTest.sol"); // globally injected artifacts helper
 var oracleAbi = Tellor.abi;
 var oracleByte = Tellor.bytecode;
 var OldTellor = artifacts.require("./oldContracts/OldTellor.sol");
@@ -63,9 +63,11 @@ contract("Further Tests w/ Upgrade", function(accounts) {
         to: oracle.address,
         from: accounts[i],
         gas: 7000000,
-        data: oracle2.methods[
-          "testSubmitMiningSolution(string,uint256[5],uint256[5])"
-        ]("nonce", [1, 2, 3, 4, 5], [1100, 1200, 1300, 1400, 1500]).encodeABI(),
+        data: oracle2.methods["submitMiningSolution(string,uint256,uint256)"](
+          "nonce",
+          1,
+          1200
+        ).encodeABI(),
       });
     }
   });

--- a/test/furtherTestswUpgrade.js
+++ b/test/furtherTestswUpgrade.js
@@ -64,8 +64,8 @@ contract("Further Tests w/ Upgrade", function(accounts) {
         from: accounts[i],
         gas: 7000000,
         data: oracle2.methods[
-          "testSubmitMiningSolution(string,uint256,uint256)"
-        ]("nonce", 1, 1200).encodeABI(),
+          "testSubmitMiningSolution(string,uint256[5],uint256[5])"
+        ]("nonce", [1, 2, 3, 4, 5], [1100, 1200, 1300, 1400, 1500]).encodeABI(),
       });
     }
   });

--- a/test/furtherTestswUpgrade.js
+++ b/test/furtherTestswUpgrade.js
@@ -1,231 +1,392 @@
-// const Web3 = require('web3')
-// const web3 = new Web3(new Web3.providers.WebsocketProvider('ws://localhost:8545'));
-// const helper = require("./helpers/test_helpers");
-// const TellorMaster = artifacts.require("./TellorMaster.sol");
-// const Tellor = artifacts.require("./Tellor.sol"); // globally injected artifacts helper
-// var oracleAbi = Tellor.abi;
-// var oracleByte = Tellor.bytecode;
-// var OldTellor = artifacts.require("./oldContracts/OldTellor.sol")
-// var oldTellorABI = OldTellor.abi;
-// var UtilitiesTests = artifacts.require("./UtilitiesTests.sol")
+const Web3 = require("web3");
+const web3 = new Web3(
+  new Web3.providers.WebsocketProvider("ws://localhost:8545")
+);
+const helper = require("./helpers/test_helpers");
+const TellorMaster = artifacts.require("./TellorMaster.sol");
+const Tellor = artifacts.require("./Tellor.sol"); // globally injected artifacts helper
+var oracleAbi = Tellor.abi;
+var oracleByte = Tellor.bytecode;
+var OldTellor = artifacts.require("./oldContracts/OldTellor.sol");
+var oldTellorABI = OldTellor.abi;
+var UtilitiesTests = artifacts.require("./UtilitiesTests.sol");
 
-// var masterAbi = TellorMaster.abi;
-// var api = "json(https://api.gdax.com/products/BTC-USD/ticker).price";
-// var api2 = "json(https://api.gdax.com/products/ETH-USD/ticker).price";
+var masterAbi = TellorMaster.abi;
+var api = "json(https://api.gdax.com/products/BTC-USD/ticker).price";
+var api2 = "json(https://api.gdax.com/products/ETH-USD/ticker).price";
 
-// contract('Further Tests w/ Upgrade', function(accounts) {
-//   let oracleBase;
-//   let oracle;
-//   let oracle2;
-//   let master;
-//   let oldTellor;
-//   let oldTellorinst;
-//   let utilities;
+contract("Further Tests w/ Upgrade", function(accounts) {
+  let oracleBase;
+  let oracle;
+  let oracle2;
+  let master;
+  let oldTellor;
+  let oldTellorinst;
+  let utilities;
 
-//     beforeEach('Setup contract for each test', async function () {
-//         //deploy old, request, update address, mine old challenge.
-//         oldTellor = await OldTellor.new()    
-//         oracle = await TellorMaster.new(oldTellor.address);
-//         master = await new web3.eth.Contract(masterAbi,oracle.address);
-//         oldTellorinst = await new web3.eth.Contract(oldTellorABI,oldTellor.address);
-//         for(var i = 0;i<6;i++){
-//             //print tokens 
-//             await web3.eth.sendTransaction({to:oracle.address,from:accounts[0],gas:7000000,data:oldTellorinst.methods.theLazyCoon(accounts[i],web3.utils.toWei('1100', 'ether')).encodeABI()})
-//         }
-//         for(var i=0; i<52;i++){
-//             x = "USD" + i
-//             apix = api + i
-//             await web3.eth.sendTransaction({to: oracle.address,from:accounts[0],gas:7000000,data:oldTellorinst.methods.requestData(apix,x,1000,0).encodeABI()})
-//         }
-//         //Deploy new upgraded Tellor
-//         oracleBase = await Tellor.new();
-//         oracle2 = await new web3.eth.Contract(oracleAbi,oracle.address);
-//         await oracle.changeTellorContract(oracleBase.address)
-//         for(var i = 0;i<5;i++){
-//           await web3.eth.sendTransaction({to:oracle.address,from:accounts[i],gas:7000000,data:oracle2.methods['testSubmitMiningSolution(string,uint256,uint256)']("nonce",1,1200).encodeABI()})
-//         }
-//     });
-  
-//      it("test utilities",async function(){
-//         var myArr = []
-//         for(var i=50;i>=0;i--){
-//             myArr.push(i)
-//         }
-//         utilities = await UtilitiesTests.new(oracle.address)
-//         let minT = await utilities.testgetMins(myArr)
-//         assert(minT[0] == 0)
-//         assert(minT[1] == 50, "index should be correct")
-//     });
-//    it("Add Tip", async function () {
-//         res = await web3.eth.sendTransaction({to: oracle.address,from:accounts[0],gas:7000000,data:oracle2.methods.addTip(11,20).encodeABI()})
-//         apiVars = await oracle.getRequestVars(11);
-//         assert(apiVars[5] == 20, "value pool should be 20");
-//     });
-//     it("several request data", async function () {
-//         let req1 = await web3.eth.sendTransaction({to: oracle.address,from:accounts[2],gas:7000000,data:oracle2.methods.addTip(41,100).encodeABI()})
-//         req1 = await web3.eth.sendTransaction({to: oracle.address,from:accounts[2],gas:7000000,data:oracle2.methods.addTip(42,100).encodeABI()})
-//         req1 = await web3.eth.sendTransaction({to: oracle.address,from:accounts[2],gas:7000000,data:oracle2.methods.addTip(43,100).encodeABI()})
-//         req1 = await web3.eth.sendTransaction({to: oracle.address,from:accounts[2],gas:7000000,data:oracle2.methods.addTip(44,100).encodeABI()})
-//         req1 = await web3.eth.sendTransaction({to: oracle.address,from:accounts[2],gas:7000000,data:oracle2.methods.addTip(31,20).encodeABI()})
-//         data = await oracle2.methods.getNewVariablesOnDeck().call();
-//         assert(data[0].includes('41'), 'ID on deck should be 41');
-//         assert(data[0].includes('31'), 'ID on deck should be 31');
-//         assert(data[1].includes('20'), 'Tip should be over 20');
-//        req1 = await web3.eth.sendTransaction({to: oracle.address,from:accounts[2],gas:7000000,data:oracle2.methods.addTip(32,40).encodeABI()})
-//         data = await oracle2.methods.getNewVariablesOnDeck().call();
-//          assert(data[0].includes('42'), 'ID on deck should be 41');
-//         assert(data[0].includes('32'), 'ID on deck should be 30');
-//         assert(data[1].includes('40'), 'Tip should be 30');
-//        req1 = await web3.eth.sendTransaction({to: oracle.address,from:accounts[2],gas:7000000,data:oracle2.methods.addTip(33,50).encodeABI()})
-//         data = await oracle2.methods.getNewVariablesOnDeck().call();
-//          assert(data[0].includes('43'), 'ID on deck should be 43');
-//         assert(data[0].includes('33'), 'ID on deck should be 30');
-//         assert(data[1].includes('50'), 'Tip should be 50');
-//        req1 = await web3.eth.sendTransaction({to: oracle.address,from:accounts[2],gas:7000000,data:oracle2.methods.addTip(34,60).encodeABI()})
-//         data = await oracle2.methods.getNewVariablesOnDeck().call();
-//          assert(data[0].includes('44'), 'ID on deck should be 44');
-//         assert(data[0].includes('34'), 'ID on deck should be 30');
-//         assert(data[1].includes('60'), 'Tip should be 60');
-//     });
-//     it("Request data and change on queue with another request", async function () {
-//     	balance1 = await (oracle.balanceOf(accounts[2],{from:accounts[1]}));
-//         let pay = web3.utils.toWei('20', 'ether');
-//         let pay2 = web3.utils.toWei('50', 'ether');
-//         let res3 = await web3.eth.sendTransaction({to: oracle.address,from:accounts[2],gas:7000000,data:oracle2.methods.addTip(31,pay).encodeABI()})
-//         apiVars = await oracle.getRequestVars(31)
-//         assert( apiVars[5] == pay, "value pool should be 20");
-//         data = await oracle2.methods.getNewVariablesOnDeck().call();
-//         assert(data[0].includes('31'), 'ID on deck should be 31');
-//         res3 = await web3.eth.sendTransaction({to: oracle.address,from:accounts[2],gas:7000000,data:oracle2.methods.addTip(32, pay2).encodeABI()})
-//         data = await oracle2.methods.getNewVariablesOnDeck().call();
-//         assert(data[0].includes('31'), 'ID on deck should be 31');
-//         assert(data[0].includes('32'), 'ID on deck should be 31');
-//         assert(data[1].includes(pay), 'ID on deck should be 31');
-//         assert(data[1].includes(pay2), 'ID on deck should be 31');
-//         balance2 = await (oracle.balanceOf(accounts[2],{from:accounts[1]}));
-//         assert(web3.utils.fromWei(balance1) - web3.utils.fromWei(balance2) == 70, "balance should be down by 70");
-//     });
-//     it("Test getMax payout and index 51 req with overlapping tips and requests", async function () {
-//         utilities = await UtilitiesTests.new(oracle.address);
-//          for(var i = 1;i <=21 ;i++){
-//         	//apix= ("api" + i);
-//         	await web3.eth.sendTransaction({to: oracle.address,from:accounts[2],gas:7000000,data:oracle2.methods.addTip(i,i).encodeABI()})
-//         }
-//        for(var j = 15;j <= 45 ;j++){
-//         	apix= ("api" + j);
-//         	await web3.eth.sendTransaction({to: oracle.address,from:accounts[2],gas:7000000,data:oracle2.methods.addTip(j,j).encodeABI()})
-//         } 
-//         max = await utilities.testgetMax();
-//         assert(web3.utils.hexToNumberString(max[0])== 45, "Max should be 45")
-//         assert(web3.utils.hexToNumberString(max[1])== 11, "Max should be 11")//note first 5 are added
-//     });
+  beforeEach("Setup contract for each test", async function() {
+    //deploy old, request, update address, mine old challenge.
+    oldTellor = await OldTellor.new();
+    oracle = await TellorMaster.new(oldTellor.address);
+    master = await new web3.eth.Contract(masterAbi, oracle.address);
+    oldTellorinst = await new web3.eth.Contract(
+      oldTellorABI,
+      oldTellor.address
+    );
+    for (var i = 0; i < 6; i++) {
+      //print tokens
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[0],
+        gas: 7000000,
+        data: oldTellorinst.methods
+          .theLazyCoon(accounts[i], web3.utils.toWei("1100", "ether"))
+          .encodeABI(),
+      });
+    }
+    for (var i = 0; i < 52; i++) {
+      x = "USD" + i;
+      apix = api + i;
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[0],
+        gas: 7000000,
+        data: oldTellorinst.methods.requestData(apix, x, 1000, 0).encodeABI(),
+      });
+    }
+    //Deploy new upgraded Tellor
+    oracleBase = await Tellor.new();
+    oracle2 = await new web3.eth.Contract(oracleAbi, oracle.address);
+    await oracle.changeTellorContract(oracleBase.address);
+    for (var i = 0; i < 5; i++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods[
+          "testSubmitMiningSolution(string,uint256,uint256)"
+        ]("nonce", 1, 1200).encodeABI(),
+      });
+    }
+  });
 
-//     it("Test getMax payout and index 60 requests", async function () {
-//         utilities = await UtilitiesTests.new(oracle.address);
-//          for(var i = 1;i <=60 ;i++){
-//         	apix= ("api" + i);
-//         	await web3.eth.sendTransaction({to: oracle.address,from:accounts[2],gas:7000000,data:oracle2.methods.addTip(i,i).encodeABI()})
-//         }
-//         max = await utilities.testgetMax();
-//         assert(max[0]== 60, "Max should be 60")
-//         assert(max[1]== 46, "Max should be 46")    
-//     });
+  it("test utilities", async function() {
+    var myArr = [];
+    for (var i = 50; i >= 0; i--) {
+      myArr.push(i);
+    }
+    utilities = await UtilitiesTests.new(oracle.address);
+    let minT = await utilities.testgetMins(myArr);
+    assert(minT[0] == 0);
+    assert(minT[1] == 50, "index should be correct");
+  });
+  it("Add Tip", async function() {
+    res = await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods.addTip(11, 20).encodeABI(),
+    });
+    apiVars = await oracle.getRequestVars(11);
+    assert(apiVars[5] == 20, "value pool should be 20");
+  });
+  it("several request data", async function() {
+    let req1 = await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[2],
+      gas: 7000000,
+      data: oracle2.methods.addTip(41, 100).encodeABI(),
+    });
+    req1 = await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[2],
+      gas: 7000000,
+      data: oracle2.methods.addTip(42, 100).encodeABI(),
+    });
+    req1 = await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[2],
+      gas: 7000000,
+      data: oracle2.methods.addTip(43, 100).encodeABI(),
+    });
+    req1 = await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[2],
+      gas: 7000000,
+      data: oracle2.methods.addTip(44, 100).encodeABI(),
+    });
+    req1 = await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[2],
+      gas: 7000000,
+      data: oracle2.methods.addTip(31, 20).encodeABI(),
+    });
+    data = await oracle2.methods.getNewVariablesOnDeck().call();
+    assert(data[0].includes("41"), "ID on deck should be 41");
+    assert(data[0].includes("31"), "ID on deck should be 31");
+    assert(data[1].includes("20"), "Tip should be over 20");
+    req1 = await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[2],
+      gas: 7000000,
+      data: oracle2.methods.addTip(32, 40).encodeABI(),
+    });
+    data = await oracle2.methods.getNewVariablesOnDeck().call();
+    assert(data[0].includes("42"), "ID on deck should be 41");
+    assert(data[0].includes("32"), "ID on deck should be 30");
+    assert(data[1].includes("40"), "Tip should be 30");
+    req1 = await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[2],
+      gas: 7000000,
+      data: oracle2.methods.addTip(33, 50).encodeABI(),
+    });
+    data = await oracle2.methods.getNewVariablesOnDeck().call();
+    assert(data[0].includes("43"), "ID on deck should be 43");
+    assert(data[0].includes("33"), "ID on deck should be 30");
+    assert(data[1].includes("50"), "Tip should be 50");
+    req1 = await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[2],
+      gas: 7000000,
+      data: oracle2.methods.addTip(34, 60).encodeABI(),
+    });
+    data = await oracle2.methods.getNewVariablesOnDeck().call();
+    assert(data[0].includes("44"), "ID on deck should be 44");
+    assert(data[0].includes("34"), "ID on deck should be 30");
+    assert(data[1].includes("60"), "Tip should be 60");
+  });
+  it("Request data and change on queue with another request", async function() {
+    balance1 = await oracle.balanceOf(accounts[2], { from: accounts[1] });
+    let pay = web3.utils.toWei("20", "ether");
+    let pay2 = web3.utils.toWei("50", "ether");
+    let res3 = await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[2],
+      gas: 7000000,
+      data: oracle2.methods.addTip(31, pay).encodeABI(),
+    });
+    apiVars = await oracle.getRequestVars(31);
+    assert(apiVars[5] == pay, "value pool should be 20");
+    data = await oracle2.methods.getNewVariablesOnDeck().call();
+    assert(data[0].includes("31"), "ID on deck should be 31");
+    res3 = await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[2],
+      gas: 7000000,
+      data: oracle2.methods.addTip(32, pay2).encodeABI(),
+    });
+    data = await oracle2.methods.getNewVariablesOnDeck().call();
+    assert(data[0].includes("31"), "ID on deck should be 31");
+    assert(data[0].includes("32"), "ID on deck should be 31");
+    assert(data[1].includes(pay), "ID on deck should be 31");
+    assert(data[1].includes(pay2), "ID on deck should be 31");
+    balance2 = await oracle.balanceOf(accounts[2], { from: accounts[1] });
+    assert(
+      web3.utils.fromWei(balance1) - web3.utils.fromWei(balance2) == 70,
+      "balance should be down by 70"
+    );
+  });
+  it("Test getMax payout and index 51 req with overlapping tips and requests", async function() {
+    utilities = await UtilitiesTests.new(oracle.address);
+    for (var i = 1; i <= 21; i++) {
+      //apix= ("api" + i);
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[2],
+        gas: 7000000,
+        data: oracle2.methods.addTip(i, i).encodeABI(),
+      });
+    }
+    for (var j = 15; j <= 45; j++) {
+      apix = "api" + j;
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[2],
+        gas: 7000000,
+        data: oracle2.methods.addTip(j, j).encodeABI(),
+      });
+    }
+    max = await utilities.testgetMax();
+    assert(web3.utils.hexToNumberString(max[0]) == 45, "Max should be 45");
+    assert(web3.utils.hexToNumberString(max[1]) == 11, "Max should be 11"); //note first 5 are added
+  });
 
-//     it("Test getMax payout and index 100 requests", async function () {
-//     	utilities = await UtilitiesTests.new(oracle.address)
-//          for(var i = 1;i <=55 ;i++){
-//         	apix= ("api" + i);
-//         	await web3.eth.sendTransaction({to: oracle.address,from:accounts[2],gas:7000000,data:oracle2.methods.addTip(i,i).encodeABI()})
-//         }
-//         for(var j = 50;j <= 95 ;j++){
-//         	apix= ("api" + j);
-//         	await web3.eth.sendTransaction({to: oracle.address,from:accounts[2],gas:7000000,data:oracle2.methods.addTip(j,j).encodeABI()})
-//         } 
+  it("Test getMax payout and index 60 requests", async function() {
+    utilities = await UtilitiesTests.new(oracle.address);
+    for (var i = 1; i <= 60; i++) {
+      apix = "api" + i;
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[2],
+        gas: 7000000,
+        data: oracle2.methods.addTip(i, i).encodeABI(),
+      });
+    }
+    max = await utilities.testgetMax();
+    assert(max[0] == 60, "Max should be 60");
+    assert(max[1] == 46, "Max should be 46");
+  });
 
-//         req = await oracle.getRequestQ();
-//         max = await utilities.testgetMax();
-//         assert(max[0] == 110, "Max should be 110")
-//         assert(max[1] == 1, "Max should be 46") 
-//     });
+  it("Test getMax payout and index 100 requests", async function() {
+    utilities = await UtilitiesTests.new(oracle.address);
+    for (var i = 1; i <= 55; i++) {
+      apix = "api" + i;
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[2],
+        gas: 7000000,
+        data: oracle2.methods.addTip(i, i).encodeABI(),
+      });
+    }
+    for (var j = 50; j <= 95; j++) {
+      apix = "api" + j;
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[2],
+        gas: 7000000,
+        data: oracle2.methods.addTip(j, j).encodeABI(),
+      });
+    }
 
-//     it("utilities Test getMin payout and index 10 req with overlapping tips and requests", async function () {
-//    	    utilities = await UtilitiesTests.new(oracle.address)
-//    	    apiVars= await oracle.getRequestVars(1);
-//    	    apiIdforpayoutPoolIndex = await oracle.getRequestIdByRequestQIndex(0);
-//         apiId = await oracle.getRequestIdByQueryHash(apiVars[2]);
-//         assert(web3.utils.hexToNumberString(apiId) == 1, "timestamp on Q should be 1");
-//          for(var i = 10;i >=1 ;i--){
-//         	apix= ("api" + i);
-//         	await web3.eth.sendTransaction({to: oracle.address,from:accounts[2],gas:7000000,data:oracle2.methods.addTip(i,i).encodeABI()})
-//         }
+    req = await oracle.getRequestQ();
+    max = await utilities.testgetMax();
+    assert(max[0] == 110, "Max should be 110");
+    assert(max[1] == 1, "Max should be 46");
+  });
 
-//         req = await oracle.getRequestQ();
-//         min = await utilities.testgetMin();
-//         assert(min[0]== 0, "Min should be 0")
-//         assert(min[1] == 45, "Min should be 40")
-//     });
+  it("utilities Test getMin payout and index 10 req with overlapping tips and requests", async function() {
+    utilities = await UtilitiesTests.new(oracle.address);
+    apiVars = await oracle.getRequestVars(1);
+    apiIdforpayoutPoolIndex = await oracle.getRequestIdByRequestQIndex(0);
+    apiId = await oracle.getRequestIdByQueryHash(apiVars[2]);
+    assert(
+      web3.utils.hexToNumberString(apiId) == 1,
+      "timestamp on Q should be 1"
+    );
+    for (var i = 10; i >= 1; i--) {
+      apix = "api" + i;
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[2],
+        gas: 7000000,
+        data: oracle2.methods.addTip(i, i).encodeABI(),
+      });
+    }
 
+    req = await oracle.getRequestQ();
+    min = await utilities.testgetMin();
+    assert(min[0] == 0, "Min should be 0");
+    assert(min[1] == 45, "Min should be 40");
+  });
 
-//     it("Test getMin payout and index 51 req count down with overlapping tips and requests", async function () {
-//    	    utilities = await UtilitiesTests.new(oracle.address)
-//    	    apiVars= await oracle.getRequestVars(1);
-//         apiIdforpayoutPoolIndex = await oracle.getRequestIdByRequestQIndex(0);
-//         apiId = await oracle.getRequestIdByQueryHash(apiVars[2]);
-//         assert(web3.utils.hexToNumberString(apiId) == 1, "timestamp on Q should be 1");
-//          for(var i = 21;i >=1 ;i--){
-//         	apix= ("api" + i);
-//         	await web3.eth.sendTransaction({to: oracle.address,from:accounts[2],gas:7000000,data:oracle2.methods.addTip(i,i).encodeABI()})
-//         }
+  it("Test getMin payout and index 51 req count down with overlapping tips and requests", async function() {
+    utilities = await UtilitiesTests.new(oracle.address);
+    apiVars = await oracle.getRequestVars(1);
+    apiIdforpayoutPoolIndex = await oracle.getRequestIdByRequestQIndex(0);
+    apiId = await oracle.getRequestIdByQueryHash(apiVars[2]);
+    assert(
+      web3.utils.hexToNumberString(apiId) == 1,
+      "timestamp on Q should be 1"
+    );
+    for (var i = 21; i >= 1; i--) {
+      apix = "api" + i;
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[2],
+        gas: 7000000,
+        data: oracle2.methods.addTip(i, i).encodeABI(),
+      });
+    }
 
-//         for(var j = 45;j >= 15 ;j--){
-//         	apix= ("api" + j);
-//         	await web3.eth.sendTransaction({to: oracle.address,from:accounts[2],gas:7000000,data:oracle2.methods.addTip(j,j).encodeABI()})
-//         } 
+    for (var j = 45; j >= 15; j--) {
+      apix = "api" + j;
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[2],
+        gas: 7000000,
+        data: oracle2.methods.addTip(j, j).encodeABI(),
+      });
+    }
 
-//         req = await oracle.getRequestQ();
-//         min = await utilities.testgetMin();
-//         assert(min[0]== 0, "Min should be 0")
-//         assert(min[1] == 10, "Min should be 5")
-//         assert(req[44]==30, "request 15 is submitted twice this should be 30")
-//         assert(req[50]==42, "request 21 is submitted twice this should be 42")
-      
-//     });
+    req = await oracle.getRequestQ();
+    min = await utilities.testgetMin();
+    assert(min[0] == 0, "Min should be 0");
+    assert(min[1] == 10, "Min should be 5");
+    assert(req[44] == 30, "request 15 is submitted twice this should be 30");
+    assert(req[50] == 42, "request 21 is submitted twice this should be 42");
+  });
 
-//     it("Test getMin payout and index 55 requests", async function () {
-//         utilities = await UtilitiesTests.new(oracle.address)
-//          for(var i = 1;i <=55 ;i++){
-//         	apix= ("api" + i);
-//         	await web3.eth.sendTransaction({to: oracle.address,from:accounts[2],gas:7000000,data:oracle2.methods.addTip(i,i).encodeABI()})
-//         }
-//         req = await oracle.getRequestQ();
-//         min = await utilities.testgetMins(req);
-//         assert(min[0]== 6, "Min should be 6")
-//         assert(min[1]== 50, "Min should be 45")    
-//     });
+  it("Test getMin payout and index 55 requests", async function() {
+    utilities = await UtilitiesTests.new(oracle.address);
+    for (var i = 1; i <= 55; i++) {
+      apix = "api" + i;
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[2],
+        gas: 7000000,
+        data: oracle2.methods.addTip(i, i).encodeABI(),
+      });
+    }
+    req = await oracle.getRequestQ();
+    min = await utilities.testgetMins(req);
+    assert(min[0] == 6, "Min should be 6");
+    assert(min[1] == 50, "Min should be 45");
+  });
 
-//    it("Test 51 request and lowest is kicked out", async function () {
-//          for(var i = 1;i <=56 ;i++){
-//         	apix= ("api" + i);
-//         	await web3.eth.sendTransaction({to: oracle.address,from:accounts[2],gas:7000000,data:oracle2.methods.addTip(i,i).encodeABI()})
-//         }
-//         let payoutPool = await oracle.getRequestQ();
-//         for(var i = 6;i <=45 ;i++){
-//         	assert(payoutPool[i] == 51-i+5,"should be equal")
-//         }
-//         apiVars= await oracle.getRequestVars(52)
-//         apiIdforpayoutPoolIndex = await oracle.getRequestIdByRequestQIndex(50);
-//         vars = await oracle2.methods.getNewVariablesOnDeck().call();
-//         let apiOnQ = vars[0];
-//         let apiPayout = vars[1];
-//         assert(apiIdforpayoutPoolIndex == 56, "position 1 should be booted"); 
-//         assert(apiPayout.includes('56'), "API on Q payout should be 51"); 
-//         assert(apiOnQ.includes('56'), "API on Q should be 51"); 
-//         assert(apiVars[4] == 4, "position 1 should have correct value"); 
-//    });
+  it("Test 51 request and lowest is kicked out", async function() {
+    for (var i = 1; i <= 56; i++) {
+      apix = "api" + i;
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[2],
+        gas: 7000000,
+        data: oracle2.methods.addTip(i, i).encodeABI(),
+      });
+    }
+    let payoutPool = await oracle.getRequestQ();
+    for (var i = 6; i <= 45; i++) {
+      assert(payoutPool[i] == 51 - i + 5, "should be equal");
+    }
+    apiVars = await oracle.getRequestVars(52);
+    apiIdforpayoutPoolIndex = await oracle.getRequestIdByRequestQIndex(50);
+    vars = await oracle2.methods.getNewVariablesOnDeck().call();
+    let apiOnQ = vars[0];
+    let apiPayout = vars[1];
+    assert(apiIdforpayoutPoolIndex == 56, "position 1 should be booted");
+    assert(apiPayout.includes("56"), "API on Q payout should be 51");
+    assert(apiOnQ.includes("56"), "API on Q should be 51");
+    assert(apiVars[4] == 4, "position 1 should have correct value");
+  });
 
-//     it("Test Throw on wrong apiId", async function () {
-//      	await helper.expectThrow(web3.eth.sendTransaction({to:oracle.address,from:accounts[0],gas:7000000,data:oracle2.methods.testSubmitMiningSolution("nonce",[6,2,3,4,5],[1200,1300,1400,1500,1600]).encodeABI()}) );
-//         for(var i = 0;i<5;i++){
-//             res = await web3.eth.sendTransaction({to:oracle.address,from:accounts[i],gas:7000000,data:oracle2.methods.testSubmitMiningSolution("nonce",[1,2,3,4,5],[1200,1300,1400,1500,1600]).encodeABI()})
-//         }});
-//  });
+  it("Test Throw on wrong apiId", async function() {
+    await helper.expectThrow(
+      web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[0],
+        gas: 7000000,
+        data: oracle2.methods
+          .testSubmitMiningSolution(
+            "nonce",
+            [6, 2, 3, 4, 5],
+            [1200, 1300, 1400, 1500, 1600]
+          )
+          .encodeABI(),
+      })
+    );
+    for (var i = 0; i < 5; i++) {
+      res = await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods
+          .testSubmitMiningSolution(
+            "nonce",
+            [1, 2, 3, 4, 5],
+            [1200, 1300, 1400, 1500, 1600]
+          )
+          .encodeABI(),
+      });
+    }
+  });
+});

--- a/test/gasTests.js
+++ b/test/gasTests.js
@@ -1,67 +1,67 @@
-// const Web3 = require("web3");
-// const web3 = new Web3(
-//   new Web3.providers.WebsocketProvider("ws://localhost:8545")
-// );
+const Web3 = require("web3");
+const web3 = new Web3(
+  new Web3.providers.WebsocketProvider("ws://localhost:8545")
+);
 
-// const Tellor = artifacts.require("MockTellor.sol"); // globally injected artifacts helper
-// const RefTellor = artifacts.require("RefTellor.sol");
+const Tellor = artifacts.require("MockTellor.sol"); // globally injected artifacts helper
+const RefTellor = artifacts.require("RefTellor.sol");
 
-// contract("Gas Tests", function(accounts) {
-//   let oracleBase;
-//   let oracle;
-//   let oracleRef;
-//   let master;
-//   let oldTellor;
-//   let oldTellorinst;
-//   let utilities;
+contract("Gas Tests", function(accounts) {
+  let oracleBase;
+  let oracle;
+  let oracleRef;
+  let master;
+  let oldTellor;
+  let oldTellorinst;
+  let utilities;
 
-//   beforeEach("Setup contract for each test", async function() {
-//     oracle = await Tellor.new();
-//     oracleRef = await RefTellor.new();
-//     await oracle.theLazyCoon(accounts[0], web3.utils.toWei("7000", "ether"));
-//     await oracleRef.theLazyCoon(accounts[0], web3.utils.toWei("7000", "ether"));
-//   });
+  beforeEach("Setup contract for each test", async function() {
+    oracle = await Tellor.new();
+    oracleRef = await RefTellor.new();
+    await oracle.theLazyCoon(accounts[0], web3.utils.toWei("7000", "ether"));
+    await oracleRef.theLazyCoon(accounts[0], web3.utils.toWei("7000", "ether"));
+  });
 
-//   it("SubmitMinningSolution", async () => {
-//     let gases = [];
-//     let refs = [];
-//     for (var i = 0; i < 5; i++) {
-//       let receipt = await oracle.submitMiningSolution(
-//         "nonce",
-//         [1, 2, 3, 4, 5],
-//         [1600, 1500, 1400, 1300, 1200],
-//         { from: accounts[i] }
-//       );
-//       gases.push(receipt.receipt.gasUsed);
+  it("SubmitMinningSolution", async () => {
+    let gases = [];
+    let refs = [];
+    for (var i = 0; i < 5; i++) {
+      let receipt = await oracle.submitMiningSolution(
+        "nonce",
+        [1, 2, 3, 4, 5],
+        [1600, 1500, 1400, 1300, 1200],
+        { from: accounts[i] }
+      );
+      gases.push(receipt.receipt.gasUsed);
 
-//       let bench = await oracleRef.submitMiningSolution(
-//         "nonce",
-//         [1, 2, 3, 4, 5],
-//         [1600, 1500, 1400, 1300, 1200],
-//         { from: accounts[i] }
-//       );
-//       refs.push(bench.receipt.gasUsed);
-//     }
-//     console.log("Gas used: ", gases, "Gas Reference: ", refs);
+      let bench = await oracleRef.submitMiningSolution(
+        "nonce",
+        [1, 2, 3, 4, 5],
+        [1600, 1500, 1400, 1300, 1200],
+        { from: accounts[i] }
+      );
+      refs.push(bench.receipt.gasUsed);
+    }
+    console.log("Gas used: ", gases, "Gas Reference: ", refs);
 
-//     assert.isTrue(gases[4] < refs[4], "Gas did not reduce");
-//   });
+    assert.isTrue(gases[4] < refs[4], "Gas did not reduce");
+  });
 
-//   it("Transfers", async () => {
-//     let gas = await oracle.transfer(
-//       accounts[2],
-//       web3.utils.toWei("1", "ether")
-//     );
-//     let ref = await oracleRef.transfer(
-//       accounts[2],
-//       web3.utils.toWei("1", "ether")
-//     );
-//     console.log(
-//       "Gas used: ",
-//       gas.receipt.gasUsed,
-//       "Gas Reference: ",
-//       ref.receipt.gasUsed
-//     );
-//     assert.isTrue(gas.receipt.gasUsed < ref.receipt.gasUsed);
-//   });
-// });
+  it("Transfers", async () => {
+    let gas = await oracle.transfer(
+      accounts[2],
+      web3.utils.toWei("1", "ether")
+    );
+    let ref = await oracleRef.transfer(
+      accounts[2],
+      web3.utils.toWei("1", "ether")
+    );
+    console.log(
+      "Gas used: ",
+      gas.receipt.gasUsed,
+      "Gas Reference: ",
+      ref.receipt.gasUsed
+    );
+    assert.isTrue(gas.receipt.gasUsed < ref.receipt.gasUsed);
+  });
+});

--- a/test/mocks/TellorLibraryTest.sol
+++ b/test/mocks/TellorLibraryTest.sol
@@ -1,0 +1,21 @@
+pragma solidity ^0.5.16;
+
+
+import "../../contracts/libraries/SafeMath.sol";
+import "../../contracts/libraries/TellorLibrary.sol";
+/**
+ * @title Tellor Oracle System Library
+ * @dev Contains the functions' logic for the Tellor contract where miners can submit the proof of work
+ * along with the value and smart contracts can requestData and tip miners.
+ */
+library TellorLibraryTest {
+
+    using TellorLibrary for TellorStorage.TellorStorageStruct;
+    bytes32 public constant total_supply = 0xb1557182e4359a1f0c6301278e8f5b35a776ab58d39892581e357578fb287836; //keccak256("total_supply")
+
+    /*This is a cheat for demo purposes, will delete upon actual launch*/
+    function theLazyCoon(TellorStorage.TellorStorageStruct storage self,address _address, uint _amount) public {
+        self.uintVars[total_supply] += _amount;
+        TellorTransfer.updateBalanceAtNow(self.balances[_address],_amount);
+    } 
+}

--- a/test/mocks/TellorTest.sol
+++ b/test/mocks/TellorTest.sol
@@ -1,0 +1,31 @@
+pragma solidity ^0.5.16;
+
+
+import "../../contracts/Tellor.sol";
+import "../../contracts/libraries/SafeMath.sol";
+import "../../contracts/libraries/TellorStorage.sol";
+import "../../contracts/libraries/TellorTransfer.sol";
+import "../../contracts/libraries/TellorDispute.sol";
+import "../../contracts/libraries/TellorStake.sol";
+import "../../contracts/libraries/TellorLibrary.sol";
+import "./TellorLibraryTest.sol";
+
+/**
+ * @title Tellor Oracle System
+ * @dev Oracle contract where miners can submit the proof of work along with the value.
+ * The logic for this contract is in TellorLibrary.sol, TellorDispute.sol, TellorStake.sol,
+ * and TellorTransfer.sol
+ */
+contract TellorTest is Tellor {
+
+    using TellorLibraryTest for TellorStorage.TellorStorageStruct;
+
+    function theLazyCoon(address _address, uint _amount) external {
+        tellor.theLazyCoon(_address,_amount);
+    }
+
+    function testSubmitMiningSolution(string calldata _nonce,uint256[5] calldata _requestId, uint256[5] calldata _value) external {
+        tellor._submitMiningSolution(_nonce,_requestId, _value);
+    }
+
+ }

--- a/test/testOracle.js
+++ b/test/testOracle.js
@@ -4,7 +4,7 @@ const web3 = new Web3(
 );
 const helper = require("./helpers/test_helpers");
 const TellorMaster = artifacts.require("./TellorMaster.sol");
-const Tellor = artifacts.require("./Tellor.sol"); // globally injected artifacts helper
+const Tellor = artifacts.require("./TellorTest.sol"); // globally injected artifacts helper
 var oracleAbi = Tellor.abi;
 var oracleByte = Tellor.bytecode;
 var OldTellor = artifacts.require("./oldContracts/OldTellor.sol");
@@ -64,9 +64,11 @@ contract("Mining Tests", function(accounts) {
         to: oracle.address,
         from: accounts[i],
         gas: 7000000,
-        data: oracle2.methods[
-          "testSubmitMiningSolution(string,uint256[5],uint256[5])"
-        ]("nonce", [1, 2, 3, 4, 5], [1100, 1200, 1300, 1400, 1500]).encodeABI(),
+        data: oracle2.methods["submitMiningSolution(string,uint256,uint256)"](
+          "nonce",
+          1,
+          1200
+        ).encodeABI(),
       });
     }
     // for(var i = 1;i<6;i++){
@@ -144,6 +146,7 @@ contract("Mining Tests", function(accounts) {
           .encodeABI(),
       });
     }
+    await helper.advanceTime(60 * 60 * 16);
     new_balances = [];
     for (var i = 0; i < 6; i++) {
       new_balances[i] = await oracle.balanceOf(accounts[i]);
@@ -201,6 +204,7 @@ contract("Mining Tests", function(accounts) {
     diff1 = await oracle2.methods.getNewCurrentVariables().call();
     assert(diff1[2] > 1, "difficulty greater than 1"); //difficulty not changing.....
     vars = await oracle2.methods.getNewCurrentVariables().call();
+    await helper.advanceTime(60 * 60 * 16);
     for (var i = 0; i < 5; i++) {
       await web3.eth.sendTransaction({
         to: oracle.address,
@@ -304,6 +308,7 @@ contract("Mining Tests", function(accounts) {
           .encodeABI(),
       });
     }
+    await helper.advanceTime(60 * 60 * 16);
     vars = await oracle2.methods.getNewCurrentVariables().call();
     for (var i = 0; i < 5; i++) {
       await web3.eth.sendTransaction({
@@ -333,6 +338,7 @@ contract("Mining Tests", function(accounts) {
     console.log(data[1][1] * 1);
 
     assert(data[1][1] > 1000, "Tip should be over 1000");
+
     await web3.eth.sendTransaction({
       to: oracle.address,
       from: accounts[2],
@@ -794,6 +800,7 @@ contract("Mining Tests", function(accounts) {
         gas: 7000000,
         data: oldTellorinst.methods.addTip(1, 500).encodeABI(),
       });
+      await helper.advanceTime(60 * 60 * 16);
       for (var i = 0; i < 5; i++) {
         await web3.eth.sendTransaction({
           to: oracle.address,
@@ -816,6 +823,7 @@ contract("Mining Tests", function(accounts) {
     assert(vars[2] > 1, "difficulty should be greater than 1"); //difficulty not changing.....
     await helper.advanceTime(86400 * 20);
     vars = await oracle2.methods.getNewCurrentVariables().call();
+    await helper.advanceTime(60 * 60 * 16);
     for (var i = 0; i < 5; i++) {
       await web3.eth.sendTransaction({
         to: oracle.address,
@@ -1023,6 +1031,7 @@ contract("Mining Tests", function(accounts) {
         gas: 7000000,
         data: oldTellorinst.methods.addTip(1, 500).encodeABI(),
       });
+      await helper.advanceTime(60 * 60 * 16);
       for (var i = 0; i < 5; i++) {
         await web3.eth.sendTransaction({
           to: oracle.address,
@@ -1045,6 +1054,7 @@ contract("Mining Tests", function(accounts) {
     assert(vars[2] > 1, "difficulty should be greater than 1"); //difficulty not changing.....
     await helper.advanceTime(86400 * 20);
     vars = await oracle2.methods.getNewCurrentVariables().call();
+    await helper.advanceTime(60 * 60 * 16);
     for (var i = 0; i < 5; i++) {
       await web3.eth.sendTransaction({
         to: oracle.address,
@@ -1088,6 +1098,7 @@ contract("Mining Tests", function(accounts) {
           .encodeABI(),
       });
     }
+    await helper.advanceTime(60 * 60 * 16);
     for (var i = 1; i <= 10; i++) {
       apix = "api" + i;
       await web3.eth.sendTransaction({

--- a/test/testOracle.js
+++ b/test/testOracle.js
@@ -1,1499 +1,1497 @@
-// const Web3 = require("web3");
-// const web3 = new Web3(
-//   new Web3.providers.WebsocketProvider("ws://localhost:8545")
-// );
-// const helper = require("./helpers/test_helpers");
-// const TellorMaster = artifacts.require("./TellorMaster.sol");
-// const Tellor = artifacts.require("./Tellor.sol"); // globally injected artifacts helper
-// var oracleAbi = Tellor.abi;
-// var oracleByte = Tellor.bytecode;
-// var OldTellor = artifacts.require("./oldContracts/OldTellor.sol");
-// var oldTellorABI = OldTellor.abi;
-// var UtilitiesTests = artifacts.require("./UtilitiesTests.sol");
+const Web3 = require("web3");
+const web3 = new Web3(
+  new Web3.providers.WebsocketProvider("ws://localhost:8545")
+);
+const helper = require("./helpers/test_helpers");
+const TellorMaster = artifacts.require("./TellorMaster.sol");
+const Tellor = artifacts.require("./Tellor.sol"); // globally injected artifacts helper
+var oracleAbi = Tellor.abi;
+var oracleByte = Tellor.bytecode;
+var OldTellor = artifacts.require("./oldContracts/OldTellor.sol");
+var oldTellorABI = OldTellor.abi;
+var UtilitiesTests = artifacts.require("./UtilitiesTests.sol");
 
-// var masterAbi = TellorMaster.abi;
-// var api = "json(https://api.gdax.com/products/BTC-USD/ticker).price";
-// var api2 = "json(https://api.gdax.com/products/ETH-USD/ticker).price";
+var masterAbi = TellorMaster.abi;
+var api = "json(https://api.gdax.com/products/BTC-USD/ticker).price";
+var api2 = "json(https://api.gdax.com/products/ETH-USD/ticker).price";
 
-// contract("Mining Tests", function(accounts) {
-//   let oracleBase;
-//   let oracle;
-//   let oracle2;
-//   let master;
-//   let oldTellor;
-//   let oldTellorinst;
-//   let utilities;
+contract("Mining Tests", function(accounts) {
+  let oracleBase;
+  let oracle;
+  let oracle2;
+  let master;
+  let oldTellor;
+  let oldTellorinst;
+  let utilities;
 
-//   beforeEach("Setup contract for each test", async function() {
-//     oldTellor = await OldTellor.new();
-//     oracle = await TellorMaster.new(oldTellor.address);
-//     master = await new web3.eth.Contract(masterAbi, oracle.address);
-//     oldTellorinst = await new web3.eth.Contract(
-//       oldTellorABI,
-//       oldTellor.address
-//     );
-//     for (var i = 0; i < 6; i++) {
-//       await web3.eth.sendTransaction({
-//         to: oracle.address,
-//         from: accounts[0],
-//         gas: 7000000,
-//         data: oldTellorinst.methods
-//           .theLazyCoon(accounts[i], web3.utils.toWei("5000", "ether"))
-//           .encodeABI(),
-//       });
-//     }
-//     for (var i = 0; i < 52; i++) {
-//       x = "USD" + i;
-//       apix = api + i;
-//       await web3.eth.sendTransaction({
-//         to: oracle.address,
-//         from: accounts[0],
-//         gas: 7000000,
-//         data: oldTellorinst.methods
-//           .requestData(apix, x, 1000, 52 - i)
-//           .encodeABI(),
-//       });
-//     }
-//     let q = await oracle.getRequestQ();
-//     //Deploy new upgraded Tellor
-//     oracleBase = await Tellor.new();
-//     oracle2 = await new web3.eth.Contract(oracleAbi, oracle.address);
-//     await oracle.changeTellorContract(oracleBase.address);
-//     for (var i = 0; i < 5; i++) {
-//       await web3.eth.sendTransaction({
-//         to: oracle.address,
-//         from: accounts[i],
-//         gas: 7000000,
-//         data: oracle2.methods[
-//           "testSubmitMiningSolution(string,uint256,uint256)"
-//         ]("nonce", 1, 1200).encodeABI(),
-//       });
-//     }
-//     // for(var i = 1;i<6;i++){
-//     //     await web3.eth.sendTransaction({to: oracle.address,from:accounts[0],gas:7000000,data:oracle2.methods.addTip(i,i).encodeABI()})
-//     // }
-//   });
+  beforeEach("Setup contract for each test", async function() {
+    oldTellor = await OldTellor.new();
+    oracle = await TellorMaster.new(oldTellor.address);
+    master = await new web3.eth.Contract(masterAbi, oracle.address);
+    oldTellorinst = await new web3.eth.Contract(
+      oldTellorABI,
+      oldTellor.address
+    );
+    for (var i = 0; i < 6; i++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[0],
+        gas: 7000000,
+        data: oldTellorinst.methods
+          .theLazyCoon(accounts[i], web3.utils.toWei("5000", "ether"))
+          .encodeABI(),
+      });
+    }
+    for (var i = 0; i < 52; i++) {
+      x = "USD" + i;
+      apix = api + i;
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[0],
+        gas: 7000000,
+        data: oldTellorinst.methods
+          .requestData(apix, x, 1000, 52 - i)
+          .encodeABI(),
+      });
+    }
+    let q = await oracle.getRequestQ();
+    //Deploy new upgraded Tellor
+    oracleBase = await Tellor.new();
+    oracle2 = await new web3.eth.Contract(oracleAbi, oracle.address);
+    await oracle.changeTellorContract(oracleBase.address);
+    for (var i = 0; i < 5; i++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods[
+          "testSubmitMiningSolution(string,uint256,uint256)"
+        ]("nonce", 1, 1200).encodeABI(),
+      });
+    }
+    // for(var i = 1;i<6;i++){
+    //     await web3.eth.sendTransaction({to: oracle.address,from:accounts[0],gas:7000000,data:oracle2.methods.addTip(i,i).encodeABI()})
+    // }
+  });
 
-//   it("test utilities", async function() {
-//     var myArr = [];
-//     for (var i = 50; i >= 0; i--) {
-//       myArr.push(i);
-//     }
-//     utilities = await UtilitiesTests.new(oracle.address);
-//     top5N = await utilities.testgetMax5(myArr);
-//     let q = await oracle.getRequestQ();
-//     for (var i = 0; i < 5; i++) {
-//       assert(top5N["_max"][i] == myArr[i + 1]);
-//       assert(top5N["_index"][i] == i + 1);
-//     }
-//   });
-  
-//   it("getVariables", async function() {
-//     vars = await web3.eth.call({
-//       to: oracle.address,
-//       from: accounts[0],
-//       data: oracle2.methods.getNewCurrentVariables().encodeABI(),
-//     });
+  it("test utilities", async function() {
+    var myArr = [];
+    for (var i = 50; i >= 0; i--) {
+      myArr.push(i);
+    }
+    utilities = await UtilitiesTests.new(oracle.address);
+    top5N = await utilities.testgetMax5(myArr);
+    let q = await oracle.getRequestQ();
+    for (var i = 0; i < 5; i++) {
+      assert(top5N["_max"][i] == myArr[i + 1]);
+      assert(top5N["_index"][i] == i + 1);
+    }
+  });
 
-//     vars = await oracle2.methods.getNewCurrentVariables().call();
-//     assert(vars["1"].length == 5, "ids should be populated");
-//     assert(vars["2"] > 0, "difficulty should be correct");
-//     assert(vars["3"] > 0, "tip should be correct");
-//   });
-//   it("getTopRequestIDs", async function() {
-//     vars = await oracle2.methods.getTopRequestIDs().call();
-//     for (var i = 0; i < 5; i++) {
-//       assert((vars[0] = i + 6));
-//     }
-//   });
-//   it("Test miner", async function() {
-//     for (var i = 0; i < 5; i++) {
-//       await web3.eth.sendTransaction({
-//         to: oracle.address,
-//         from: accounts[i],
-//         gas: 10000000,
-//         data: oracle2.methods
-//           .testSubmitMiningSolution(
-//             "nonce",
-//             [1, 2, 3, 4, 5],
-//             [1200, 1300, 1400, 1500, 1600]
-//           )
-//           .encodeABI(),
-//       });
-//     }
-//     vars = await oracle.getLastNewValueById(5);
-//     assert(vars[0] > 0, "value should be positive");
-//     assert(vars[1] == true, "value should be there");
-//   });
-//   it("Test Miner decreasing payout", async function() {
-//     balances = [];
-//     for (var i = 0; i < 6; i++) {
-//       balances[i] = await oracle.balanceOf(accounts[i]);
-//     }
-//     for (var i = 0; i < 5; i++) {
-//       await web3.eth.sendTransaction({
-//         to: oracle.address,
-//         from: accounts[i],
-//         gas: 7000000,
-//         data: oracle2.methods
-//           .testSubmitMiningSolution(
-//             "nonce",
-//             [1, 2, 3, 4, 5],
-//             [1200, 1300, 1400, 1500, 1600]
-//           )
-//           .encodeABI(),
-//       });
-//     }
-//     new_balances = [];
-//     for (var i = 0; i < 6; i++) {
-//       new_balances[i] = await oracle.balanceOf(accounts[i]);
-//     }
-//     changes = [];
-//     for (var i = 0; i < 6; i++) {
-//       changes[i] = new_balances[i] - balances[i];
-//     }
-//     vars = await oracle2.methods.getNewCurrentVariables().call();
-//     for (var i = 0; i < 5; i++) {
-//       await web3.eth.sendTransaction({
-//         to: oracle.address,
-//         from: accounts[i],
-//         gas: 7000000,
-//         data: oracle2.methods
-//           .testSubmitMiningSolution("nonce", vars["1"], [
-//             1200,
-//             1300,
-//             1400,
-//             1500,
-//             1600,
-//           ])
-//           .encodeABI(),
-//       });
-//     }
-//     new_balances2 = [];
-//     for (var i = 0; i < 6; i++) {
-//       new_balances2[i] = await oracle.balanceOf(accounts[i]);
-//     }
-//     changes2 = [];
-//     for (var i = 0; i < 6; i++) {
-//       changes2[i] = new_balances2[i] - new_balances[i];
-//     }
-//     assert(changes2[1] < changes[1]);
-//     assert(changes2[2] < changes[2]);
-//     assert(changes2[3] < changes[4]);
-//     assert(changes2[4] < changes[4]);
-//     assert(changes2[0] < changes[0], "miner payout should be decreasing");
-//   });
-//   it("Test Difficulty Adjustment", async function() {
-//     for (var i = 0; i < 5; i++) {
-//       await web3.eth.sendTransaction({
-//         to: oracle.address,
-//         from: accounts[i],
-//         gas: 7000000,
-//         data: oracle2.methods
-//           .testSubmitMiningSolution(
-//             "nonce",
-//             [1, 2, 3, 4, 5],
-//             [1200, 1300, 1400, 1500, 1600]
-//           )
-//           .encodeABI(),
-//       });
-//     }
-//     diff1 = await oracle2.methods.getNewCurrentVariables().call();
-//     assert(diff1[2] > 1, "difficulty greater than 1"); //difficulty not changing.....
-//     vars = await oracle2.methods.getNewCurrentVariables().call();
-//     for (var i = 0; i < 5; i++) {
-//       await web3.eth.sendTransaction({
-//         to: oracle.address,
-//         from: accounts[i],
-//         gas: 7000000,
-//         data: oracle2.methods
-//           .testSubmitMiningSolution("nonce", vars["1"], [
-//             1200,
-//             1300,
-//             1400,
-//             1500,
-//             1600,
-//           ])
-//           .encodeABI(),
-//       });
-//     }
-//     vars = await oracle2.methods.getNewCurrentVariables().call();
-//     assert(vars[2] > diff1[2], "difficulty should continue to move up");
-//   });
-//   it("Test Get MinersbyValue ", async function() {
-//     //Here we're testing with randomized values. This way, we can be sure that
-//     //both the values and the miners are being properly sorted
-//     let res;
-//     let prices = [1100, 1200, 1300, 1400, 1500, 1600, 1700, 1800, 1900];
-//     let requestValues = [[], [], [], [], []];
-//     let minersByVal = { 0: {}, 1: {}, 2: {}, 3: {}, 4: {} };
+  it("getVariables", async function() {
+    vars = await web3.eth.call({
+      to: oracle.address,
+      from: accounts[0],
+      data: oracle2.methods.getNewCurrentVariables().encodeABI(),
+    });
 
-//     for (var i = 0; i < 5; i++) {
-//       //Getting a random number
-//       let vals = [];
-//       for (var j = 0; j < 5; j++) {
-//         let rd = Math.floor(Math.random() * (7 - 0));
-//         vals.push(prices[rd]);
-//         requestValues[j].push(prices[rd]);
-//         minersByVal[j][accounts[i]] = prices[rd];
-//       }
+    vars = await oracle2.methods.getNewCurrentVariables().call();
+    assert(vars["1"].length == 5, "ids should be populated");
+    assert(vars["2"] > 0, "difficulty should be correct");
+    assert(vars["3"] > 0, "tip should be correct");
+  });
+  it("getTopRequestIDs", async function() {
+    vars = await oracle2.methods.getTopRequestIDs().call();
+    for (var i = 0; i < 5; i++) {
+      assert((vars[0] = i + 6));
+    }
+  });
+  it("Test miner", async function() {
+    for (var i = 0; i < 5; i++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 10000000,
+        data: oracle2.methods
+          .testSubmitMiningSolution(
+            "nonce",
+            [1, 2, 3, 4, 5],
+            [1200, 1300, 1400, 1500, 1600]
+          )
+          .encodeABI(),
+      });
+    }
+    vars = await oracle.getLastNewValueById(5);
+    assert(vars[0] > 0, "value should be positive");
+    assert(vars[1] == true, "value should be there");
+  });
+  it("Test Miner decreasing payout", async function() {
+    balances = [];
+    for (var i = 0; i < 6; i++) {
+      balances[i] = await oracle.balanceOf(accounts[i]);
+    }
+    for (var i = 0; i < 5; i++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods
+          .testSubmitMiningSolution(
+            "nonce",
+            [1, 2, 3, 4, 5],
+            [1200, 1300, 1400, 1500, 1600]
+          )
+          .encodeABI(),
+      });
+    }
+    new_balances = [];
+    for (var i = 0; i < 6; i++) {
+      new_balances[i] = await oracle.balanceOf(accounts[i]);
+    }
+    changes = [];
+    for (var i = 0; i < 6; i++) {
+      changes[i] = new_balances[i] - balances[i];
+    }
+    vars = await oracle2.methods.getNewCurrentVariables().call();
+    for (var i = 0; i < 5; i++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods
+          .testSubmitMiningSolution("nonce", vars["1"], [
+            1200,
+            1300,
+            1400,
+            1500,
+            1600,
+          ])
+          .encodeABI(),
+      });
+    }
+    new_balances2 = [];
+    for (var i = 0; i < 6; i++) {
+      new_balances2[i] = await oracle.balanceOf(accounts[i]);
+    }
+    changes2 = [];
+    for (var i = 0; i < 6; i++) {
+      changes2[i] = new_balances2[i] - new_balances[i];
+    }
+    assert(changes2[1] < changes[1]);
+    assert(changes2[2] < changes[2]);
+    assert(changes2[3] < changes[4]);
+    assert(changes2[4] < changes[4]);
+    assert(changes2[0] < changes[0], "miner payout should be decreasing");
+  });
+  it("Test Difficulty Adjustment", async function() {
+    for (var i = 0; i < 5; i++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods
+          .testSubmitMiningSolution(
+            "nonce",
+            [1, 2, 3, 4, 5],
+            [1200, 1300, 1400, 1500, 1600]
+          )
+          .encodeABI(),
+      });
+    }
+    diff1 = await oracle2.methods.getNewCurrentVariables().call();
+    assert(diff1[2] > 1, "difficulty greater than 1"); //difficulty not changing.....
+    vars = await oracle2.methods.getNewCurrentVariables().call();
+    for (var i = 0; i < 5; i++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods
+          .testSubmitMiningSolution("nonce", vars["1"], [
+            1200,
+            1300,
+            1400,
+            1500,
+            1600,
+          ])
+          .encodeABI(),
+      });
+    }
+    vars = await oracle2.methods.getNewCurrentVariables().call();
+    assert(vars[2] > diff1[2], "difficulty should continue to move up");
+  });
+  it("Test Get MinersbyValue ", async function() {
+    //Here we're testing with randomized values. This way, we can be sure that
+    //both the values and the miners are being properly sorted
+    let res;
+    let prices = [1100, 1200, 1300, 1400, 1500, 1600, 1700, 1800, 1900];
+    let requestValues = [[], [], [], [], []];
+    let minersByVal = { 0: {}, 1: {}, 2: {}, 3: {}, 4: {} };
 
-//       res = await web3.eth.sendTransaction({
-//         to: oracle.address,
-//         from: accounts[i],
-//         gas: 7000000,
-//         data: oracle2.methods
-//           .testSubmitMiningSolution("nonce", [1, 2, 3, 4, 5], vals)
-//           .encodeABI(),
-//       });
-//     }
-//     res = web3.eth.abi.decodeParameters(
-//       ["uint256[5]", "uint256", "uint256[5]", "uint256"],
-//       res.logs["1"].data
-//     );
+    for (var i = 0; i < 5; i++) {
+      //Getting a random number
+      let vals = [];
+      for (var j = 0; j < 5; j++) {
+        let rd = Math.floor(Math.random() * (7 - 0));
+        vals.push(prices[rd]);
+        requestValues[j].push(prices[rd]);
+        minersByVal[j][accounts[i]] = prices[rd];
+      }
 
-//     console.log("res", res)
+      res = await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods
+          .testSubmitMiningSolution("nonce", [1, 2, 3, 4, 5], vals)
+          .encodeABI(),
+      });
+    }
+    res = web3.eth.abi.decodeParameters(
+      ["uint256[5]", "uint256", "uint256[5]", "uint256"],
+      res.logs["1"].data
+    );
 
-//     for (var i = 0; i < 5; i++) {
-//       let sortReq = requestValues[i].sort();
-//       var values = await oracle.getSubmissionsByTimestamp(i + 1, res[1]);
-//       var miners = await oracle.getMinersByRequestIdAndTimestamp(i + 1, res[1]);
-//       for (var j = 0; j < 5; j++) {
-//         assert(
-//           minersByVal[i.toString()][miners[j]] == values[j].toNumber(),
-//           "wrong miner to value relationship"
-//         );
-//         assert(values[j].toNumber() == sortReq[j], "wrong value"); //Make sure that the medians are right
-//       }
-//     }
-//   });
+    console.log("res", res);
 
-//   it("Test dev Share", async function() {
-//     begbal = await oracle.balanceOf(accounts[0]);
-//     for (var i = 1; i < 6; i++) {
-//       await web3.eth.sendTransaction({
-//         to: oracle.address,
-//         from: accounts[i],
-//         gas: 7000000,
-//         data: oracle2.methods
-//           .testSubmitMiningSolution(
-//             "nonce",
-//             [1, 2, 3, 4, 5],
-//             [1200, 1300, 1400, 1500, 1600]
-//           )
-//           .encodeABI(),
-//       });
-//     }
-//     endbal = await oracle.balanceOf(accounts[0]);
-//     assert((endbal - begbal) / 1e18 >= 1.2, "devShare");
-//     assert((endbal - begbal) / 1e18 <= 1.25, "devShare2");
-//   });
+    for (var i = 0; i < 5; i++) {
+      let sortReq = requestValues[i].sort();
+      var values = await oracle.getSubmissionsByTimestamp(i + 1, res[1]);
+      var miners = await oracle.getMinersByRequestIdAndTimestamp(i + 1, res[1]);
+      for (var j = 0; j < 5; j++) {
+        assert(
+          minersByVal[i.toString()][miners[j]] == values[j].toNumber(),
+          "wrong miner to value relationship"
+        );
+        assert(values[j].toNumber() == sortReq[j], "wrong value"); //Make sure that the medians are right
+      }
+    }
+  });
 
-//   it("Test miner, alternating api request on Q and auto select", async function() {
-//     for (var i = 0; i < 5; i++) {
-//       await web3.eth.sendTransaction({
-//         to: oracle.address,
-//         from: accounts[i],
-//         gas: 7000000,
-//         data: oracle2.methods
-//           .testSubmitMiningSolution(
-//             "nonce",
-//             [1, 2, 3, 4, 5],
-//             [1200, 1300, 1400, 1500, 1600]
-//           )
-//           .encodeABI(),
-//       });
-//     }
-//     vars = await oracle2.methods.getNewCurrentVariables().call();
-//     for (var i = 0; i < 5; i++) {
-//       await web3.eth.sendTransaction({
-//         to: oracle.address,
-//         from: accounts[i],
-//         gas: 7000000,
-//         data: oracle2.methods
-//           .testSubmitMiningSolution("nonce", vars["1"], [
-//             1200,
-//             1300,
-//             1400,
-//             1500,
-//             1600,
-//           ])
-//           .encodeABI(),
-//       });
-//     }
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[2],
-//       gas: 7000000,
-//       data: oracle2.methods.addTip(30, 1000).encodeABI(),
-//     });
-//     data = await oracle2.methods.getNewVariablesOnDeck().call();
-//     assert(data[0].includes("30"), "ID on deck should be 30");
-//     console.log(data[0])
-//     console.log(data[1][1]*1)
-    
-//     assert(data[1][1] > 1000, "Tip should be over 1000");
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[2],
-//       gas: 7000000,
-//       data: oracle2.methods.addTip(31, 2000).encodeABI(),
-//     });
-//     data = await oracle2.methods.getNewVariablesOnDeck().call();
-//     var x = 0;
-//     for (var i = 0; i < 5; i++) {
-//       if (data[0][i] == 30) {
-//         assert(data[1][i] > 1000);
-//         x++;
-//       } else if (data[0][i] == 31) {
-//         assert(data[1][i] > 2000);
-//         x++;
-//       }
-//     }
-//     assert(x == 2);
+  it("Test dev Share", async function() {
+    begbal = await oracle.balanceOf(accounts[0]);
+    for (var i = 1; i < 6; i++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods
+          .testSubmitMiningSolution(
+            "nonce",
+            [1, 2, 3, 4, 5],
+            [1200, 1300, 1400, 1500, 1600]
+          )
+          .encodeABI(),
+      });
+    }
+    endbal = await oracle.balanceOf(accounts[0]);
+    assert((endbal - begbal) / 1e18 >= 1.2, "devShare");
+    assert((endbal - begbal) / 1e18 <= 1.25, "devShare2");
+  });
 
-//   });
+  it("Test miner, alternating api request on Q and auto select", async function() {
+    for (var i = 0; i < 5; i++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods
+          .testSubmitMiningSolution(
+            "nonce",
+            [1, 2, 3, 4, 5],
+            [1200, 1300, 1400, 1500, 1600]
+          )
+          .encodeABI(),
+      });
+    }
+    vars = await oracle2.methods.getNewCurrentVariables().call();
+    for (var i = 0; i < 5; i++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods
+          .testSubmitMiningSolution("nonce", vars["1"], [
+            1200,
+            1300,
+            1400,
+            1500,
+            1600,
+          ])
+          .encodeABI(),
+      });
+    }
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[2],
+      gas: 7000000,
+      data: oracle2.methods.addTip(30, 1000).encodeABI(),
+    });
+    data = await oracle2.methods.getNewVariablesOnDeck().call();
+    assert(data[0].includes("30"), "ID on deck should be 30");
+    console.log(data[0]);
+    console.log(data[1][1] * 1);
 
-//   // it("Test dispute", async function() {
-//   //   for (var i = 0; i < 5; i++) {
-//   //     res = await web3.eth.sendTransaction({
-//   //       to: oracle.address,
-//   //       from: accounts[i],
-//   //       gas: 7000000,
-//   //       data: oracle2.methods
-//   //         .testSubmitMiningSolution(
-//   //           "nonce",
-//   //           [1, 2, 3, 4, 5],
-//   //           [1200, 1300, 1400, 1500, 1600]
-//   //         )
-//   //         .encodeABI(),
-//   //     });
-//   //   }
-//   //   res = web3.eth.abi.decodeParameters(
-//   //     ["uint256[5]", "uint256", "uint256[5]", "uint256"],
-//   //     res.logs["1"].data
-//   //   );
-//   //   balance1 = await oracle.balanceOf(accounts[2]);
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[0],
-//   //     gas: 7000000,
-//   //     data: oracle2.methods
-//   //       .theLazyCoon(accounts[1], web3.utils.toWei("5000", "ether"))
-//   //       .encodeABI(),
-//   //   });
-//   //   dispBal1 = await oracle.balanceOf(accounts[1]);
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[1],
-//   //     gas: 7000000,
-//   //     data: oracle2.methods.beginDispute(1, res[1], 2).encodeABI(),
-//   //   });
-//   //   count = await oracle.getUintVar(web3.utils.keccak256("disputeCount"));
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[3],
-//   //     gas: 7000000,
-//   //     data: oracle2.methods.vote(1, true).encodeABI(),
-//   //   });
-//   //   await helper.advanceTime(86400 * 22);
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[0],
-//   //     gas: 7000000,
-//   //     data: oracle2.methods.tallyVotes(1).encodeABI(),
-//   //   });
-//   //   await helper.advanceTime(86400 * 2);
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[0],
-//   //     gas: 9000000,
-//   //     data: oracle2.methods.unlockDisputeFee(1).encodeABI(),
-//   //   });
-//   //   dispInfo = await oracle.getAllDisputeVars(1);
-//   //   assert(dispInfo[7][0] == 1);
-//   //   assert(dispInfo[7][1] == res[1]);
-//   //   assert(dispInfo[7][2] == 1200);
-//   //   assert(dispInfo[2] == true, "Dispute Vote passed");
-//   //   voted = await oracle.didVote(1, accounts[3]);
-//   //   assert(voted == true, "account 3 voted");
-//   //   voted = await oracle.didVote(1, accounts[5]);
-//   //   assert(voted == false, "account 5 did not vote");
-//   //   apid2valueF = await oracle.retrieveData(1, res[1]);
-//   //   assert(
-//   //     apid2valueF == 0,
-//   //     "value should now be zero this checks updateDisputeValue-internal fx  works"
-//   //   );
-//   //   balance2 = await oracle.balanceOf(accounts[2]);
-//   //   dispBal2 = await oracle.balanceOf(accounts[1]);
-//   //   assert(
-//   //     web3.utils.fromWei(balance1) - web3.utils.fromWei(balance2) == 1000,
-//   //     "reported miner's balance should change correctly"
-//   //   );
-//   //   assert(
-//   //     web3.utils.fromWei(dispBal2) - web3.utils.fromWei(dispBal1) == 1000,
-//   //     "disputing party's balance should change correctly"
-//   //   );
-//   //   s = await oracle.getStakerInfo(accounts[2]);
-//   //   assert(s != 1, " Not staked");
-//   // });
-//   // it("Test multiple dispute to the same miner", async function() {
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[0],
-//   //     gas: 7000000,
-//   //     data: oracle2.methods
-//   //       .theLazyCoon(accounts[0], web3.utils.toWei("5000", "ether"))
-//   //       .encodeABI(),
-//   //   });
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[0],
-//   //     gas: 7000000,
-//   //     data: oracle2.methods
-//   //       .theLazyCoon(accounts[2], web3.utils.toWei("5000", "ether"))
-//   //       .encodeABI(),
-//   //   });
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[0],
-//   //     gas: 7000000,
-//   //     data: oracle2.methods
-//   //       .theLazyCoon(accounts[4], web3.utils.toWei("5000", "ether"))
-//   //       .encodeABI(),
-//   //   });
-//   //   resVars = [];
-//   //   for (j = 0; j < 5; j++) {
-//   //     await web3.eth.sendTransaction({
-//   //       to: oracle.address,
-//   //       from: accounts[0],
-//   //       gas: 7000000,
-//   //       data: oracle2.methods.addTip(1, 1000).encodeABI(),
-//   //     });
-//   //     vars = await oracle2.methods.getNewCurrentVariables().call();
-//   //     for (var i = 0; i < 5; i++) {
-//   //       res = await web3.eth.sendTransaction({
-//   //         to: oracle.address,
-//   //         from: accounts[i],
-//   //         gas: 7000000,
-//   //         data: oracle2.methods
-//   //           .testSubmitMiningSolution("nonce", vars["1"], [
-//   //             1200,
-//   //             1300,
-//   //             1400,
-//   //             1500,
-//   //             1600,
-//   //           ])
-//   //           .encodeABI(),
-//   //       });
-//   //     }
-//   //     resVars[j] = web3.eth.abi.decodeParameters(
-//   //       ["uint256[5]", "uint256", "uint256[5]", "uint256"],
-//   //       res.logs["1"].data
-//   //     );
-//   //     await helper.advanceTime(1000);
-//   //   }
-//   //   balance1 = await oracle.balanceOf(accounts[1]);
-//   //   dispBal1 = await oracle.balanceOf(accounts[2]);
-//   //   orig_dispBal4 = await oracle.balanceOf(accounts[4]);
-//   //   //1st dispute to miner
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[2],
-//   //     gas: 7000000,
-//   //     data: oracle2.methods.beginDispute(1, resVars[0][1], 1).encodeABI(),
-//   //   });
-//   //   count = await oracle.getUintVar(web3.utils.keccak256("disputeCount"));
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[4],
-//   //     gas: 7000000,
-//   //     data: oracle2.methods.beginDispute(1, resVars[2][1], 1).encodeABI(),
-//   //   });
-//   //   count2 = await oracle.getUintVar(web3.utils.keccak256("disputeCount"));
+    assert(data[1][1] > 1000, "Tip should be over 1000");
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[2],
+      gas: 7000000,
+      data: oracle2.methods.addTip(31, 2000).encodeABI(),
+    });
+    data = await oracle2.methods.getNewVariablesOnDeck().call();
+    var x = 0;
+    for (var i = 0; i < 5; i++) {
+      if (data[0][i] == 30) {
+        assert(data[1][i] > 1000);
+        x++;
+      } else if (data[0][i] == 31) {
+        assert(data[1][i] > 2000);
+        x++;
+      }
+    }
+    assert(x == 2);
+  });
 
-//   //   //3rd dispute to same miner
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[0],
-//   //     gas: 7000000,
-//   //     data: oracle2.methods.beginDispute(1, resVars[4][1], 1).encodeABI(),
-//   //   });
-//   //   count2 = await oracle.getUintVar(web3.utils.keccak256("disputeCount"));
-//   //   //dispute votes and tally
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[3],
-//   //     gas: 7000000,
-//   //     data: oracle2.methods.vote(1, true).encodeABI(),
-//   //   });
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[3],
-//   //     gas: 7000000,
-//   //     data: oracle2.methods.vote(2, true).encodeABI(),
-//   //   });
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[3],
-//   //     gas: 7000000,
-//   //     data: oracle2.methods.vote(3, true).encodeABI(),
-//   //   });
-//   //   await helper.advanceTime(86400 * 22);
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[0],
-//   //     gas: 7000000,
-//   //     data: oracle2.methods.tallyVotes(1).encodeABI(),
-//   //   });
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[0],
-//   //     gas: 7000000,
-//   //     data: oracle2.methods.tallyVotes(2).encodeABI(),
-//   //   });
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[0],
-//   //     gas: 7000000,
-//   //     data: oracle2.methods.tallyVotes(3).encodeABI(),
-//   //   });
-//   //   await helper.advanceTime(86400 * 2);
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[0],
-//   //     gas: 9000000,
-//   //     data: oracle2.methods.unlockDisputeFee(1).encodeABI(),
-//   //   });
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[0],
-//   //     gas: 9000000,
-//   //     data: oracle2.methods.unlockDisputeFee(2).encodeABI(),
-//   //   });
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[0],
-//   //     gas: 9000000,
-//   //     data: oracle2.methods.unlockDisputeFee(3).encodeABI(),
-//   //   });
-//   //   dispInfo = await oracle.getAllDisputeVars(1);
-//   //   assert(dispInfo[7][0] == 1);
-//   //   assert(dispInfo[7][1] == resVars[0][1]);
-//   //   assert(dispInfo[7][2] == 1200);
-//   //   assert(dispInfo[2] == true, "Dispute Vote passed");
-//   //   voted = await oracle.didVote(1, accounts[3]);
-//   //   assert(voted == true, "account 3 voted");
-//   //   voted = await oracle.didVote(1, accounts[5]);
-//   //   assert(voted == false, "account 5 did not vote");
-//   //   apid2valueF = await oracle.retrieveData(1, resVars[0][1]);
-//   //   assert(
-//   //     apid2valueF * 1 > 0,
-//   //     "value should not be zero since the disputed miner index is not 2/official value this checks updateDisputeValue-internal fx  works"
-//   //   );
+  it("Test dispute", async function() {
+    for (var i = 0; i < 5; i++) {
+      res = await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods
+          .testSubmitMiningSolution(
+            "nonce",
+            [1, 2, 3, 4, 5],
+            [1200, 1300, 1400, 1500, 1600]
+          )
+          .encodeABI(),
+      });
+    }
+    res = web3.eth.abi.decodeParameters(
+      ["uint256[5]", "uint256", "uint256[5]", "uint256"],
+      res.logs["1"].data
+    );
+    balance1 = await oracle.balanceOf(accounts[2]);
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods
+        .theLazyCoon(accounts[1], web3.utils.toWei("5000", "ether"))
+        .encodeABI(),
+    });
+    dispBal1 = await oracle.balanceOf(accounts[1]);
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[1],
+      gas: 7000000,
+      data: oracle2.methods.beginDispute(1, res[1], 2).encodeABI(),
+    });
+    count = await oracle.getUintVar(web3.utils.keccak256("disputeCount"));
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[3],
+      gas: 7000000,
+      data: oracle2.methods.vote(1, true).encodeABI(),
+    });
+    await helper.advanceTime(86400 * 22);
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods.tallyVotes(1).encodeABI(),
+    });
+    await helper.advanceTime(86400 * 2);
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 9000000,
+      data: oracle2.methods.unlockDisputeFee(1).encodeABI(),
+    });
+    dispInfo = await oracle.getAllDisputeVars(1);
+    assert(dispInfo[7][0] == 1);
+    assert(dispInfo[7][1] == res[1]);
+    assert(dispInfo[7][2] == 1200);
+    assert(dispInfo[2] == true, "Dispute Vote passed");
+    voted = await oracle.didVote(1, accounts[3]);
+    assert(voted == true, "account 3 voted");
+    voted = await oracle.didVote(1, accounts[5]);
+    assert(voted == false, "account 5 did not vote");
+    apid2valueF = await oracle.retrieveData(1, res[1]);
+    assert(
+      apid2valueF == 0,
+      "value should now be zero this checks updateDisputeValue-internal fx  works"
+    );
+    balance2 = await oracle.balanceOf(accounts[2]);
+    dispBal2 = await oracle.balanceOf(accounts[1]);
+    assert(
+      web3.utils.fromWei(balance1) - web3.utils.fromWei(balance2) == 1000,
+      "reported miner's balance should change correctly"
+    );
+    assert(
+      web3.utils.fromWei(dispBal2) - web3.utils.fromWei(dispBal1) == 1000,
+      "disputing party's balance should change correctly"
+    );
+    s = await oracle.getStakerInfo(accounts[2]);
+    assert(s != 1, " Not staked");
+  });
+  it("Test multiple dispute to the same miner", async function() {
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods
+        .theLazyCoon(accounts[0], web3.utils.toWei("5000", "ether"))
+        .encodeABI(),
+    });
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods
+        .theLazyCoon(accounts[2], web3.utils.toWei("5000", "ether"))
+        .encodeABI(),
+    });
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods
+        .theLazyCoon(accounts[4], web3.utils.toWei("5000", "ether"))
+        .encodeABI(),
+    });
+    resVars = [];
+    for (j = 0; j < 5; j++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[0],
+        gas: 7000000,
+        data: oracle2.methods.addTip(1, 1000).encodeABI(),
+      });
+      vars = await oracle2.methods.getNewCurrentVariables().call();
+      for (var i = 0; i < 5; i++) {
+        res = await web3.eth.sendTransaction({
+          to: oracle.address,
+          from: accounts[i],
+          gas: 7000000,
+          data: oracle2.methods
+            .testSubmitMiningSolution("nonce", vars["1"], [
+              1200,
+              1300,
+              1400,
+              1500,
+              1600,
+            ])
+            .encodeABI(),
+        });
+      }
+      resVars[j] = web3.eth.abi.decodeParameters(
+        ["uint256[5]", "uint256", "uint256[5]", "uint256"],
+        res.logs["1"].data
+      );
+      await helper.advanceTime(1000);
+    }
+    balance1 = await oracle.balanceOf(accounts[1]);
+    dispBal1 = await oracle.balanceOf(accounts[2]);
+    orig_dispBal4 = await oracle.balanceOf(accounts[4]);
+    //1st dispute to miner
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[2],
+      gas: 7000000,
+      data: oracle2.methods.beginDispute(1, resVars[0][1], 1).encodeABI(),
+    });
+    count = await oracle.getUintVar(web3.utils.keccak256("disputeCount"));
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[4],
+      gas: 7000000,
+      data: oracle2.methods.beginDispute(1, resVars[2][1], 1).encodeABI(),
+    });
+    count2 = await oracle.getUintVar(web3.utils.keccak256("disputeCount"));
 
-//   //   //checks balances after dispute 1
-//   //   balance2 = await oracle.balanceOf(accounts[1]);
-//   //   dispBal2 = await oracle.balanceOf(accounts[2]);
-//   //   assert(
-//   //     web3.utils.fromWei(balance1) - web3.utils.fromWei(balance2) > 999,
-//   //     "reported miner's balance should change correctly"
-//   //   );
-//   //   assert(
-//   //     web3.utils.fromWei(balance1) - web3.utils.fromWei(balance2) < 1001,
-//   //     "reported miner's balance should change correctly"
-//   //   );
-//   //   assert(
-//   //     web3.utils.fromWei(dispBal2) - web3.utils.fromWei(dispBal1) == 1000,
-//   //     "disputing party's balance should change correctly"
-//   //   );
-//   //   s = await oracle.getStakerInfo(accounts[1]);
-//   //   assert(s != 1, " Not staked");
-//   //   dispBal4 = await oracle.balanceOf(accounts[4]);
-//   //   assert(dispBal4 - orig_dispBal4 == 0, "a4 shouldn't change'");
-//   // });
+    //3rd dispute to same miner
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods.beginDispute(1, resVars[4][1], 1).encodeABI(),
+    });
+    count2 = await oracle.getUintVar(web3.utils.keccak256("disputeCount"));
+    //dispute votes and tally
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[3],
+      gas: 7000000,
+      data: oracle2.methods.vote(1, true).encodeABI(),
+    });
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[3],
+      gas: 7000000,
+      data: oracle2.methods.vote(2, true).encodeABI(),
+    });
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[3],
+      gas: 7000000,
+      data: oracle2.methods.vote(3, true).encodeABI(),
+    });
+    await helper.advanceTime(86400 * 22);
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods.tallyVotes(1).encodeABI(),
+    });
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods.tallyVotes(2).encodeABI(),
+    });
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods.tallyVotes(3).encodeABI(),
+    });
+    await helper.advanceTime(86400 * 2);
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 9000000,
+      data: oracle2.methods.unlockDisputeFee(1).encodeABI(),
+    });
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 9000000,
+      data: oracle2.methods.unlockDisputeFee(2).encodeABI(),
+    });
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 9000000,
+      data: oracle2.methods.unlockDisputeFee(3).encodeABI(),
+    });
+    dispInfo = await oracle.getAllDisputeVars(1);
+    assert(dispInfo[7][0] == 1);
+    assert(dispInfo[7][1] == resVars[0][1]);
+    assert(dispInfo[7][2] == 1200);
+    assert(dispInfo[2] == true, "Dispute Vote passed");
+    voted = await oracle.didVote(1, accounts[3]);
+    assert(voted == true, "account 3 voted");
+    voted = await oracle.didVote(1, accounts[5]);
+    assert(voted == false, "account 5 did not vote");
+    apid2valueF = await oracle.retrieveData(1, resVars[0][1]);
+    assert(
+      apid2valueF * 1 > 0,
+      "value should not be zero since the disputed miner index is not 2/official value this checks updateDisputeValue-internal fx  works"
+    );
 
-//   // it("Test multiple dispute to official value/miner index 2", async function() {
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[0],
-//   //     gas: 7000000,
-//   //     data: oracle2.methods
-//   //       .theLazyCoon(accounts[0], web3.utils.toWei("5000", "ether"))
-//   //       .encodeABI(),
-//   //   });
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[0],
-//   //     gas: 7000000,
-//   //     data: oracle2.methods
-//   //       .theLazyCoon(accounts[1], web3.utils.toWei("5000", "ether"))
-//   //       .encodeABI(),
-//   //   });
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[0],
-//   //     gas: 7000000,
-//   //     data: oracle2.methods
-//   //       .theLazyCoon(accounts[4], web3.utils.toWei("5000", "ether"))
-//   //       .encodeABI(),
-//   //   });
-//   //   resVars = [];
-//   //   for (j = 0; j < 5; j++) {
-//   //     await web3.eth.sendTransaction({
-//   //       to: oracle.address,
-//   //       from: accounts[0],
-//   //       gas: 7000000,
-//   //       data: oracle2.methods.addTip(1, 1000).encodeABI(),
-//   //     });
-//   //     vars = await oracle2.methods.getNewCurrentVariables().call();
-//   //     for (var i = 0; i < 5; i++) {
-//   //       res = await web3.eth.sendTransaction({
-//   //         to: oracle.address,
-//   //         from: accounts[i],
-//   //         gas: 7000000,
-//   //         data: oracle2.methods
-//   //           .testSubmitMiningSolution("nonce", vars["1"], [
-//   //             1200,
-//   //             1300,
-//   //             1400,
-//   //             1500,
-//   //             1600,
-//   //           ])
-//   //           .encodeABI(),
-//   //       });
-//   //     }
-//   //     resVars[j] = web3.eth.abi.decodeParameters(
-//   //       ["uint256[5]", "uint256", "uint256[5]", "uint256"],
-//   //       res.logs["1"].data
-//   //     );
-//   //     await helper.advanceTime(1000);
-//   //   }
-//   //   balance1 = await oracle.balanceOf(accounts[2]);
-//   //   dispBal1 = await oracle.balanceOf(accounts[1]);
-//   //   orig_dispBal4 = await oracle.balanceOf(accounts[4]);
-//   //   //1st dispute to miner
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[1],
-//   //     gas: 7000000,
-//   //     data: oracle2.methods.beginDispute(1, resVars[0][1], 2).encodeABI(),
-//   //   });
-//   //   count = await oracle.getUintVar(web3.utils.keccak256("disputeCount"));
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[4],
-//   //     gas: 7000000,
-//   //     data: oracle2.methods.beginDispute(1, resVars[2][1], 2).encodeABI(),
-//   //   });
-//   //   count2 = await oracle.getUintVar(web3.utils.keccak256("disputeCount"));
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[0],
-//   //     gas: 7000000,
-//   //     data: oracle2.methods.beginDispute(1, resVars[4][1], 2).encodeABI(),
-//   //   });
-//   //   count2 = await oracle.getUintVar(web3.utils.keccak256("disputeCount"));
-//   //   //dispute votes and tally
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[3],
-//   //     gas: 7000000,
-//   //     data: oracle2.methods.vote(1, true).encodeABI(),
-//   //   });
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[3],
-//   //     gas: 7000000,
-//   //     data: oracle2.methods.vote(2, true).encodeABI(),
-//   //   });
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[3],
-//   //     gas: 7000000,
-//   //     data: oracle2.methods.vote(3, true).encodeABI(),
-//   //   });
-//   //   await helper.advanceTime(86400 * 22);
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[0],
-//   //     gas: 7000000,
-//   //     data: oracle2.methods.tallyVotes(1).encodeABI(),
-//   //   });
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[0],
-//   //     gas: 7000000,
-//   //     data: oracle2.methods.tallyVotes(2).encodeABI(),
-//   //   });
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[0],
-//   //     gas: 7000000,
-//   //     data: oracle2.methods.tallyVotes(3).encodeABI(),
-//   //   });
-//   //   await helper.advanceTime(86400 * 2);
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[0],
-//   //     gas: 9000000,
-//   //     data: oracle2.methods.unlockDisputeFee(1).encodeABI(),
-//   //   });
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[0],
-//   //     gas: 9000000,
-//   //     data: oracle2.methods.unlockDisputeFee(2).encodeABI(),
-//   //   });
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[0],
-//   //     gas: 9000000,
-//   //     data: oracle2.methods.unlockDisputeFee(3).encodeABI(),
-//   //   });
-//   //   dispInfo = await oracle.getAllDisputeVars(1);
-//   //   assert(dispInfo[7][0] == 1);
-//   //   assert(dispInfo[7][1] == resVars[0][1]);
-//   //   assert(dispInfo[7][2] == 1200);
-//   //   assert(dispInfo[2] == true, "Dispute Vote passed");
-//   //   voted = await oracle.didVote(1, accounts[3]);
-//   //   assert(voted == true, "account 3 voted");
-//   //   voted = await oracle.didVote(1, accounts[5]);
-//   //   assert(voted == false, "account 5 did not vote");
-//   //   apid2valueF = await oracle.retrieveData(1, resVars[0][1]);
-//   //   assert(
-//   //     apid2valueF == 0,
-//   //     "value should now be zero this checks updateDisputeValue-internal fx  works"
-//   //   );
-//   //   //checks balances after dispute 1
-//   //   balance2 = await oracle.balanceOf(accounts[2]);
-//   //   dispBal2 = await oracle.balanceOf(accounts[1]);
-//   //   assert(
-//   //     web3.utils.fromWei(balance1) - web3.utils.fromWei(balance2) > 999.99,
-//   //     "reported miner's balance should change correctly"
-//   //   );
-//   //   assert(
-//   //     web3.utils.fromWei(balance1) - web3.utils.fromWei(balance2) <= 1000,
-//   //     "reported miner's balance should change correctly"
-//   //   );
-//   //   assert(
-//   //     web3.utils.fromWei(dispBal2) - web3.utils.fromWei(dispBal1) == 1000,
-//   //     "disputing party's balance should change correctly"
-//   //   );
-//   //   s = await oracle.getStakerInfo(accounts[2]);
-//   //   assert(s != 1, " Not staked");
-//   //   dispBal4 = await oracle.balanceOf(accounts[4]);
-//   //   assert(dispBal4 - orig_dispBal4 == 0, "a4 shouldn't change'");
-//   // });
+    //checks balances after dispute 1
+    balance2 = await oracle.balanceOf(accounts[1]);
+    dispBal2 = await oracle.balanceOf(accounts[2]);
+    assert(
+      web3.utils.fromWei(balance1) - web3.utils.fromWei(balance2) > 999,
+      "reported miner's balance should change correctly"
+    );
+    assert(
+      web3.utils.fromWei(balance1) - web3.utils.fromWei(balance2) < 1001,
+      "reported miner's balance should change correctly"
+    );
+    assert(
+      web3.utils.fromWei(dispBal2) - web3.utils.fromWei(dispBal1) == 1000,
+      "disputing party's balance should change correctly"
+    );
+    s = await oracle.getStakerInfo(accounts[1]);
+    assert(s != 1, " Not staked");
+    dispBal4 = await oracle.balanceOf(accounts[4]);
+    assert(dispBal4 - orig_dispBal4 == 0, "a4 shouldn't change'");
+  });
 
-//   // it("Test time travel in data -- really long timesincelastPoof and proper difficulty adjustment", async function() {
-//   //   for (var j = 0; j < 6; j++) {
-//   //     vars = await oracle2.methods.getNewCurrentVariables().call();
-//   //     await web3.eth.sendTransaction({
-//   //       to: oracle.address,
-//   //       from: accounts[0],
-//   //       gas: 7000000,
-//   //       data: oldTellorinst.methods.addTip(1, 500).encodeABI(),
-//   //     });
-//   //     for (var i = 0; i < 5; i++) {
-//   //       await web3.eth.sendTransaction({
-//   //         to: oracle.address,
-//   //         from: accounts[i],
-//   //         gas: 7000000,
-//   //         data: oracle2.methods
-//   //           .testSubmitMiningSolution("nonce", vars["1"], [
-//   //             1200,
-//   //             1300,
-//   //             1400,
-//   //             1500,
-//   //             1600,
-//   //           ])
-//   //           .encodeABI(),
-//   //       });
-//   //     }
-//   //   }
-//   //   vars = await oracle2.methods.getNewCurrentVariables().call();
-//   //   var oldDiff = vars[2];
-//   //   assert(vars[2] > 1, "difficulty should be greater than 1"); //difficulty not changing.....
-//   //   await helper.advanceTime(86400 * 20);
-//   //   vars = await oracle2.methods.getNewCurrentVariables().call();
-//   //   for (var i = 0; i < 5; i++) {
-//   //     await web3.eth.sendTransaction({
-//   //       to: oracle.address,
-//   //       from: accounts[i],
-//   //       gas: 7000000,
-//   //       data: oracle2.methods
-//   //         .testSubmitMiningSolution("nonce", vars["1"], [
-//   //           1200,
-//   //           1300,
-//   //           1400,
-//   //           1500,
-//   //           1600,
-//   //         ])
-//   //         .encodeABI(),
-//   //     });
-//   //   }
-//   //   vars = await oracle2.methods.getNewCurrentVariables().call();
-//   //   var newDiff = vars[2];
-//   //   assert(newDiff < oldDiff, "difficulty should be lower");
-//   //   assert(
-//   //     (await oracle.getNewValueCountbyRequestId(1)) == 5,
-//   //     "Request ID 1 should have 8 mines"
-//   //   );
-//   // });
+  it("Test multiple dispute to official value/miner index 2", async function() {
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods
+        .theLazyCoon(accounts[0], web3.utils.toWei("5000", "ether"))
+        .encodeABI(),
+    });
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods
+        .theLazyCoon(accounts[1], web3.utils.toWei("5000", "ether"))
+        .encodeABI(),
+    });
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods
+        .theLazyCoon(accounts[4], web3.utils.toWei("5000", "ether"))
+        .encodeABI(),
+    });
+    resVars = [];
+    for (j = 0; j < 5; j++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[0],
+        gas: 7000000,
+        data: oracle2.methods.addTip(1, 1000).encodeABI(),
+      });
+      vars = await oracle2.methods.getNewCurrentVariables().call();
+      for (var i = 0; i < 5; i++) {
+        res = await web3.eth.sendTransaction({
+          to: oracle.address,
+          from: accounts[i],
+          gas: 7000000,
+          data: oracle2.methods
+            .testSubmitMiningSolution("nonce", vars["1"], [
+              1200,
+              1300,
+              1400,
+              1500,
+              1600,
+            ])
+            .encodeABI(),
+        });
+      }
+      resVars[j] = web3.eth.abi.decodeParameters(
+        ["uint256[5]", "uint256", "uint256[5]", "uint256"],
+        res.logs["1"].data
+      );
+      await helper.advanceTime(1000);
+    }
+    balance1 = await oracle.balanceOf(accounts[2]);
+    dispBal1 = await oracle.balanceOf(accounts[1]);
+    orig_dispBal4 = await oracle.balanceOf(accounts[4]);
+    //1st dispute to miner
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[1],
+      gas: 7000000,
+      data: oracle2.methods.beginDispute(1, resVars[0][1], 2).encodeABI(),
+    });
+    count = await oracle.getUintVar(web3.utils.keccak256("disputeCount"));
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[4],
+      gas: 7000000,
+      data: oracle2.methods.beginDispute(1, resVars[2][1], 2).encodeABI(),
+    });
+    count2 = await oracle.getUintVar(web3.utils.keccak256("disputeCount"));
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods.beginDispute(1, resVars[4][1], 2).encodeABI(),
+    });
+    count2 = await oracle.getUintVar(web3.utils.keccak256("disputeCount"));
+    //dispute votes and tally
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[3],
+      gas: 7000000,
+      data: oracle2.methods.vote(1, true).encodeABI(),
+    });
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[3],
+      gas: 7000000,
+      data: oracle2.methods.vote(2, true).encodeABI(),
+    });
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[3],
+      gas: 7000000,
+      data: oracle2.methods.vote(3, true).encodeABI(),
+    });
+    await helper.advanceTime(86400 * 22);
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods.tallyVotes(1).encodeABI(),
+    });
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods.tallyVotes(2).encodeABI(),
+    });
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods.tallyVotes(3).encodeABI(),
+    });
+    await helper.advanceTime(86400 * 2);
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 9000000,
+      data: oracle2.methods.unlockDisputeFee(1).encodeABI(),
+    });
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 9000000,
+      data: oracle2.methods.unlockDisputeFee(2).encodeABI(),
+    });
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 9000000,
+      data: oracle2.methods.unlockDisputeFee(3).encodeABI(),
+    });
+    dispInfo = await oracle.getAllDisputeVars(1);
+    assert(dispInfo[7][0] == 1);
+    assert(dispInfo[7][1] == resVars[0][1]);
+    assert(dispInfo[7][2] == 1200);
+    assert(dispInfo[2] == true, "Dispute Vote passed");
+    voted = await oracle.didVote(1, accounts[3]);
+    assert(voted == true, "account 3 voted");
+    voted = await oracle.didVote(1, accounts[5]);
+    assert(voted == false, "account 5 did not vote");
+    apid2valueF = await oracle.retrieveData(1, resVars[0][1]);
+    assert(
+      apid2valueF == 0,
+      "value should now be zero this checks updateDisputeValue-internal fx  works"
+    );
+    //checks balances after dispute 1
+    balance2 = await oracle.balanceOf(accounts[2]);
+    dispBal2 = await oracle.balanceOf(accounts[1]);
+    assert(
+      web3.utils.fromWei(balance1) - web3.utils.fromWei(balance2) > 999.99,
+      "reported miner's balance should change correctly"
+    );
+    assert(
+      web3.utils.fromWei(balance1) - web3.utils.fromWei(balance2) <= 1000,
+      "reported miner's balance should change correctly"
+    );
+    assert(
+      web3.utils.fromWei(dispBal2) - web3.utils.fromWei(dispBal1) == 1000,
+      "disputing party's balance should change correctly"
+    );
+    s = await oracle.getStakerInfo(accounts[2]);
+    assert(s != 1, " Not staked");
+    dispBal4 = await oracle.balanceOf(accounts[4]);
+    assert(dispBal4 - orig_dispBal4 == 0, "a4 shouldn't change'");
+  });
 
-//   // //index 2 dispute fee updates
-//   // it("Test multiple dispute to official value/miner index 2", async function() {
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[0],
-//   //     gas: 7000000,
-//   //     data: oracle2.methods
-//   //       .theLazyCoon(accounts[0], web3.utils.toWei("5000", "ether"))
-//   //       .encodeABI(),
-//   //   });
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[0],
-//   //     gas: 7000000,
-//   //     data: oracle2.methods
-//   //       .theLazyCoon(accounts[1], web3.utils.toWei("5000", "ether"))
-//   //       .encodeABI(),
-//   //   });
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[0],
-//   //     gas: 7000000,
-//   //     data: oracle2.methods
-//   //       .theLazyCoon(accounts[4], web3.utils.toWei("5000", "ether"))
-//   //       .encodeABI(),
-//   //   });
-//   //   resVars = [];
-//   //   for (j = 0; j < 5; j++) {
-//   //     await web3.eth.sendTransaction({
-//   //       to: oracle.address,
-//   //       from: accounts[0],
-//   //       gas: 7000000,
-//   //       data: oracle2.methods.addTip(1, 1000).encodeABI(),
-//   //     });
-//   //     vars = await oracle2.methods.getNewCurrentVariables().call();
-//   //     for (var i = 0; i < 5; i++) {
-//   //       res = await web3.eth.sendTransaction({
-//   //         to: oracle.address,
-//   //         from: accounts[i],
-//   //         gas: 7000000,
-//   //         data: oracle2.methods
-//   //           .testSubmitMiningSolution("nonce", vars["1"], [
-//   //             1200,
-//   //             1300,
-//   //             1400,
-//   //             1500,
-//   //             1600,
-//   //           ])
-//   //           .encodeABI(),
-//   //       });
-//   //     }
-//   //     resVars[j] = web3.eth.abi.decodeParameters(
-//   //       ["uint256[5]", "uint256", "uint256[5]", "uint256"],
-//   //       res.logs["1"].data
-//   //     );
-//   //     await helper.advanceTime(1000);
-//   //   }
-//   //   balance1 = await oracle.balanceOf(accounts[2]);
-//   //   dispBal1 = await oracle.balanceOf(accounts[1]);
-//   //   orig_dispBal4 = await oracle.balanceOf(accounts[4]);
-//   //   //1st dispute to miner
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[1],
-//   //     gas: 7000000,
-//   //     data: oracle2.methods.beginDispute(1, resVars[0][1], 2).encodeABI(),
-//   //   });
-//   //   count = await oracle.getUintVar(web3.utils.keccak256("disputeCount"));
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[4],
-//   //     gas: 7000000,
-//   //     data: oracle2.methods.beginDispute(1, resVars[2][1], 2).encodeABI(),
-//   //   });
-//   //   count2 = await oracle.getUintVar(web3.utils.keccak256("disputeCount"));
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[0],
-//   //     gas: 7000000,
-//   //     data: oracle2.methods.beginDispute(1, resVars[4][1], 2).encodeABI(),
-//   //   });
-//   //   count2 = await oracle.getUintVar(web3.utils.keccak256("disputeCount"));
-//   //   //dispute votes and tally
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[3],
-//   //     gas: 7000000,
-//   //     data: oracle2.methods.vote(1, true).encodeABI(),
-//   //   });
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[3],
-//   //     gas: 7000000,
-//   //     data: oracle2.methods.vote(2, true).encodeABI(),
-//   //   });
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[3],
-//   //     gas: 7000000,
-//   //     data: oracle2.methods.vote(3, true).encodeABI(),
-//   //   });
-//   //   await helper.advanceTime(86400 * 22);
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[0],
-//   //     gas: 7000000,
-//   //     data: oracle2.methods.tallyVotes(1).encodeABI(),
-//   //   });
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[0],
-//   //     gas: 7000000,
-//   //     data: oracle2.methods.tallyVotes(2).encodeABI(),
-//   //   });
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[0],
-//   //     gas: 7000000,
-//   //     data: oracle2.methods.tallyVotes(3).encodeABI(),
-//   //   });
-//   //   await helper.advanceTime(86400 * 2);
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[0],
-//   //     gas: 9000000,
-//   //     data: oracle2.methods.unlockDisputeFee(1).encodeABI(),
-//   //   });
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[0],
-//   //     gas: 9000000,
-//   //     data: oracle2.methods.unlockDisputeFee(2).encodeABI(),
-//   //   });
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[0],
-//   //     gas: 9000000,
-//   //     data: oracle2.methods.unlockDisputeFee(3).encodeABI(),
-//   //   });
-//   //   dispInfo = await oracle.getAllDisputeVars(1);
-//   //   assert(dispInfo[7][0] == 1);
-//   //   assert(dispInfo[7][1] == resVars[0][1]);
-//   //   assert(dispInfo[7][2] == 1200);
-//   //   assert(dispInfo[2] == true, "Dispute Vote passed");
-//   //   voted = await oracle.didVote(1, accounts[3]);
-//   //   assert(voted == true, "account 3 voted");
-//   //   voted = await oracle.didVote(1, accounts[5]);
-//   //   assert(voted == false, "account 5 did not vote");
-//   //   apid2valueF = await oracle.retrieveData(1, resVars[0][1]);
-//   //   assert(
-//   //     apid2valueF == 0,
-//   //     "value should now be zero this checks updateDisputeValue-internal fx  works"
-//   //   );
-//   //   //checks balances after dispute 1
-//   //   balance2 = await oracle.balanceOf(accounts[2]);
-//   //   dispBal2 = await oracle.balanceOf(accounts[1]);
-//   //   assert(
-//   //     web3.utils.fromWei(balance1) - web3.utils.fromWei(balance2) > 999,
-//   //     "reported miner's balance should change correctly"
-//   //   );
-//   //   assert(
-//   //     web3.utils.fromWei(balance1) - web3.utils.fromWei(balance2) < 1001,
-//   //     "reported miner's balance should change correctly"
-//   //   );
-//   //   assert(
-//   //     web3.utils.fromWei(dispBal2) - web3.utils.fromWei(dispBal1) == 1000,
-//   //     "disputing party's balance should change correctly"
-//   //   );
-//   //   s = await oracle.getStakerInfo(accounts[2]);
-//   //   assert(s != 1, " Not staked");
-//   //   dispBal4 = await oracle.balanceOf(accounts[4]);
-//   //   assert(dispBal4 - orig_dispBal4 == 0, "a4 shouldn't change'");
-//   // });
-//   // it("Test time travel in data -- really long timesincelastPoof and proper difficulty adjustment", async function() {
-//   //   for (var j = 0; j < 6; j++) {
-//   //     vars = await oracle2.methods.getNewCurrentVariables().call();
-//   //     await web3.eth.sendTransaction({
-//   //       to: oracle.address,
-//   //       from: accounts[0],
-//   //       gas: 7000000,
-//   //       data: oldTellorinst.methods.addTip(1, 500).encodeABI(),
-//   //     });
-//   //     for (var i = 0; i < 5; i++) {
-//   //       await web3.eth.sendTransaction({
-//   //         to: oracle.address,
-//   //         from: accounts[i],
-//   //         gas: 7000000,
-//   //         data: oracle2.methods
-//   //           .testSubmitMiningSolution("nonce", vars["1"], [
-//   //             1200,
-//   //             1300,
-//   //             1400,
-//   //             1500,
-//   //             1600,
-//   //           ])
-//   //           .encodeABI(),
-//   //       });
-//   //     }
-//   //   }
-//   //   vars = await oracle2.methods.getNewCurrentVariables().call();
-//   //   var oldDiff = vars[2];
-//   //   assert(vars[2] > 1, "difficulty should be greater than 1"); //difficulty not changing.....
-//   //   await helper.advanceTime(86400 * 20);
-//   //   vars = await oracle2.methods.getNewCurrentVariables().call();
-//   //   for (var i = 0; i < 5; i++) {
-//   //     await web3.eth.sendTransaction({
-//   //       to: oracle.address,
-//   //       from: accounts[i],
-//   //       gas: 7000000,
-//   //       data: oracle2.methods
-//   //         .testSubmitMiningSolution("nonce", vars["1"], [
-//   //           1200,
-//   //           1300,
-//   //           1400,
-//   //           1500,
-//   //           1600,
-//   //         ])
-//   //         .encodeABI(),
-//   //     });
-//   //   }
-//   //   vars = await oracle2.methods.getNewCurrentVariables().call();
-//   //   var newDiff = vars[2];
-//   //   assert(newDiff < oldDiff, "difficulty should be lower");
-//   //   assert(
-//   //     (await oracle.getNewValueCountbyRequestId(1)) == 5,
-//   //     "Request ID 1 should have 8 mines"
-//   //   );
-//   // });
-  
-//   it("Test 50 requests, proper booting, and mining of 5", async function() {
-//     vars = await oracle2.methods.getNewCurrentVariables().call();
-//     for (var i = 0; i < 5; i++) {
-//       await web3.eth.sendTransaction({
-//         to: oracle.address,
-//         from: accounts[i],
-//         gas: 7000000,
-//         data: oracle2.methods
-//           .testSubmitMiningSolution("nonce", vars["1"], [
-//             1200,
-//             1300,
-//             1400,
-//             1500,
-//             1600,
-//           ])
-//           .encodeABI(),
-//       });
-//     }
-//     for (var i = 1; i <= 10; i++) {
-//       apix = "api" + i;
-//       await web3.eth.sendTransaction({
-//         to: oracle.address,
-//         from: accounts[2],
-//         gas: 7000000,
-//         data: oracle2.methods.addTip(i + 2, i).encodeABI(),
-//       });
-//     }
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[2],
-//       gas: 7000000,
-//       data: oracle2.methods.addTip(1, 11).encodeABI(),
-//     });
-//     vars = await oracle2.methods.getNewCurrentVariables().call();
-//     for (var i = 0; i < 5; i++) {
-//       res = await web3.eth.sendTransaction({
-//         to: oracle.address,
-//         from: accounts[i],
-//         gas: 7000000,
-//         data: oracle2.methods
-//           .testSubmitMiningSolution("nonce", vars["1"], [
-//             1200,
-//             1300,
-//             1400,
-//             1500,
-//             1600,
-//           ])
-//           .encodeABI(),
-//       });
-//     }
-//     res = web3.eth.abi.decodeParameters(
-//       ["uint256[5]", "uint256", "uint256[5]", "uint256"],
-//       res.logs["1"].data
-//     );
-//     data = await oracle.getMinedBlockNum(2, res[1]);
-//     console.log("data1", data*1 )
-//     assert(data*1 > 0, "Should be true if Data exist for that point in time");
-//     for (var i = 11; i <= 20; i++) {
-//       apix = "api" + i;
-//       await web3.eth.sendTransaction({
-//         to: oracle.address,
-//         from: accounts[2],
-//         gas: 7000000,
-//         data: oracle2.methods.addTip(i + 2, i).encodeABI(),
-//       });
-//     }
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[2],
-//       gas: 7000000,
-//       data: oracle2.methods.addTip(2, 21).encodeABI(),
-//     });
-//     vars = await oracle2.methods.getNewCurrentVariables().call();
-//     for (var i = 0; i < 5; i++) {
-//       res = await web3.eth.sendTransaction({
-//         to: oracle.address,
-//         from: accounts[i],
-//         gas: 7000000,
-//         data: oracle2.methods
-//           .testSubmitMiningSolution("nonce", vars["1"], [
-//             1200,
-//             1300,
-//             1400,
-//             1500,
-//             1600,
-//           ])
-//           .encodeABI(),
-//       });
-//     }
-//     res = web3.eth.abi.decodeParameters(
-//       ["uint256[5]", "uint256", "uint256[5]", "uint256"],
-//       res.logs["1"].data
-//     );
-//     data = await oracle.getMinedBlockNum(1, res[1]);
-//     console.log("data2", data *1)
-//     assert(data*1 > 0, "Should be true if Data exist for that point in time");
-//     for (var i = 21; i <= 30; i++) {
-//       apix = "api" + i;
-//       await web3.eth.sendTransaction({
-//         to: oracle.address,
-//         from: accounts[2],
-//         gas: 7000000,
-//         data: oracle2.methods.addTip(i + 2, i).encodeABI(),
-//       });
-//     }
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[2],
-//       gas: 7000000,
-//       data: oracle2.methods.addTip(1, 31).encodeABI(),
-//     });
-//     vars = await oracle2.methods.getNewCurrentVariables().call();
-//     for (var i = 0; i < 5; i++) {
-//       res = await web3.eth.sendTransaction({
-//         to: oracle.address,
-//         from: accounts[i],
-//         gas: 7000000,
-//         data: oracle2.methods
-//           .testSubmitMiningSolution("nonce", vars["1"], [
-//             1200,
-//             1300,
-//             1400,
-//             1500,
-//             1600,
-//           ])
-//           .encodeABI(),
-//       });
-//     }
-//     res = web3.eth.abi.decodeParameters(
-//       ["uint256[5]", "uint256", "uint256[5]", "uint256"],
-//       res.logs["1"].data
-//     );
-//     data = await oracle.getMinedBlockNum(2, res[1]);
-//     console.log("data3", data*1)
-//     //assert(data*1 > 0, "Should be true if Data exist for that point in time");
-//     for (var i = 31; i <= 40; i++) {
-//       await web3.eth.sendTransaction({
-//         to: oracle.address,
-//         from: accounts[2],
-//         gas: 7000000,
-//         data: oracle2.methods.addTip(i + 2, i).encodeABI(),
-//       });
-//     }
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[2],
-//       gas: 7000000,
-//       data: oracle2.methods.addTip(2, 41).encodeABI(),
-//     });
-//     vars = await oracle2.methods.getNewCurrentVariables().call();
-//     for (var i = 0; i < 5; i++) {
-//       res = await web3.eth.sendTransaction({
-//         to: oracle.address,
-//         from: accounts[i],
-//         gas: 7000000,
-//         data: oracle2.methods
-//           .testSubmitMiningSolution("nonce", vars["1"], [
-//             1200,
-//             1300,
-//             1400,
-//             1500,
-//             1600,
-//           ])
-//           .encodeABI(),
-//       });
-//     }
-//     res = web3.eth.abi.decodeParameters(
-//       ["uint256[5]", "uint256", "uint256[5]", "uint256"],
-//       res.logs["1"].data
-//     );
-//     data = await oracle.getMinedBlockNum(1, res[1]);
-//     console.log("data4", data*1)
-//     assert(data > 0, "Should be true if Data exist for that point in time");
-//     for (var i = 41; i <= 55; i++) {
-//       apix = "api" + i;
-//       await web3.eth.sendTransaction({
-//         to: oracle.address,
-//         from: accounts[2],
-//         gas: 7000000,
-//         data: oracle2.methods.addTip(i + 2, i).encodeABI(),
-//       });
-//     }
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[2],
-//       gas: 7000000,
-//       data: oracle2.methods.addTip(1, 56).encodeABI(),
-//     });
-//     vars = await oracle2.methods.getNewCurrentVariables().call();
-//     for (var i = 0; i < 5; i++) {
-//       res = await web3.eth.sendTransaction({
-//         to: oracle.address,
-//         from: accounts[i],
-//         gas: 7000000,
-//         data: oracle2.methods
-//           .testSubmitMiningSolution("nonce", vars["1"], [
-//             1200,
-//             1300,
-//             1400,
-//             1500,
-//             1600,
-//           ])
-//           .encodeABI(),
-//       });
-//     }
-//     res = web3.eth.abi.decodeParameters(
-//       ["uint256[5]", "uint256", "uint256[5]", "uint256"],
-//       res.logs["1"].data
-//     );
-//     data = await oracle.getMinedBlockNum(2, res[1]);
-//     console.log("data5", data*1)
-//     assert(data*1 > 0, "Should be true if Data exist for that point in time");
-//     apiVars = await oracle.getRequestVars(52);
-//     apiIdforpayoutPoolIndex = await oracle.getRequestIdByRequestQIndex(50);
-//     vars = await oracle2.methods.getNewVariablesOnDeck().call();
-//     let apiOnQ = vars["0"];
-//     apiIdforpayoutPoolIndex2 = await oracle.getRequestIdByRequestQIndex(49);
-//     assert(apiIdforpayoutPoolIndex == 1, "position 1 should be booted");
-//     assert(vars["1"].includes("51"), "API on Q payout should be 51");
-//     assert(apiOnQ.includes("51"), "API on Q should be 51");
-//     assert(apiVars[5] == 51, "value at position 52 should have correct value");
-//     assert(apiIdforpayoutPoolIndex2 == 3, "position 2 should be in same place");
-//   });
-//   // it("Test Throw on Multiple Disputes", async function() {
-//   //   vars = await oracle2.methods.getNewCurrentVariables().call();
-//   //   for (var i = 0; i < 5; i++) {
-//   //     res = await web3.eth.sendTransaction({
-//   //       to: oracle.address,
-//   //       from: accounts[i],
-//   //       gas: 7000000,
-//   //       data: oracle2.methods
-//   //         .testSubmitMiningSolution("nonce", vars["1"], [
-//   //           1200,
-//   //           1300,
-//   //           1400,
-//   //           1500,
-//   //           1600,
-//   //         ])
-//   //         .encodeABI(),
-//   //     });
-//   //   }
-//   //   res = web3.eth.abi.decodeParameters(
-//   //     ["uint256[5]", "uint256", "uint256[5]", "uint256"],
-//   //     res.logs["1"].data
-//   //   );
-//   //   balance1 = await oracle.balanceOf(accounts[2], { from: accounts[4] });
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[0],
-//   //     gas: 7000000,
-//   //     data: oracle2.methods
-//   //       .theLazyCoon(accounts[1], web3.utils.toWei("5000", "ether"))
-//   //       .encodeABI(),
-//   //   });
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[1],
-//   //     gas: 7000000,
-//   //     data: oracle2.methods.beginDispute(1, res[1], 2).encodeABI(),
-//   //   });
-//   //   await helper.expectThrow(
-//   //     web3.eth.sendTransaction({
-//   //       to: oracle.address,
-//   //       from: accounts[1],
-//   //       gas: 7000000,
-//   //       data: oracle2.methods.beginDispute(1, res[1], 2).encodeABI(),
-//   //     })
-//   //   );
-//   //   let miners = await oracle.getMinersByRequestIdAndTimestamp(1, res[1]);
+  it("Test time travel in data -- really long timesincelastPoof and proper difficulty adjustment", async function() {
+    for (var j = 0; j < 6; j++) {
+      vars = await oracle2.methods.getNewCurrentVariables().call();
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[0],
+        gas: 7000000,
+        data: oldTellorinst.methods.addTip(1, 500).encodeABI(),
+      });
+      for (var i = 0; i < 5; i++) {
+        await web3.eth.sendTransaction({
+          to: oracle.address,
+          from: accounts[i],
+          gas: 7000000,
+          data: oracle2.methods
+            .testSubmitMiningSolution("nonce", vars["1"], [
+              1200,
+              1300,
+              1400,
+              1500,
+              1600,
+            ])
+            .encodeABI(),
+        });
+      }
+    }
+    vars = await oracle2.methods.getNewCurrentVariables().call();
+    var oldDiff = vars[2];
+    assert(vars[2] > 1, "difficulty should be greater than 1"); //difficulty not changing.....
+    await helper.advanceTime(86400 * 20);
+    vars = await oracle2.methods.getNewCurrentVariables().call();
+    for (var i = 0; i < 5; i++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods
+          .testSubmitMiningSolution("nonce", vars["1"], [
+            1200,
+            1300,
+            1400,
+            1500,
+            1600,
+          ])
+          .encodeABI(),
+      });
+    }
+    vars = await oracle2.methods.getNewCurrentVariables().call();
+    var newDiff = vars[2];
+    assert(newDiff < oldDiff, "difficulty should be lower");
+    assert(
+      (await oracle.getNewValueCountbyRequestId(1)) == 5,
+      "Request ID 1 should have 8 mines"
+    );
+  });
 
-//   //   let disp = await oracle.getAllDisputeVars(1);
-//   //   let _var = await oracle.getDisputeIdByDisputeHash(
-//   //     web3.utils.soliditySha3(
-//   //       { t: "address", v: miners[2] },
-//   //       { t: "uint256", v: 1 },
-//   //       { t: "uint256", v: res[1] }
-//   //     )
-//   //   );
-//   //   assert(_var == 1, "hash should be same");
-//   // });
-//   // it("Ensure Miner staked after failed dispute", async function() {
-//   //   vars = await oracle2.methods.getNewCurrentVariables().call();
-//   //   for (var i = 0; i < 5; i++) {
-//   //     res = await web3.eth.sendTransaction({
-//   //       to: oracle.address,
-//   //       from: accounts[i],
-//   //       gas: 7000000,
-//   //       data: oracle2.methods
-//   //         .testSubmitMiningSolution("nonce", vars["1"], [
-//   //           1200,
-//   //           1300,
-//   //           1400,
-//   //           1500,
-//   //           1600,
-//   //         ])
-//   //         .encodeABI(),
-//   //     });
-//   //   }
-//   //   res = web3.eth.abi.decodeParameters(
-//   //     ["uint256[5]", "uint256", "uint256[5]", "uint256"],
-//   //     res.logs["1"].data
-//   //   );
-//   //   balance1 = await oracle.balanceOf(accounts[2]);
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[0],
-//   //     gas: 7000000,
-//   //     data: oracle2.methods
-//   //       .theLazyCoon(accounts[1], web3.utils.toWei("5000", "ether"))
-//   //       .encodeABI(),
-//   //   });
-//   //   dispBal1 = await oracle.balanceOf(accounts[1]);
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[1],
-//   //     gas: 7000000,
-//   //     data: oracle2.methods.beginDispute(1, res[1], 2).encodeABI(),
-//   //   });
-//   //   count = await await oracle.getUintVar(web3.utils.keccak256("disputeCount"));
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[3],
-//   //     gas: 7000000,
-//   //     data: oracle2.methods.vote(1, false).encodeABI(),
-//   //   });
-//   //   await helper.advanceTime(86400 * 22);
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[0],
-//   //     gas: 7000000,
-//   //     data: oracle2.methods.tallyVotes(1).encodeABI(),
-//   //   });
-//   //   await helper.advanceTime(86400 * 2);
-//   //   await web3.eth.sendTransaction({
-//   //     to: oracle.address,
-//   //     from: accounts[0],
-//   //     gas: 9000000,
-//   //     data: oracle2.methods.unlockDisputeFee(1).encodeABI(),
-//   //   });
-//   //   balance2 = await oracle.balanceOf(accounts[2]);
-//   //   dispBal2 = await oracle.balanceOf(accounts[1]);
-//   //   let df = await oracle.getUintVar(web3.utils.keccak256("disputeFee"));
-//   //   assert(
-//   //     web3.utils.fromWei(balance2) - web3.utils.fromWei(balance1) == 1000,
-//   //     "balance1 should equal balance2 plus disputeBal"
-//   //   );
-//   //   assert(
-//   //     web3.utils.fromWei(dispBal1) - web3.utils.fromWei(dispBal2) == 1000,
-//   //     "disputers balance shoudl change properly"
-//   //   );
-//   //   s = await oracle.getStakerInfo(accounts[2]);
-//   //   assert(s[0] == 1, " Staked");
-//   // });
+  //index 2 dispute fee updates
+  it("Test multiple dispute to official value/miner index 2", async function() {
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods
+        .theLazyCoon(accounts[0], web3.utils.toWei("5000", "ether"))
+        .encodeABI(),
+    });
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods
+        .theLazyCoon(accounts[1], web3.utils.toWei("5000", "ether"))
+        .encodeABI(),
+    });
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods
+        .theLazyCoon(accounts[4], web3.utils.toWei("5000", "ether"))
+        .encodeABI(),
+    });
+    resVars = [];
+    for (j = 0; j < 5; j++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[0],
+        gas: 7000000,
+        data: oracle2.methods.addTip(1, 1000).encodeABI(),
+      });
+      vars = await oracle2.methods.getNewCurrentVariables().call();
+      for (var i = 0; i < 5; i++) {
+        res = await web3.eth.sendTransaction({
+          to: oracle.address,
+          from: accounts[i],
+          gas: 7000000,
+          data: oracle2.methods
+            .testSubmitMiningSolution("nonce", vars["1"], [
+              1200,
+              1300,
+              1400,
+              1500,
+              1600,
+            ])
+            .encodeABI(),
+        });
+      }
+      resVars[j] = web3.eth.abi.decodeParameters(
+        ["uint256[5]", "uint256", "uint256[5]", "uint256"],
+        res.logs["1"].data
+      );
+      await helper.advanceTime(1000);
+    }
+    balance1 = await oracle.balanceOf(accounts[2]);
+    dispBal1 = await oracle.balanceOf(accounts[1]);
+    orig_dispBal4 = await oracle.balanceOf(accounts[4]);
+    //1st dispute to miner
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[1],
+      gas: 7000000,
+      data: oracle2.methods.beginDispute(1, resVars[0][1], 2).encodeABI(),
+    });
+    count = await oracle.getUintVar(web3.utils.keccak256("disputeCount"));
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[4],
+      gas: 7000000,
+      data: oracle2.methods.beginDispute(1, resVars[2][1], 2).encodeABI(),
+    });
+    count2 = await oracle.getUintVar(web3.utils.keccak256("disputeCount"));
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods.beginDispute(1, resVars[4][1], 2).encodeABI(),
+    });
+    count2 = await oracle.getUintVar(web3.utils.keccak256("disputeCount"));
+    //dispute votes and tally
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[3],
+      gas: 7000000,
+      data: oracle2.methods.vote(1, true).encodeABI(),
+    });
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[3],
+      gas: 7000000,
+      data: oracle2.methods.vote(2, true).encodeABI(),
+    });
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[3],
+      gas: 7000000,
+      data: oracle2.methods.vote(3, true).encodeABI(),
+    });
+    await helper.advanceTime(86400 * 22);
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods.tallyVotes(1).encodeABI(),
+    });
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods.tallyVotes(2).encodeABI(),
+    });
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods.tallyVotes(3).encodeABI(),
+    });
+    await helper.advanceTime(86400 * 2);
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 9000000,
+      data: oracle2.methods.unlockDisputeFee(1).encodeABI(),
+    });
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 9000000,
+      data: oracle2.methods.unlockDisputeFee(2).encodeABI(),
+    });
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 9000000,
+      data: oracle2.methods.unlockDisputeFee(3).encodeABI(),
+    });
+    dispInfo = await oracle.getAllDisputeVars(1);
+    assert(dispInfo[7][0] == 1);
+    assert(dispInfo[7][1] == resVars[0][1]);
+    assert(dispInfo[7][2] == 1200);
+    assert(dispInfo[2] == true, "Dispute Vote passed");
+    voted = await oracle.didVote(1, accounts[3]);
+    assert(voted == true, "account 3 voted");
+    voted = await oracle.didVote(1, accounts[5]);
+    assert(voted == false, "account 5 did not vote");
+    apid2valueF = await oracle.retrieveData(1, resVars[0][1]);
+    assert(
+      apid2valueF == 0,
+      "value should now be zero this checks updateDisputeValue-internal fx  works"
+    );
+    //checks balances after dispute 1
+    balance2 = await oracle.balanceOf(accounts[2]);
+    dispBal2 = await oracle.balanceOf(accounts[1]);
+    assert(
+      web3.utils.fromWei(balance1) - web3.utils.fromWei(balance2) > 999,
+      "reported miner's balance should change correctly"
+    );
+    assert(
+      web3.utils.fromWei(balance1) - web3.utils.fromWei(balance2) < 1001,
+      "reported miner's balance should change correctly"
+    );
+    assert(
+      web3.utils.fromWei(dispBal2) - web3.utils.fromWei(dispBal1) == 1000,
+      "disputing party's balance should change correctly"
+    );
+    s = await oracle.getStakerInfo(accounts[2]);
+    assert(s != 1, " Not staked");
+    dispBal4 = await oracle.balanceOf(accounts[4]);
+    assert(dispBal4 - orig_dispBal4 == 0, "a4 shouldn't change'");
+  });
+  it("Test time travel in data -- really long timesincelastPoof and proper difficulty adjustment", async function() {
+    for (var j = 0; j < 6; j++) {
+      vars = await oracle2.methods.getNewCurrentVariables().call();
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[0],
+        gas: 7000000,
+        data: oldTellorinst.methods.addTip(1, 500).encodeABI(),
+      });
+      for (var i = 0; i < 5; i++) {
+        await web3.eth.sendTransaction({
+          to: oracle.address,
+          from: accounts[i],
+          gas: 7000000,
+          data: oracle2.methods
+            .testSubmitMiningSolution("nonce", vars["1"], [
+              1200,
+              1300,
+              1400,
+              1500,
+              1600,
+            ])
+            .encodeABI(),
+        });
+      }
+    }
+    vars = await oracle2.methods.getNewCurrentVariables().call();
+    var oldDiff = vars[2];
+    assert(vars[2] > 1, "difficulty should be greater than 1"); //difficulty not changing.....
+    await helper.advanceTime(86400 * 20);
+    vars = await oracle2.methods.getNewCurrentVariables().call();
+    for (var i = 0; i < 5; i++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods
+          .testSubmitMiningSolution("nonce", vars["1"], [
+            1200,
+            1300,
+            1400,
+            1500,
+            1600,
+          ])
+          .encodeABI(),
+      });
+    }
+    vars = await oracle2.methods.getNewCurrentVariables().call();
+    var newDiff = vars[2];
+    assert(newDiff < oldDiff, "difficulty should be lower");
+    assert(
+      (await oracle.getNewValueCountbyRequestId(1)) == 5,
+      "Request ID 1 should have 8 mines"
+    );
+  });
 
-//   // it("Test failed Dispute of different miner Indexes", async function() {
-//   //   for (var i = 1; i < 5; i++) {
-//   //     vars = await oracle2.methods.getNewCurrentVariables().call();
-//   //     for (var ii = 1; ii < 6; ii++) {
-//   //       res = await web3.eth.sendTransaction({
-//   //         to: oracle.address,
-//   //         from: accounts[ii],
-//   //         gas: 7000000,
-//   //         data: oracle2.methods
-//   //           .testSubmitMiningSolution("nonce", vars["1"], [
-//   //             1200,
-//   //             1300,
-//   //             1400,
-//   //             1500,
-//   //             1600,
-//   //           ])
-//   //           .encodeABI(),
-//   //       });
-//   //     }
-//   //     res = web3.eth.abi.decodeParameters(
-//   //       ["uint256[5]", "uint256", "uint256[5]", "uint256"],
-//   //       res.logs["1"].data
-//   //     );
-//   //     let miners = await oracle.getMinersByRequestIdAndTimestamp(
-//   //       vars["1"][0],
-//   //       res[1]
-//   //     );
-//   //     await web3.eth.sendTransaction({
-//   //       to: oracle.address,
-//   //       from: accounts[0],
-//   //       gas: 7000000,
-//   //       data: oracle2.methods
-//   //         .beginDispute(vars["1"][0], res[1], i - 1)
-//   //         .encodeABI(),
-//   //     });
-//   //     let disputeVars = await oracle.getAllDisputeVars(i);
-//   //     balance1 = await oracle.balanceOf(miners[i - 1]);
-//   //     assert(disputeVars["4"] == miners[i - 1], "miner should be correct");
-//   //     await web3.eth.sendTransaction({
-//   //       to: oracle.address,
-//   //       from: accounts[i + 1],
-//   //       gas: 7000000,
-//   //       data: oracle2.methods.vote(i, false).encodeABI(),
-//   //     });
-//   //     await helper.advanceTime(86400 * 7);
-//   //     await web3.eth.sendTransaction({
-//   //       to: oracle.address,
-//   //       from: accounts[0],
-//   //       gas: 7000000,
-//   //       data: oracle2.methods.tallyVotes(i).encodeABI(),
-//   //     });
-//   //     await helper.advanceTime(86400 * 2);
-//   //     await web3.eth.sendTransaction({
-//   //       to: oracle.address,
-//   //       from: accounts[0],
-//   //       gas: 9000000,
-//   //       data: oracle2.methods.unlockDisputeFee(i).encodeABI(),
-//   //     });
-//   //     assert((await oracle.isInDispute(vars["1"][0], res[1])) == false);
-//   //     balance2 = await oracle.balanceOf(miners[i - 1]);
-//   //     dispVars = await oracle.getAllDisputeVars(i);
-//   //     assert(
-//   //       web3.utils.fromWei(balance2) - web3.utils.fromWei(balance1) ==
-//   //         web3.utils.fromWei(dispVars[7][8]),
-//   //       "reported miner's balance should change correctly"
-//   //     );
-//   //     s = await oracle.getStakerInfo(miners[i - 1]);
-//   //     assert(s[0] == 1, " Staked");
-//   //   }
-//   // });
-  
-//  });
+  it("Test 50 requests, proper booting, and mining of 5", async function() {
+    vars = await oracle2.methods.getNewCurrentVariables().call();
+    for (var i = 0; i < 5; i++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods
+          .testSubmitMiningSolution("nonce", vars["1"], [
+            1200,
+            1300,
+            1400,
+            1500,
+            1600,
+          ])
+          .encodeABI(),
+      });
+    }
+    for (var i = 1; i <= 10; i++) {
+      apix = "api" + i;
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[2],
+        gas: 7000000,
+        data: oracle2.methods.addTip(i + 2, i).encodeABI(),
+      });
+    }
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[2],
+      gas: 7000000,
+      data: oracle2.methods.addTip(1, 11).encodeABI(),
+    });
+    vars = await oracle2.methods.getNewCurrentVariables().call();
+    for (var i = 0; i < 5; i++) {
+      res = await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods
+          .testSubmitMiningSolution("nonce", vars["1"], [
+            1200,
+            1300,
+            1400,
+            1500,
+            1600,
+          ])
+          .encodeABI(),
+      });
+    }
+    res = web3.eth.abi.decodeParameters(
+      ["uint256[5]", "uint256", "uint256[5]", "uint256"],
+      res.logs["1"].data
+    );
+    data = await oracle.getMinedBlockNum(2, res[1]);
+    console.log("data1", data * 1);
+    assert(data * 1 > 0, "Should be true if Data exist for that point in time");
+    for (var i = 11; i <= 20; i++) {
+      apix = "api" + i;
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[2],
+        gas: 7000000,
+        data: oracle2.methods.addTip(i + 2, i).encodeABI(),
+      });
+    }
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[2],
+      gas: 7000000,
+      data: oracle2.methods.addTip(2, 21).encodeABI(),
+    });
+    vars = await oracle2.methods.getNewCurrentVariables().call();
+    for (var i = 0; i < 5; i++) {
+      res = await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods
+          .testSubmitMiningSolution("nonce", vars["1"], [
+            1200,
+            1300,
+            1400,
+            1500,
+            1600,
+          ])
+          .encodeABI(),
+      });
+    }
+    res = web3.eth.abi.decodeParameters(
+      ["uint256[5]", "uint256", "uint256[5]", "uint256"],
+      res.logs["1"].data
+    );
+    data = await oracle.getMinedBlockNum(1, res[1]);
+    console.log("data2", data * 1);
+    assert(data * 1 > 0, "Should be true if Data exist for that point in time");
+    for (var i = 21; i <= 30; i++) {
+      apix = "api" + i;
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[2],
+        gas: 7000000,
+        data: oracle2.methods.addTip(i + 2, i).encodeABI(),
+      });
+    }
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[2],
+      gas: 7000000,
+      data: oracle2.methods.addTip(1, 31).encodeABI(),
+    });
+    vars = await oracle2.methods.getNewCurrentVariables().call();
+    for (var i = 0; i < 5; i++) {
+      res = await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods
+          .testSubmitMiningSolution("nonce", vars["1"], [
+            1200,
+            1300,
+            1400,
+            1500,
+            1600,
+          ])
+          .encodeABI(),
+      });
+    }
+    res = web3.eth.abi.decodeParameters(
+      ["uint256[5]", "uint256", "uint256[5]", "uint256"],
+      res.logs["1"].data
+    );
+    data = await oracle.getMinedBlockNum(2, res[1]);
+    console.log("data3", data * 1);
+    //assert(data*1 > 0, "Should be true if Data exist for that point in time");
+    for (var i = 31; i <= 40; i++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[2],
+        gas: 7000000,
+        data: oracle2.methods.addTip(i + 2, i).encodeABI(),
+      });
+    }
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[2],
+      gas: 7000000,
+      data: oracle2.methods.addTip(2, 41).encodeABI(),
+    });
+    vars = await oracle2.methods.getNewCurrentVariables().call();
+    for (var i = 0; i < 5; i++) {
+      res = await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods
+          .testSubmitMiningSolution("nonce", vars["1"], [
+            1200,
+            1300,
+            1400,
+            1500,
+            1600,
+          ])
+          .encodeABI(),
+      });
+    }
+    res = web3.eth.abi.decodeParameters(
+      ["uint256[5]", "uint256", "uint256[5]", "uint256"],
+      res.logs["1"].data
+    );
+    data = await oracle.getMinedBlockNum(1, res[1]);
+    console.log("data4", data * 1);
+    assert(data > 0, "Should be true if Data exist for that point in time");
+    for (var i = 41; i <= 55; i++) {
+      apix = "api" + i;
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[2],
+        gas: 7000000,
+        data: oracle2.methods.addTip(i + 2, i).encodeABI(),
+      });
+    }
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[2],
+      gas: 7000000,
+      data: oracle2.methods.addTip(1, 56).encodeABI(),
+    });
+    vars = await oracle2.methods.getNewCurrentVariables().call();
+    for (var i = 0; i < 5; i++) {
+      res = await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods
+          .testSubmitMiningSolution("nonce", vars["1"], [
+            1200,
+            1300,
+            1400,
+            1500,
+            1600,
+          ])
+          .encodeABI(),
+      });
+    }
+    res = web3.eth.abi.decodeParameters(
+      ["uint256[5]", "uint256", "uint256[5]", "uint256"],
+      res.logs["1"].data
+    );
+    data = await oracle.getMinedBlockNum(2, res[1]);
+    console.log("data5", data * 1);
+    assert(data * 1 > 0, "Should be true if Data exist for that point in time");
+    apiVars = await oracle.getRequestVars(52);
+    apiIdforpayoutPoolIndex = await oracle.getRequestIdByRequestQIndex(50);
+    vars = await oracle2.methods.getNewVariablesOnDeck().call();
+    let apiOnQ = vars["0"];
+    apiIdforpayoutPoolIndex2 = await oracle.getRequestIdByRequestQIndex(49);
+    assert(apiIdforpayoutPoolIndex == 1, "position 1 should be booted");
+    assert(vars["1"].includes("51"), "API on Q payout should be 51");
+    assert(apiOnQ.includes("51"), "API on Q should be 51");
+    assert(apiVars[5] == 51, "value at position 52 should have correct value");
+    assert(apiIdforpayoutPoolIndex2 == 3, "position 2 should be in same place");
+  });
+  it("Test Throw on Multiple Disputes", async function() {
+    vars = await oracle2.methods.getNewCurrentVariables().call();
+    for (var i = 0; i < 5; i++) {
+      res = await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods
+          .testSubmitMiningSolution("nonce", vars["1"], [
+            1200,
+            1300,
+            1400,
+            1500,
+            1600,
+          ])
+          .encodeABI(),
+      });
+    }
+    res = web3.eth.abi.decodeParameters(
+      ["uint256[5]", "uint256", "uint256[5]", "uint256"],
+      res.logs["1"].data
+    );
+    balance1 = await oracle.balanceOf(accounts[2], { from: accounts[4] });
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods
+        .theLazyCoon(accounts[1], web3.utils.toWei("5000", "ether"))
+        .encodeABI(),
+    });
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[1],
+      gas: 7000000,
+      data: oracle2.methods.beginDispute(1, res[1], 2).encodeABI(),
+    });
+    await helper.expectThrow(
+      web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[1],
+        gas: 7000000,
+        data: oracle2.methods.beginDispute(1, res[1], 2).encodeABI(),
+      })
+    );
+    let miners = await oracle.getMinersByRequestIdAndTimestamp(1, res[1]);
+
+    let disp = await oracle.getAllDisputeVars(1);
+    let _var = await oracle.getDisputeIdByDisputeHash(
+      web3.utils.soliditySha3(
+        { t: "address", v: miners[2] },
+        { t: "uint256", v: 1 },
+        { t: "uint256", v: res[1] }
+      )
+    );
+    assert(_var == 1, "hash should be same");
+  });
+  it("Ensure Miner staked after failed dispute", async function() {
+    vars = await oracle2.methods.getNewCurrentVariables().call();
+    for (var i = 0; i < 5; i++) {
+      res = await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods
+          .testSubmitMiningSolution("nonce", vars["1"], [
+            1200,
+            1300,
+            1400,
+            1500,
+            1600,
+          ])
+          .encodeABI(),
+      });
+    }
+    res = web3.eth.abi.decodeParameters(
+      ["uint256[5]", "uint256", "uint256[5]", "uint256"],
+      res.logs["1"].data
+    );
+    balance1 = await oracle.balanceOf(accounts[2]);
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods
+        .theLazyCoon(accounts[1], web3.utils.toWei("5000", "ether"))
+        .encodeABI(),
+    });
+    dispBal1 = await oracle.balanceOf(accounts[1]);
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[1],
+      gas: 7000000,
+      data: oracle2.methods.beginDispute(1, res[1], 2).encodeABI(),
+    });
+    count = await await oracle.getUintVar(web3.utils.keccak256("disputeCount"));
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[3],
+      gas: 7000000,
+      data: oracle2.methods.vote(1, false).encodeABI(),
+    });
+    await helper.advanceTime(86400 * 22);
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods.tallyVotes(1).encodeABI(),
+    });
+    await helper.advanceTime(86400 * 2);
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 9000000,
+      data: oracle2.methods.unlockDisputeFee(1).encodeABI(),
+    });
+    balance2 = await oracle.balanceOf(accounts[2]);
+    dispBal2 = await oracle.balanceOf(accounts[1]);
+    let df = await oracle.getUintVar(web3.utils.keccak256("disputeFee"));
+    assert(
+      web3.utils.fromWei(balance2) - web3.utils.fromWei(balance1) == 1000,
+      "balance1 should equal balance2 plus disputeBal"
+    );
+    assert(
+      web3.utils.fromWei(dispBal1) - web3.utils.fromWei(dispBal2) == 1000,
+      "disputers balance shoudl change properly"
+    );
+    s = await oracle.getStakerInfo(accounts[2]);
+    assert(s[0] == 1, " Staked");
+  });
+
+  it("Test failed Dispute of different miner Indexes", async function() {
+    for (var i = 1; i < 5; i++) {
+      vars = await oracle2.methods.getNewCurrentVariables().call();
+      for (var ii = 1; ii < 6; ii++) {
+        res = await web3.eth.sendTransaction({
+          to: oracle.address,
+          from: accounts[ii],
+          gas: 7000000,
+          data: oracle2.methods
+            .testSubmitMiningSolution("nonce", vars["1"], [
+              1200,
+              1300,
+              1400,
+              1500,
+              1600,
+            ])
+            .encodeABI(),
+        });
+      }
+      res = web3.eth.abi.decodeParameters(
+        ["uint256[5]", "uint256", "uint256[5]", "uint256"],
+        res.logs["1"].data
+      );
+      let miners = await oracle.getMinersByRequestIdAndTimestamp(
+        vars["1"][0],
+        res[1]
+      );
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[0],
+        gas: 7000000,
+        data: oracle2.methods
+          .beginDispute(vars["1"][0], res[1], i - 1)
+          .encodeABI(),
+      });
+      let disputeVars = await oracle.getAllDisputeVars(i);
+      balance1 = await oracle.balanceOf(miners[i - 1]);
+      assert(disputeVars["4"] == miners[i - 1], "miner should be correct");
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i + 1],
+        gas: 7000000,
+        data: oracle2.methods.vote(i, false).encodeABI(),
+      });
+      await helper.advanceTime(86400 * 7);
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[0],
+        gas: 7000000,
+        data: oracle2.methods.tallyVotes(i).encodeABI(),
+      });
+      await helper.advanceTime(86400 * 2);
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[0],
+        gas: 9000000,
+        data: oracle2.methods.unlockDisputeFee(i).encodeABI(),
+      });
+      assert((await oracle.isInDispute(vars["1"][0], res[1])) == false);
+      balance2 = await oracle.balanceOf(miners[i - 1]);
+      dispVars = await oracle.getAllDisputeVars(i);
+      assert(
+        web3.utils.fromWei(balance2) - web3.utils.fromWei(balance1) ==
+          web3.utils.fromWei(dispVars[7][8]),
+        "reported miner's balance should change correctly"
+      );
+      s = await oracle.getStakerInfo(miners[i - 1]);
+      assert(s[0] == 1, " Staked");
+    }
+  });
+});

--- a/test/testOracle.js
+++ b/test/testOracle.js
@@ -65,8 +65,8 @@ contract("Mining Tests", function(accounts) {
         from: accounts[i],
         gas: 7000000,
         data: oracle2.methods[
-          "testSubmitMiningSolution(string,uint256,uint256)"
-        ]("nonce", 1, 1200).encodeABI(),
+          "testSubmitMiningSolution(string,uint256[5],uint256[5])"
+        ]("nonce", [1, 2, 3, 4, 5], [1100, 1200, 1300, 1400, 1500]).encodeABI(),
       });
     }
     // for(var i = 1;i<6;i++){

--- a/test/testUpgrade.js
+++ b/test/testUpgrade.js
@@ -1,734 +1,734 @@
-/**
- * This tests the oracle upgrade functions
- */
-const Web3 = require("web3");
-const web3 = new Web3(
-  new Web3.providers.WebsocketProvider("ws://localhost:8545")
-);
-const helper = require("./helpers/test_helpers");
-const TellorMaster = artifacts.require("./TellorMaster.sol");
-const Tellor = artifacts.require("./Tellor.sol"); // globally injected artifacts helper
-var oracleAbi = Tellor.abi;
-var oracleByte = Tellor.bytecode;
-var OldTellor = artifacts.require("./oldContracts/OldTellor.sol");
-var oldTellorABI = OldTellor.abi;
+// /**
+//  * This tests the oracle upgrade functions
+//  */
+// const Web3 = require("web3");
+// const web3 = new Web3(
+//   new Web3.providers.WebsocketProvider("ws://localhost:8545")
+// );
+// const helper = require("./helpers/test_helpers");
+// const TellorMaster = artifacts.require("./TellorMaster.sol");
+// const Tellor = artifacts.require("./Tellor.sol"); // globally injected artifacts helper
+// var oracleAbi = Tellor.abi;
+// var oracleByte = Tellor.bytecode;
+// var OldTellor = artifacts.require("./oldContracts/OldTellor.sol");
+// var oldTellorABI = OldTellor.abi;
 
-var OldTellor2 = artifacts.require("./oldContracts2/OldTellor2.sol");
-var oldTellor2ABI = OldTellor2.abi;
-var UtilitiesTests = artifacts.require("./UtilitiesTests.sol");
-var masterAbi = TellorMaster.abi;
-var api = "json(https://api.gdax.com/products/BTC-USD/ticker).price";
-var api2 = "json(https://api.gdax.com/products/ETH-USD/ticker).price";
+// var OldTellor2 = artifacts.require("./oldContracts2/OldTellor2.sol");
+// var oldTellor2ABI = OldTellor2.abi;
+// var UtilitiesTests = artifacts.require("./UtilitiesTests.sol");
+// var masterAbi = TellorMaster.abi;
+// var api = "json(https://api.gdax.com/products/BTC-USD/ticker).price";
+// var api2 = "json(https://api.gdax.com/products/ETH-USD/ticker).price";
 
-contract("Upgrade Tests", function(accounts) {
-  let oracleBase;
-  let oracle;
-  let oracle2;
-  let master;
-  let oldTellor;
-  let oldTellor2;
-  let utilities;
+// contract("Upgrade Tests", function(accounts) {
+//   let oracleBase;
+//   let oracle;
+//   let oracle2;
+//   let master;
+//   let oldTellor;
+//   let oldTellor2;
+//   let utilities;
 
-  it("Test upgrade no Q", async function() {
-    //deploy old, request, update address, mine old challenge.
-    oldTellor = await OldTellor.new();
-    oracle = await TellorMaster.new(oldTellor.address);
-    master = await new web3.eth.Contract(masterAbi, oracle.address);
-    oracle2 = await new web3.eth.Contract(oldTellorABI, oldTellor.address);
-    for (var i = 0; i < 6; i++) {
-      //print tokens
-      await web3.eth.sendTransaction({
-        to: oracle.address,
-        from: accounts[0],
-        gas: 7000000,
-        data: oracle2.methods
-          .theLazyCoon(accounts[i], web3.utils.toWei("1100", "ether"))
-          .encodeABI(),
-      });
-    }
+//   it("Test upgrade no Q", async function() {
+//     //deploy old, request, update address, mine old challenge.
+//     oldTellor = await OldTellor.new();
+//     oracle = await TellorMaster.new(oldTellor.address);
+//     master = await new web3.eth.Contract(masterAbi, oracle.address);
+//     oracle2 = await new web3.eth.Contract(oldTellorABI, oldTellor.address);
+//     for (var i = 0; i < 6; i++) {
+//       //print tokens
+//       await web3.eth.sendTransaction({
+//         to: oracle.address,
+//         from: accounts[0],
+//         gas: 7000000,
+//         data: oracle2.methods
+//           .theLazyCoon(accounts[i], web3.utils.toWei("1100", "ether"))
+//           .encodeABI(),
+//       });
+//     }
 
-    await web3.eth.sendTransaction({
-      to: oracle.address,
-      from: accounts[0],
-      gas: 7000000,
-      data: oracle2.methods.requestData(api, "i", 1000, 0).encodeABI(),
-    });
-    for (var i = 0; i < 5; i++) {
-      await web3.eth.sendTransaction({
-        to: oracle.address,
-        from: accounts[i],
-        gas: 7000000,
-        data: oracle2.methods[
-          "testSubmitMiningSolution(string,uint256,uint256)"
-        ]("nonce", 1, 1200).encodeABI(),
-      });
-    }
-    oldTellor2 = await OldTellor2.new();
-    await oracle.changeTellorContract(oldTellor2.address);
-    assert(
-      (await oracle.getAddressVars(web3.utils.keccak256("tellorContract"))) ==
-        oldTellor2.address
-    );
-    await web3.eth.sendTransaction({
-      to: oracle.address,
-      from: accounts[0],
-      gas: 7000000,
-      data: oracle2.methods.requestData("api2", "i2", 5000, 0).encodeABI(),
-    });
-    for (var i = 0; i < 5; i++) {
-      await web3.eth.sendTransaction({
-        to: oracle.address,
-        from: accounts[i],
-        gas: 7000000,
-        data: oracle2.methods[
-          "testSubmitMiningSolution(string,uint256,uint256)"
-        ]("nonce", 2, 1200).encodeABI(),
-      });
-    }
-    await web3.eth.sendTransaction({
-      to: oracle.address,
-      from: accounts[0],
-      gas: 7000000,
-      data: oracle2.methods.addTip(1, 0).encodeABI(),
-    });
-    for (var i = 0; i < 52; i++) {
-      x = "USD" + i;
-      apix = api + i;
-      await web3.eth.sendTransaction({
-        to: oracle.address,
-        from: accounts[0],
-        gas: 7000000,
-        data: oracle2.methods.requestData(apix, x, 1000, 0).encodeABI(),
-      });
-    }
-    //Deploy new upgraded Tellor
-    oracleBase = await Tellor.new();
-    oracle2 = await new web3.eth.Contract(oracleAbi, oracle.address);
-    await oracle.changeTellorContract(oracleBase.address);
-    for (var i = 0; i < 5; i++) {
-      await web3.eth.sendTransaction({
-        to: oracle.address,
-        from: accounts[i],
-        gas: 7000000,
-        data: oracle2.methods[
-          "testSubmitMiningSolution(string,uint256,uint256)"
-        ]("nonce", 1, 1200).encodeABI(),
-      });
-    }
-    vars = await oracle2.methods.getNewCurrentVariables().call();
-    for (var i = 0; i < 5; i++) {
-      await web3.eth.sendTransaction({
-        to: oracle.address,
-        from: accounts[i],
-        gas: 7000000,
-        data: oracle2.methods
-          .testSubmitMiningSolution("nonce", vars["1"], [
-            1200,
-            1300,
-            1400,
-            1500,
-            1600,
-          ])
-          .encodeABI(),
-      });
-    }
-    assert(
-      (await oracle.getAddressVars(web3.utils.keccak256("tellorContract"))) ==
-        oracleBase.address
-    );
-  });
-  it("Test upgrade with full queue", async function() {
-    //deploy old, request, update address, mine old challenge.
-    oldTellor = await OldTellor.new();
-    oracle = await TellorMaster.new(oldTellor.address);
-    master = await new web3.eth.Contract(masterAbi, oracle.address);
-    oracle2 = await new web3.eth.Contract(oldTellorABI, oldTellor.address);
-    utilities = await UtilitiesTests.new(oracle.address);
-    for (var i = 0; i < 6; i++) {
-      await web3.eth.sendTransaction({
-        to: oracle.address,
-        from: accounts[0],
-        gas: 7000000,
-        data: oracle2.methods
-          .theLazyCoon(accounts[i], web3.utils.toWei("1100", "ether"))
-          .encodeABI(),
-      });
-    }
-    for (var i = 0; i < 52; i++) {
-      x = "USD" + i;
-      apix = api + i;
-      await web3.eth.sendTransaction({
-        to: oracle.address,
-        from: accounts[0],
-        gas: 7000000,
-        data: oracle2.methods.requestData(apix, x, 1000, 50 + i).encodeABI(),
-      });
-    }
+//     await web3.eth.sendTransaction({
+//       to: oracle.address,
+//       from: accounts[0],
+//       gas: 7000000,
+//       data: oracle2.methods.requestData(api, "i", 1000, 0).encodeABI(),
+//     });
+//     for (var i = 0; i < 5; i++) {
+//       await web3.eth.sendTransaction({
+//         to: oracle.address,
+//         from: accounts[i],
+//         gas: 7000000,
+//         data: oracle2.methods[
+//           "testSubmitMiningSolution(string,uint256,uint256)"
+//         ]("nonce", 1, 1200).encodeABI(),
+//       });
+//     }
+//     oldTellor2 = await OldTellor2.new();
+//     await oracle.changeTellorContract(oldTellor2.address);
+//     assert(
+//       (await oracle.getAddressVars(web3.utils.keccak256("tellorContract"))) ==
+//         oldTellor2.address
+//     );
+//     await web3.eth.sendTransaction({
+//       to: oracle.address,
+//       from: accounts[0],
+//       gas: 7000000,
+//       data: oracle2.methods.requestData("api2", "i2", 5000, 0).encodeABI(),
+//     });
+//     for (var i = 0; i < 5; i++) {
+//       await web3.eth.sendTransaction({
+//         to: oracle.address,
+//         from: accounts[i],
+//         gas: 7000000,
+//         data: oracle2.methods[
+//           "testSubmitMiningSolution(string,uint256,uint256)"
+//         ]("nonce", 2, 1200).encodeABI(),
+//       });
+//     }
+//     await web3.eth.sendTransaction({
+//       to: oracle.address,
+//       from: accounts[0],
+//       gas: 7000000,
+//       data: oracle2.methods.addTip(1, 0).encodeABI(),
+//     });
+//     for (var i = 0; i < 52; i++) {
+//       x = "USD" + i;
+//       apix = api + i;
+//       await web3.eth.sendTransaction({
+//         to: oracle.address,
+//         from: accounts[0],
+//         gas: 7000000,
+//         data: oracle2.methods.requestData(apix, x, 1000, 0).encodeABI(),
+//       });
+//     }
+//     //Deploy new upgraded Tellor
+//     oracleBase = await Tellor.new();
+//     oracle2 = await new web3.eth.Contract(oracleAbi, oracle.address);
+//     await oracle.changeTellorContract(oracleBase.address);
+//     for (var i = 0; i < 5; i++) {
+//       await web3.eth.sendTransaction({
+//         to: oracle.address,
+//         from: accounts[i],
+//         gas: 7000000,
+//         data: oracle2.methods[
+//           "testSubmitMiningSolution(string,uint256[5],uint256[5])"
+//         ]("nonce", [1, 2, 3, 4, 5], [1100, 1200, 1300, 1400, 1500]).encodeABI(),
+//       });
+//     }
+//     vars = await oracle2.methods.getNewCurrentVariables().call();
+//     for (var i = 0; i < 5; i++) {
+//       await web3.eth.sendTransaction({
+//         to: oracle.address,
+//         from: accounts[i],
+//         gas: 7000000,
+//         data: oracle2.methods
+//           .testSubmitMiningSolution("nonce", vars["1"], [
+//             1200,
+//             1300,
+//             1400,
+//             1500,
+//             1600,
+//           ])
+//           .encodeABI(),
+//       });
+//     }
+//     assert(
+//       (await oracle.getAddressVars(web3.utils.keccak256("tellorContract"))) ==
+//         oracleBase.address
+//     );
+//   });
+//   it("Test upgrade with full queue", async function() {
+//     //deploy old, request, update address, mine old challenge.
+//     oldTellor = await OldTellor.new();
+//     oracle = await TellorMaster.new(oldTellor.address);
+//     master = await new web3.eth.Contract(masterAbi, oracle.address);
+//     oracle2 = await new web3.eth.Contract(oldTellorABI, oldTellor.address);
+//     utilities = await UtilitiesTests.new(oracle.address);
+//     for (var i = 0; i < 6; i++) {
+//       await web3.eth.sendTransaction({
+//         to: oracle.address,
+//         from: accounts[0],
+//         gas: 7000000,
+//         data: oracle2.methods
+//           .theLazyCoon(accounts[i], web3.utils.toWei("1100", "ether"))
+//           .encodeABI(),
+//       });
+//     }
+//     for (var i = 0; i < 52; i++) {
+//       x = "USD" + i;
+//       apix = api + i;
+//       await web3.eth.sendTransaction({
+//         to: oracle.address,
+//         from: accounts[0],
+//         gas: 7000000,
+//         data: oracle2.methods.requestData(apix, x, 1000, 50 + i).encodeABI(),
+//       });
+//     }
 
-    for (var i = 0; i < 5; i++) {
-      await web3.eth.sendTransaction({
-        to: oracle.address,
-        from: accounts[i],
-        gas: 7000000,
-        data: oracle2.methods[
-          "testSubmitMiningSolution(string,uint256,uint256)"
-        ]("nonce", 1, 1200).encodeABI(),
-      });
-    }
+//     for (var i = 0; i < 5; i++) {
+//       await web3.eth.sendTransaction({
+//         to: oracle.address,
+//         from: accounts[i],
+//         gas: 7000000,
+//         data: oracle2.methods[
+//           "testSubmitMiningSolution(string,uint256,uint256)"
+//         ]("nonce", 1, 1200).encodeABI(),
+//       });
+//     }
 
-    oldTellor2 = await OldTellor2.new();
-    oracle2 = await new web3.eth.Contract(oldTellor2ABI, oracle.address);
-    await oracle.changeTellorContract(oldTellor2.address);
-    assert(
-      (await oracle.getAddressVars(web3.utils.keccak256("tellorContract"))) ==
-        oldTellor2.address
-    );
-    for (var i = 0; i < 5; i++) {
-      await web3.eth.sendTransaction({
-        to: oracle.address,
-        from: accounts[i],
-        gas: 7000000,
-        data: oracle2.methods[
-          "testSubmitMiningSolution(string,uint256,uint256)"
-        ]("nonce", 52, 1200).encodeABI(),
-      });
-    }
-    await web3.eth.sendTransaction({
-      to: oracle.address,
-      from: accounts[0],
-      gas: 7000000,
-      data: oracle2.methods.addTip(51, 1).encodeABI(),
-    });
+//     oldTellor2 = await OldTellor2.new();
+//     oracle2 = await new web3.eth.Contract(oldTellor2ABI, oracle.address);
+//     await oracle.changeTellorContract(oldTellor2.address);
+//     assert(
+//       (await oracle.getAddressVars(web3.utils.keccak256("tellorContract"))) ==
+//         oldTellor2.address
+//     );
+//     for (var i = 0; i < 5; i++) {
+//       await web3.eth.sendTransaction({
+//         to: oracle.address,
+//         from: accounts[i],
+//         gas: 7000000,
+//         data: oracle2.methods[
+//           "testSubmitMiningSolution(string,uint256,uint256)"
+//         ]("nonce", 52, 1200).encodeABI(),
+//       });
+//     }
+//     await web3.eth.sendTransaction({
+//       to: oracle.address,
+//       from: accounts[0],
+//       gas: 7000000,
+//       data: oracle2.methods.addTip(51, 1).encodeABI(),
+//     });
 
-    oracleBase = await Tellor.new();
-    oracle2 = await new web3.eth.Contract(oracleAbi, oracle.address);
-    await oracle.changeTellorContract(oracleBase.address);
-    for (var i = 0; i < 5; i++) {
-      await web3.eth.sendTransaction({
-        to: oracle.address,
-        from: accounts[i],
-        gas: 7000000,
-        data: oracle2.methods[
-          "testSubmitMiningSolution(string,uint256,uint256)"
-        ]("nonce", 51, 1200).encodeABI(),
-      });
-    }
-    vars = await oracle2.methods.getNewCurrentVariables().call();
-    for (var i = 0; i < 5; i++) {
-      await web3.eth.sendTransaction({
-        to: oracle.address,
-        from: accounts[i],
-        gas: 7000000,
-        data: oracle2.methods
-          .testSubmitMiningSolution("nonce", vars["1"], [
-            1200,
-            1300,
-            1400,
-            1500,
-            1600,
-          ])
-          .encodeABI(),
-      });
-    }
-    assert(
-      (await oracle.getAddressVars(web3.utils.keccak256("tellorContract"))) ==
-        oracleBase.address
-    );
-  });
-  it("Test upgrade halfway through mining", async function() {
-    //deploy old, request, update address, mine old challenge.
-    oldTellor = await OldTellor.new();
-    oracle = await TellorMaster.new(oldTellor.address);
-    master = await new web3.eth.Contract(masterAbi, oracle.address);
-    oracle2 = await new web3.eth.Contract(oldTellorABI, oldTellor.address);
-    for (var i = 0; i < 6; i++) {
-      await web3.eth.sendTransaction({
-        to: oracle.address,
-        from: accounts[0],
-        gas: 7000000,
-        data: oracle2.methods
-          .theLazyCoon(accounts[i], web3.utils.toWei("1100", "ether"))
-          .encodeABI(),
-      });
-    }
-    for (var i = 0; i < 58; i++) {
-      x = "USD" + i;
-      apix = api + i;
-      await web3.eth.sendTransaction({
-        to: oracle.address,
-        from: accounts[0],
-        gas: 7000000,
-        data: oracle2.methods.requestData(apix, x, 1000, 50 + i).encodeABI(),
-      });
-    }
+//     oracleBase = await Tellor.new();
+//     oracle2 = await new web3.eth.Contract(oracleAbi, oracle.address);
+//     await oracle.changeTellorContract(oracleBase.address);
+//     for (var i = 0; i < 5; i++) {
+//       await web3.eth.sendTransaction({
+//         to: oracle.address,
+//         from: accounts[i],
+//         gas: 7000000,
+//         data: oracle2.methods[
+//           "testSubmitMiningSolution(string,uint256[5],uint256[5])"
+//         ]("nonce", [1, 2, 3, 4, 5], [1100, 1200, 1300, 1400, 1500]).encodeABI(),
+//       });
+//     }
+//     vars = await oracle2.methods.getNewCurrentVariables().call();
+//     for (var i = 0; i < 5; i++) {
+//       await web3.eth.sendTransaction({
+//         to: oracle.address,
+//         from: accounts[i],
+//         gas: 7000000,
+//         data: oracle2.methods
+//           .testSubmitMiningSolution("nonce", vars["1"], [
+//             1200,
+//             1300,
+//             1400,
+//             1500,
+//             1600,
+//           ])
+//           .encodeABI(),
+//       });
+//     }
+//     assert(
+//       (await oracle.getAddressVars(web3.utils.keccak256("tellorContract"))) ==
+//         oracleBase.address
+//     );
+//   });
+//   it("Test upgrade halfway through mining", async function() {
+//     //deploy old, request, update address, mine old challenge.
+//     oldTellor = await OldTellor.new();
+//     oracle = await TellorMaster.new(oldTellor.address);
+//     master = await new web3.eth.Contract(masterAbi, oracle.address);
+//     oracle2 = await new web3.eth.Contract(oldTellorABI, oldTellor.address);
+//     for (var i = 0; i < 6; i++) {
+//       await web3.eth.sendTransaction({
+//         to: oracle.address,
+//         from: accounts[0],
+//         gas: 7000000,
+//         data: oracle2.methods
+//           .theLazyCoon(accounts[i], web3.utils.toWei("1100", "ether"))
+//           .encodeABI(),
+//       });
+//     }
+//     for (var i = 0; i < 58; i++) {
+//       x = "USD" + i;
+//       apix = api + i;
+//       await web3.eth.sendTransaction({
+//         to: oracle.address,
+//         from: accounts[0],
+//         gas: 7000000,
+//         data: oracle2.methods.requestData(apix, x, 1000, 50 + i).encodeABI(),
+//       });
+//     }
 
-    for (var i = 0; i < 5; i++) {
-      await web3.eth.sendTransaction({
-        to: oracle.address,
-        from: accounts[i],
-        gas: 7000000,
-        data: oracle2.methods[
-          "testSubmitMiningSolution(string,uint256,uint256)"
-        ]("nonce", 1, 1200).encodeABI(),
-      });
-    }
-    oldTellor2 = await OldTellor2.new();
-    await oracle.changeTellorContract(oldTellor2.address);
-    assert(
-      (await oracle.getAddressVars(web3.utils.keccak256("tellorContract"))) ==
-        oldTellor2.address
-    );
+//     for (var i = 0; i < 5; i++) {
+//       await web3.eth.sendTransaction({
+//         to: oracle.address,
+//         from: accounts[i],
+//         gas: 7000000,
+//         data: oracle2.methods[
+//           "testSubmitMiningSolution(string,uint256,uint256)"
+//         ]("nonce", 1, 1200).encodeABI(),
+//       });
+//     }
+//     oldTellor2 = await OldTellor2.new();
+//     await oracle.changeTellorContract(oldTellor2.address);
+//     assert(
+//       (await oracle.getAddressVars(web3.utils.keccak256("tellorContract"))) ==
+//         oldTellor2.address
+//     );
 
-    for (var i = 0; i < 5; i++) {
-      await web3.eth.sendTransaction({
-        to: oracle.address,
-        from: accounts[i],
-        gas: 7000000,
-        data: oracle2.methods[
-          "testSubmitMiningSolution(string,uint256,uint256)"
-        ]("nonce", 58, 1200).encodeABI(),
-      });
-    }
-    oracleBase = await Tellor.new();
-    oracle2 = await new web3.eth.Contract(oracleAbi, oracle.address);
-    for (var i = 0; i < 3; i++) {
-      await web3.eth.sendTransaction({
-        to: oracle.address,
-        from: accounts[i],
-        gas: 7000000,
-        data: oracle2.methods[
-          "testSubmitMiningSolution(string,uint256,uint256)"
-        ]("nonce", 57, 1200).encodeABI(),
-      });
-    }
-    await oracle.changeTellorContract(oracleBase.address);
-    for (var i = 3; i < 5; i++) {
-      await web3.eth.sendTransaction({
-        to: oracle.address,
-        from: accounts[i],
-        gas: 7000000,
-        data: oracle2.methods[
-          "testSubmitMiningSolution(string,uint256,uint256)"
-        ]("nonce", 57, 1200).encodeABI(),
-      });
-    }
+//     for (var i = 0; i < 5; i++) {
+//       await web3.eth.sendTransaction({
+//         to: oracle.address,
+//         from: accounts[i],
+//         gas: 7000000,
+//         data: oracle2.methods[
+//           "testSubmitMiningSolution(string,uint256,uint256)"
+//         ]("nonce", 58, 1200).encodeABI(),
+//       });
+//     }
+//     oracleBase = await Tellor.new();
+//     oracle2 = await new web3.eth.Contract(oracleAbi, oracle.address);
+//     for (var i = 0; i < 3; i++) {
+//       await web3.eth.sendTransaction({
+//         to: oracle.address,
+//         from: accounts[i],
+//         gas: 7000000,
+//         data: oracle2.methods[
+//           "testSubmitMiningSolution(string,uint256,uint256)"
+//         ]("nonce", 57, 1200).encodeABI(),
+//       });
+//     }
+//     await oracle.changeTellorContract(oracleBase.address);
+//     for (var i = 3; i < 5; i++) {
+//       await web3.eth.sendTransaction({
+//         to: oracle.address,
+//         from: accounts[i],
+//         gas: 7000000,
+//         data: oracle2.methods[
+//           "testSubmitMiningSolution(string,uint256,uint256)"
+//         ]("nonce", 57, 1200).encodeABI(),
+//       });
+//     }
 
-    vars = await oracle2.methods.getNewCurrentVariables().call();
-    for (var i = 0; i < 5; i++) {
-      await web3.eth.sendTransaction({
-        to: oracle.address,
-        from: accounts[i],
-        gas: 7000000,
-        data: oracle2.methods
-          .testSubmitMiningSolution("nonce", vars["1"], [
-            1200,
-            1300,
-            1400,
-            1500,
-            1600,
-          ])
-          .encodeABI(),
-      });
-    }
-    assert(
-      (await oracle.getAddressVars(web3.utils.keccak256("tellorContract"))) ==
-        oracleBase.address
-    );
-  });
-  it("Test upgrade halfway through dispute", async function() {
-    //deploy old, request, update address, mine old challenge.
-    oldTellor = await OldTellor.new();
-    oracle = await TellorMaster.new(oldTellor.address);
-    master = await new web3.eth.Contract(masterAbi, oracle.address);
-    oracle2 = await new web3.eth.Contract(oldTellorABI, oldTellor.address);
-    for (var i = 0; i < 6; i++) {
-      //print tokens
-      await web3.eth.sendTransaction({
-        to: oracle.address,
-        from: accounts[0],
-        gas: 7000000,
-        data: oracle2.methods
-          .theLazyCoon(accounts[i], web3.utils.toWei("1100", "ether"))
-          .encodeABI(),
-      });
-    }
-    for (var i = 0; i < 57; i++) {
-      x = "USD" + i;
-      apix = api + i;
-      await web3.eth.sendTransaction({
-        to: oracle.address,
-        from: accounts[0],
-        gas: 7000000,
-        data: oracle2.methods.requestData(apix, x, 1000, i).encodeABI(),
-      });
-    }
-    for (var i = 0; i < 5; i++) {
-      await web3.eth.sendTransaction({
-        to: oracle.address,
-        from: accounts[i],
-        gas: 7000000,
-        data: oracle2.methods[
-          "testSubmitMiningSolution(string,uint256,uint256)"
-        ]("nonce", 1, 1200).encodeABI(),
-      });
-    }
-    oldTellor2 = await OldTellor2.new();
-    await oracle.changeTellorContract(oldTellor2.address);
-    assert(
-      (await oracle.getAddressVars(web3.utils.keccak256("tellorContract"))) ==
-        oldTellor2.address
-    );
-    for (var i = 0; i < 5; i++) {
-      res = await web3.eth.sendTransaction({
-        to: oracle.address,
-        from: accounts[i],
-        gas: 7000000,
-        data: oracle2.methods[
-          "testSubmitMiningSolution(string,uint256,uint256)"
-        ]("nonce", 57, 1200 + i).encodeABI(),
-      });
-    }
-    for (var i = 0; i < 52; i++) {
-      x = "USD" + i;
-      apix = api + i;
-      await web3.eth.sendTransaction({
-        to: oracle.address,
-        from: accounts[0],
-        gas: 7000000,
-        data: oracle2.methods.requestData(apix, x, 1000, 0).encodeABI(),
-      });
-    }
+//     vars = await oracle2.methods.getNewCurrentVariables().call();
+//     for (var i = 0; i < 5; i++) {
+//       await web3.eth.sendTransaction({
+//         to: oracle.address,
+//         from: accounts[i],
+//         gas: 7000000,
+//         data: oracle2.methods
+//           .testSubmitMiningSolution("nonce", vars["1"], [
+//             1200,
+//             1300,
+//             1400,
+//             1500,
+//             1600,
+//           ])
+//           .encodeABI(),
+//       });
+//     }
+//     assert(
+//       (await oracle.getAddressVars(web3.utils.keccak256("tellorContract"))) ==
+//         oracleBase.address
+//     );
+//   });
+//   it("Test upgrade halfway through dispute", async function() {
+//     //deploy old, request, update address, mine old challenge.
+//     oldTellor = await OldTellor.new();
+//     oracle = await TellorMaster.new(oldTellor.address);
+//     master = await new web3.eth.Contract(masterAbi, oracle.address);
+//     oracle2 = await new web3.eth.Contract(oldTellorABI, oldTellor.address);
+//     for (var i = 0; i < 6; i++) {
+//       //print tokens
+//       await web3.eth.sendTransaction({
+//         to: oracle.address,
+//         from: accounts[0],
+//         gas: 7000000,
+//         data: oracle2.methods
+//           .theLazyCoon(accounts[i], web3.utils.toWei("1100", "ether"))
+//           .encodeABI(),
+//       });
+//     }
+//     for (var i = 0; i < 57; i++) {
+//       x = "USD" + i;
+//       apix = api + i;
+//       await web3.eth.sendTransaction({
+//         to: oracle.address,
+//         from: accounts[0],
+//         gas: 7000000,
+//         data: oracle2.methods.requestData(apix, x, 1000, i).encodeABI(),
+//       });
+//     }
+//     for (var i = 0; i < 5; i++) {
+//       await web3.eth.sendTransaction({
+//         to: oracle.address,
+//         from: accounts[i],
+//         gas: 7000000,
+//         data: oracle2.methods[
+//           "testSubmitMiningSolution(string,uint256,uint256)"
+//         ]("nonce", 1, 1200).encodeABI(),
+//       });
+//     }
+//     oldTellor2 = await OldTellor2.new();
+//     await oracle.changeTellorContract(oldTellor2.address);
+//     assert(
+//       (await oracle.getAddressVars(web3.utils.keccak256("tellorContract"))) ==
+//         oldTellor2.address
+//     );
+//     for (var i = 0; i < 5; i++) {
+//       res = await web3.eth.sendTransaction({
+//         to: oracle.address,
+//         from: accounts[i],
+//         gas: 7000000,
+//         data: oracle2.methods[
+//           "testSubmitMiningSolution(string,uint256,uint256)"
+//         ]("nonce", 57, 1200 + i).encodeABI(),
+//       });
+//     }
+//     for (var i = 0; i < 52; i++) {
+//       x = "USD" + i;
+//       apix = api + i;
+//       await web3.eth.sendTransaction({
+//         to: oracle.address,
+//         from: accounts[0],
+//         gas: 7000000,
+//         data: oracle2.methods.requestData(apix, x, 1000, 0).encodeABI(),
+//       });
+//     }
 
-    //dispute piece
-    balance1 = await oracle.balanceOf(accounts[2]);
-    res = web3.eth.abi.decodeParameters(
-      ["uint256", "uint256", "uint256", "bytes32"],
-      res.logs["1"].data
-    );
-    blocknum = await oracle.getMinedBlockNum(1, res[0]);
-    await web3.eth.sendTransaction({
-      to: oracle.address,
-      from: accounts[0],
-      gas: 7000000,
-      data: oracle2.methods
-        .theLazyCoon(accounts[1], web3.utils.toWei("5000", "ether"))
-        .encodeABI(),
-    });
-    dispBal1 = await oracle.balanceOf(accounts[1]);
-    await web3.eth.sendTransaction({
-      to: oracle.address,
-      from: accounts[1],
-      gas: 7000000,
-      data: oracle2.methods.beginDispute(57, res[0], 2).encodeABI(),
-    });
-    count = await oracle.getUintVar(web3.utils.keccak256("disputeCount"));
-    assert(await oracle.isInDispute(57, res[0]), "should be in dispute");
-    await web3.eth.sendTransaction({
-      to: oracle.address,
-      from: accounts[3],
-      gas: 7000000,
-      data: oracle2.methods.vote(1, true).encodeABI(),
-    });
-    await helper.advanceTime(86400 * 22);
-    //Deploy new upgraded Tellor
-    oracleBase = await Tellor.new();
-    oracle2 = await new web3.eth.Contract(oracleAbi, oracle.address);
-    assert(await oracle.isInDispute(57, res[0]), "should still be in dispute1");
-    await oracle.changeTellorContract(oracleBase.address);
-    await web3.eth.sendTransaction({
-      to: oracle.address,
-      from: accounts[0],
-      gas: 7000000,
-      data: oracle2.methods.tallyVotes(1).encodeABI(),
-    });
-    await helper.advanceTime(86400 * 2);
-    assert(await oracle.isInDispute(57, res[0]), "should still be in dispute2");
-    await web3.eth.sendTransaction({
-      to: oracle.address,
-      from: accounts[0],
-      gas: 9000000,
-      data: oracle2.methods.unlockDisputeFee(1).encodeABI(),
-    });
-    assert(await oracle.isInDispute(57, res[0]), "should still be in dispute3");
-    dispInfo = await oracle.getAllDisputeVars(1);
-    assert(dispInfo[7][0] == 57);
-    assert(dispInfo[7][1] == res[0]);
-    assert(dispInfo[7][2] == 1202, "dispute info should be correct");
-    assert(dispInfo[2] == true, "Dispute Vote passed");
-    voted = await oracle.didVote(1, accounts[3]);
-    assert(voted == true, "account 3 voted");
-    voted = await oracle.didVote(1, accounts[5]);
-    assert(voted == false, "account 5 did not vote");
-    apid2valueF = await oracle.retrieveData(57, res[0]);
-    assert(
-      apid2valueF == 1202,
-      "value should now be zero this checks updateDisputeValue-internal fx  works"
-    ); //note this will not be fixed if upgraded during
-    assert(await oracle.isInDispute(57, res[0]), "should still be in dispute");
-    balance2 = await oracle.balanceOf(accounts[2]);
-    dispBal2 = await oracle.balanceOf(accounts[1]);
-    assert(
-      balance1 - balance2 ==
-        (await oracle.getUintVar(web3.utils.keccak256("stakeAmount"))),
-      "reported miner's balance should change correctly"
-    );
-    assert(
-      dispBal2 - dispBal1 ==
-        (await oracle.getUintVar(web3.utils.keccak256("stakeAmount"))),
-      "disputing party's balance should change correctly"
-    );
-    s = await oracle.getStakerInfo(accounts[2]);
-    assert(s != 1, " Not staked");
-    await web3.eth.sendTransaction({
-      to: oracle.address,
-      from: accounts[0],
-      gas: 7000000,
-      data: oracle2.methods
-        .theLazyCoon(accounts[6], web3.utils.toWei("5000", "ether"))
-        .encodeABI(),
-    });
-    await web3.eth.sendTransaction({
-      to: oracle.address,
-      from: accounts[6],
-      gas: 7000000,
-      data: oracle2.methods.depositStake().encodeABI(),
-    });
-    for (var i = 0; i < 6; i++) {
-      if (i != 2) {
-        await web3.eth.sendTransaction({
-          to: oracle.address,
-          from: accounts[i],
-          gas: 7000000,
-          data: oracle2.methods[
-            "testSubmitMiningSolution(string,uint256,uint256)"
-          ]("nonce", 56, 1200).encodeABI(),
-        });
-      }
-    }
-    vars = await oracle2.methods.getNewCurrentVariables().call();
-    for (var i = 0; i < 6; i++) {
-      if (i != 2) {
-        await web3.eth.sendTransaction({
-          to: oracle.address,
-          from: accounts[i],
-          gas: 7000000,
-          data: oracle2.methods
-            .testSubmitMiningSolution("nonce", vars["1"], [
-              1200,
-              1300,
-              1400,
-              1500,
-              1600,
-            ])
-            .encodeABI(),
-        });
-      }
-    }
-    assert(
-      (await oracle.getAddressVars(web3.utils.keccak256("tellorContract"))) ==
-        oracleBase.address
-    );
-  });
-  it("Test switch partially through with tips added before new block", async function() {
-    oldTellor = await OldTellor.new();
-    oracle = await TellorMaster.new(oldTellor.address);
-    master = await new web3.eth.Contract(masterAbi, oracle.address);
-    oracle2 = await new web3.eth.Contract(oldTellorABI, oldTellor.address);
-    for (var i = 0; i < 6; i++) {
-      await web3.eth.sendTransaction({
-        to: oracle.address,
-        from: accounts[0],
-        gas: 7000000,
-        data: oracle2.methods
-          .theLazyCoon(accounts[i], web3.utils.toWei("1100", "ether"))
-          .encodeABI(),
-      });
-    }
-    for (var i = 0; i < 58; i++) {
-      x = "USD" + i;
-      apix = api + i;
-      await web3.eth.sendTransaction({
-        to: oracle.address,
-        from: accounts[0],
-        gas: 7000000,
-        data: oracle2.methods.requestData(apix, x, 1000, 50 + i).encodeABI(),
-      });
-    }
+//     //dispute piece
+//     balance1 = await oracle.balanceOf(accounts[2]);
+//     res = web3.eth.abi.decodeParameters(
+//       ["uint256", "uint256", "uint256", "bytes32"],
+//       res.logs["1"].data
+//     );
+//     blocknum = await oracle.getMinedBlockNum(1, res[0]);
+//     await web3.eth.sendTransaction({
+//       to: oracle.address,
+//       from: accounts[0],
+//       gas: 7000000,
+//       data: oracle2.methods
+//         .theLazyCoon(accounts[1], web3.utils.toWei("5000", "ether"))
+//         .encodeABI(),
+//     });
+//     dispBal1 = await oracle.balanceOf(accounts[1]);
+//     await web3.eth.sendTransaction({
+//       to: oracle.address,
+//       from: accounts[1],
+//       gas: 7000000,
+//       data: oracle2.methods.beginDispute(57, res[0], 2).encodeABI(),
+//     });
+//     count = await oracle.getUintVar(web3.utils.keccak256("disputeCount"));
+//     assert(await oracle.isInDispute(57, res[0]), "should be in dispute");
+//     await web3.eth.sendTransaction({
+//       to: oracle.address,
+//       from: accounts[3],
+//       gas: 7000000,
+//       data: oracle2.methods.vote(1, true).encodeABI(),
+//     });
+//     await helper.advanceTime(86400 * 22);
+//     //Deploy new upgraded Tellor
+//     oracleBase = await Tellor.new();
+//     oracle2 = await new web3.eth.Contract(oracleAbi, oracle.address);
+//     assert(await oracle.isInDispute(57, res[0]), "should still be in dispute1");
+//     await oracle.changeTellorContract(oracleBase.address);
+//     await web3.eth.sendTransaction({
+//       to: oracle.address,
+//       from: accounts[0],
+//       gas: 7000000,
+//       data: oracle2.methods.tallyVotes(1).encodeABI(),
+//     });
+//     await helper.advanceTime(86400 * 2);
+//     assert(await oracle.isInDispute(57, res[0]), "should still be in dispute2");
+//     await web3.eth.sendTransaction({
+//       to: oracle.address,
+//       from: accounts[0],
+//       gas: 9000000,
+//       data: oracle2.methods.unlockDisputeFee(1).encodeABI(),
+//     });
+//     assert(await oracle.isInDispute(57, res[0]), "should still be in dispute3");
+//     dispInfo = await oracle.getAllDisputeVars(1);
+//     assert(dispInfo[7][0] == 57);
+//     assert(dispInfo[7][1] == res[0]);
+//     assert(dispInfo[7][2] == 1202, "dispute info should be correct");
+//     assert(dispInfo[2] == true, "Dispute Vote passed");
+//     voted = await oracle.didVote(1, accounts[3]);
+//     assert(voted == true, "account 3 voted");
+//     voted = await oracle.didVote(1, accounts[5]);
+//     assert(voted == false, "account 5 did not vote");
+//     apid2valueF = await oracle.retrieveData(57, res[0]);
+//     assert(
+//       apid2valueF == 1202,
+//       "value should now be zero this checks updateDisputeValue-internal fx  works"
+//     ); //note this will not be fixed if upgraded during
+//     assert(await oracle.isInDispute(57, res[0]), "should still be in dispute");
+//     balance2 = await oracle.balanceOf(accounts[2]);
+//     dispBal2 = await oracle.balanceOf(accounts[1]);
+//     assert(
+//       balance1 - balance2 ==
+//         (await oracle.getUintVar(web3.utils.keccak256("stakeAmount"))),
+//       "reported miner's balance should change correctly"
+//     );
+//     assert(
+//       dispBal2 - dispBal1 ==
+//         (await oracle.getUintVar(web3.utils.keccak256("stakeAmount"))),
+//       "disputing party's balance should change correctly"
+//     );
+//     s = await oracle.getStakerInfo(accounts[2]);
+//     assert(s != 1, " Not staked");
+//     await web3.eth.sendTransaction({
+//       to: oracle.address,
+//       from: accounts[0],
+//       gas: 7000000,
+//       data: oracle2.methods
+//         .theLazyCoon(accounts[6], web3.utils.toWei("5000", "ether"))
+//         .encodeABI(),
+//     });
+//     await web3.eth.sendTransaction({
+//       to: oracle.address,
+//       from: accounts[6],
+//       gas: 7000000,
+//       data: oracle2.methods.depositStake().encodeABI(),
+//     });
+//     for (var i = 0; i < 6; i++) {
+//       if (i != 2) {
+//         await web3.eth.sendTransaction({
+//           to: oracle.address,
+//           from: accounts[i],
+//           gas: 7000000,
+//           data: oracle2.methods[
+//             "testSubmitMiningSolution(string,uint256,uint256)"
+//           ]("nonce", 56, 1200).encodeABI(),
+//         });
+//       }
+//     }
+//     vars = await oracle2.methods.getNewCurrentVariables().call();
+//     for (var i = 0; i < 6; i++) {
+//       if (i != 2) {
+//         await web3.eth.sendTransaction({
+//           to: oracle.address,
+//           from: accounts[i],
+//           gas: 7000000,
+//           data: oracle2.methods
+//             .testSubmitMiningSolution("nonce", vars["1"], [
+//               1200,
+//               1300,
+//               1400,
+//               1500,
+//               1600,
+//             ])
+//             .encodeABI(),
+//         });
+//       }
+//     }
+//     assert(
+//       (await oracle.getAddressVars(web3.utils.keccak256("tellorContract"))) ==
+//         oracleBase.address
+//     );
+//   });
+//   it("Test switch partially through with tips added before new block", async function() {
+//     oldTellor = await OldTellor.new();
+//     oracle = await TellorMaster.new(oldTellor.address);
+//     master = await new web3.eth.Contract(masterAbi, oracle.address);
+//     oracle2 = await new web3.eth.Contract(oldTellorABI, oldTellor.address);
+//     for (var i = 0; i < 6; i++) {
+//       await web3.eth.sendTransaction({
+//         to: oracle.address,
+//         from: accounts[0],
+//         gas: 7000000,
+//         data: oracle2.methods
+//           .theLazyCoon(accounts[i], web3.utils.toWei("1100", "ether"))
+//           .encodeABI(),
+//       });
+//     }
+//     for (var i = 0; i < 58; i++) {
+//       x = "USD" + i;
+//       apix = api + i;
+//       await web3.eth.sendTransaction({
+//         to: oracle.address,
+//         from: accounts[0],
+//         gas: 7000000,
+//         data: oracle2.methods.requestData(apix, x, 1000, 50 + i).encodeABI(),
+//       });
+//     }
 
-    for (var i = 0; i < 5; i++) {
-      await web3.eth.sendTransaction({
-        to: oracle.address,
-        from: accounts[i],
-        gas: 7000000,
-        data: oracle2.methods[
-          "testSubmitMiningSolution(string,uint256,uint256)"
-        ]("nonce", 1, 1200).encodeABI(),
-      });
-    }
-    oldTellor2 = await OldTellor2.new();
-    await oracle.changeTellorContract(oldTellor2.address);
-    assert(
-      (await oracle.getAddressVars(web3.utils.keccak256("tellorContract"))) ==
-        oldTellor2.address
-    );
+//     for (var i = 0; i < 5; i++) {
+//       await web3.eth.sendTransaction({
+//         to: oracle.address,
+//         from: accounts[i],
+//         gas: 7000000,
+//         data: oracle2.methods[
+//           "testSubmitMiningSolution(string,uint256,uint256)"
+//         ]("nonce", 1, 1200).encodeABI(),
+//       });
+//     }
+//     oldTellor2 = await OldTellor2.new();
+//     await oracle.changeTellorContract(oldTellor2.address);
+//     assert(
+//       (await oracle.getAddressVars(web3.utils.keccak256("tellorContract"))) ==
+//         oldTellor2.address
+//     );
 
-    for (var i = 0; i < 5; i++) {
-      await web3.eth.sendTransaction({
-        to: oracle.address,
-        from: accounts[i],
-        gas: 7000000,
-        data: oracle2.methods[
-          "testSubmitMiningSolution(string,uint256,uint256)"
-        ]("nonce", 58, 1200).encodeABI(),
-      });
-    }
-    //Deploy new upgraded Tellor
-    oracleBase = await Tellor.new();
-    oracle2 = await new web3.eth.Contract(oracleAbi, oracle.address);
-    for (var i = 0; i < 3; i++) {
-      await web3.eth.sendTransaction({
-        to: oracle.address,
-        from: accounts[i],
-        gas: 7000000,
-        data: oracle2.methods[
-          "testSubmitMiningSolution(string,uint256,uint256)"
-        ]("nonce", 57, 1200).encodeABI(),
-      });
-    }
-    await web3.eth.sendTransaction({
-      to: oracle.address,
-      from: accounts[0],
-      gas: 7000000,
-      data: oracle2.methods.addTip(31, 1000).encodeABI(),
-    });
-    await oracle.changeTellorContract(oracleBase.address);
-    await web3.eth.sendTransaction({
-      to: oracle.address,
-      from: accounts[0],
-      gas: 7000000,
-      data: oracle2.methods.addTip(41, 20000).encodeABI(),
-    });
-    for (var i = 3; i < 5; i++) {
-      await web3.eth.sendTransaction({
-        to: oracle.address,
-        from: accounts[i],
-        gas: 7000000,
-        data: oracle2.methods[
-          "testSubmitMiningSolution(string,uint256,uint256)"
-        ]("nonce", 57, 1200).encodeABI(),
-      });
-    }
-    vars = await oracle2.methods.getNewCurrentVariables().call();
-    for (var i = 0; i < 5; i++) {
-      await web3.eth.sendTransaction({
-        to: oracle.address,
-        from: accounts[i],
-        gas: 7000000,
-        data: oracle2.methods
-          .testSubmitMiningSolution("nonce", vars["1"], [
-            1200,
-            1300,
-            1400,
-            1500,
-            1600,
-          ])
-          .encodeABI(),
-      });
-    }
-    assert(
-      (await oracle.getAddressVars(web3.utils.keccak256("tellorContract"))) ==
-        oracleBase.address
-    );
-    data = await oracle2.methods.getNewVariablesOnDeck().call();
-    var x = 0;
-    for (var i = 0; i < 5; i++) {
-      if (data[0][i] == "41") {
-        x = x + 1;
-        assert(data[1][i] > 20000, "Th");
-      }
-      if (data[0][i] == "31") {
-        x = x + 1;
-        assert(data[1][i] > 1000, "The");
-      }
-    }
-  });
-  it("Test initial difficulty drop", async function() {
-    //deploy old, request, update address, mine old challenge.
-    oldTellor = await OldTellor.new();
-    oracle = await TellorMaster.new(oldTellor.address);
-    oracle2 = await new web3.eth.Contract(oracleAbi, oracle.address);
-    master = await new web3.eth.Contract(masterAbi, oracle.address);
-    oldTellorinst = await new web3.eth.Contract(
-      oldTellorABI,
-      oldTellor.address
-    );
-    for (var i = 0; i < 6; i++) {
-      //print tokens
-      await web3.eth.sendTransaction({
-        to: oracle.address,
-        from: accounts[0],
-        gas: 7000000,
-        data: oldTellorinst.methods
-          .theLazyCoon(accounts[i], web3.utils.toWei("1100", "ether"))
-          .encodeABI(),
-      });
-    }
-    for (var i = 0; i < 57; i++) {
-      x = "USD" + i;
-      apix = api + i;
-      await web3.eth.sendTransaction({
-        to: oracle.address,
-        from: accounts[0],
-        gas: 7000000,
-        data: oldTellorinst.methods.requestData(apix, x, 1000, i).encodeABI(),
-      });
-    }
-    for (var i = 0; i < 5; i++) {
-      await web3.eth.sendTransaction({
-        to: oracle.address,
-        from: accounts[i],
-        gas: 7000000,
-        data: oracle2.methods[
-          "testSubmitMiningSolution(string,uint256,uint256)"
-        ]("nonce", 1, 1200).encodeABI(),
-      });
-    }
-    for (var i = 0; i < 5; i++) {
-      await web3.eth.sendTransaction({
-        to: oracle.address,
-        from: accounts[i],
-        gas: 7000000,
-        data: oracle2.methods[
-          "testSubmitMiningSolution(string,uint256,uint256)"
-        ]("nonce", 57, 1200).encodeABI(),
-      });
-    }
-    for (var i = 0; i < 5; i++) {
-      await web3.eth.sendTransaction({
-        to: oracle.address,
-        from: accounts[i],
-        gas: 7000000,
-        data: oracle2.methods[
-          "testSubmitMiningSolution(string,uint256,uint256)"
-        ]("nonce", 56, 1200).encodeABI(),
-      });
-    }
-    diff1 = await oracle.getCurrentVariables();
-    //Deploy new upgraded Tellor
-    oracleBase = await Tellor.new();
-    oracle2 = await new web3.eth.Contract(oracleAbi, oracle.address);
-    await oracle.changeTellorContract(oracleBase.address);
-    for (var i = 0; i < 5; i++) {
-      await web3.eth.sendTransaction({
-        to: oracle.address,
-        from: accounts[i],
-        gas: 7000000,
-        data: oracle2.methods[
-          "testSubmitMiningSolution(string,uint256,uint256)"
-        ]("nonce", 55, 1200).encodeABI(),
-      });
-    }
-    diff2 = await oracle.getCurrentVariables();
-    assert(diff2[2] < diff1[2] / 2, "difficulty should drop");
-  });
-});
+//     for (var i = 0; i < 5; i++) {
+//       await web3.eth.sendTransaction({
+//         to: oracle.address,
+//         from: accounts[i],
+//         gas: 7000000,
+//         data: oracle2.methods[
+//           "testSubmitMiningSolution(string,uint256,uint256)"
+//         ]("nonce", 58, 1200).encodeABI(),
+//       });
+//     }
+//     //Deploy new upgraded Tellor
+//     oracleBase = await Tellor.new();
+//     oracle2 = await new web3.eth.Contract(oracleAbi, oracle.address);
+//     for (var i = 0; i < 3; i++) {
+//       await web3.eth.sendTransaction({
+//         to: oracle.address,
+//         from: accounts[i],
+//         gas: 7000000,
+//         data: oracle2.methods[
+//           "testSubmitMiningSolution(string,uint256,uint256)"
+//         ]("nonce", 57, 1200).encodeABI(),
+//       });
+//     }
+//     await web3.eth.sendTransaction({
+//       to: oracle.address,
+//       from: accounts[0],
+//       gas: 7000000,
+//       data: oracle2.methods.addTip(31, 1000).encodeABI(),
+//     });
+//     await oracle.changeTellorContract(oracleBase.address);
+//     await web3.eth.sendTransaction({
+//       to: oracle.address,
+//       from: accounts[0],
+//       gas: 7000000,
+//       data: oracle2.methods.addTip(41, 20000).encodeABI(),
+//     });
+//     for (var i = 3; i < 5; i++) {
+//       await web3.eth.sendTransaction({
+//         to: oracle.address,
+//         from: accounts[i],
+//         gas: 7000000,
+//         data: oracle2.methods[
+//           "testSubmitMiningSolution(string,uint256,uint256)"
+//         ]("nonce", 57, 1200).encodeABI(),
+//       });
+//     }
+//     vars = await oracle2.methods.getNewCurrentVariables().call();
+//     for (var i = 0; i < 5; i++) {
+//       await web3.eth.sendTransaction({
+//         to: oracle.address,
+//         from: accounts[i],
+//         gas: 7000000,
+//         data: oracle2.methods
+//           .testSubmitMiningSolution("nonce", vars["1"], [
+//             1200,
+//             1300,
+//             1400,
+//             1500,
+//             1600,
+//           ])
+//           .encodeABI(),
+//       });
+//     }
+//     assert(
+//       (await oracle.getAddressVars(web3.utils.keccak256("tellorContract"))) ==
+//         oracleBase.address
+//     );
+//     data = await oracle2.methods.getNewVariablesOnDeck().call();
+//     var x = 0;
+//     for (var i = 0; i < 5; i++) {
+//       if (data[0][i] == "41") {
+//         x = x + 1;
+//         assert(data[1][i] > 20000, "Th");
+//       }
+//       if (data[0][i] == "31") {
+//         x = x + 1;
+//         assert(data[1][i] > 1000, "The");
+//       }
+//     }
+//   });
+//   it("Test initial difficulty drop", async function() {
+//     //deploy old, request, update address, mine old challenge.
+//     oldTellor = await OldTellor.new();
+//     oracle = await TellorMaster.new(oldTellor.address);
+//     oracle2 = await new web3.eth.Contract(oracleAbi, oracle.address);
+//     master = await new web3.eth.Contract(masterAbi, oracle.address);
+//     oldTellorinst = await new web3.eth.Contract(
+//       oldTellorABI,
+//       oldTellor.address
+//     );
+//     for (var i = 0; i < 6; i++) {
+//       //print tokens
+//       await web3.eth.sendTransaction({
+//         to: oracle.address,
+//         from: accounts[0],
+//         gas: 7000000,
+//         data: oldTellorinst.methods
+//           .theLazyCoon(accounts[i], web3.utils.toWei("1100", "ether"))
+//           .encodeABI(),
+//       });
+//     }
+//     for (var i = 0; i < 57; i++) {
+//       x = "USD" + i;
+//       apix = api + i;
+//       await web3.eth.sendTransaction({
+//         to: oracle.address,
+//         from: accounts[0],
+//         gas: 7000000,
+//         data: oldTellorinst.methods.requestData(apix, x, 1000, i).encodeABI(),
+//       });
+//     }
+//     for (var i = 0; i < 5; i++) {
+//       await web3.eth.sendTransaction({
+//         to: oracle.address,
+//         from: accounts[i],
+//         gas: 7000000,
+//         data: oracle2.methods[
+//           "testSubmitMiningSolution(string,uint256,uint256)"
+//         ]("nonce", 1, 1200).encodeABI(),
+//       });
+//     }
+//     for (var i = 0; i < 5; i++) {
+//       await web3.eth.sendTransaction({
+//         to: oracle.address,
+//         from: accounts[i],
+//         gas: 7000000,
+//         data: oracle2.methods[
+//           "testSubmitMiningSolution(string,uint256,uint256)"
+//         ]("nonce", 57, 1200).encodeABI(),
+//       });
+//     }
+//     for (var i = 0; i < 5; i++) {
+//       await web3.eth.sendTransaction({
+//         to: oracle.address,
+//         from: accounts[i],
+//         gas: 7000000,
+//         data: oracle2.methods[
+//           "testSubmitMiningSolution(string,uint256,uint256)"
+//         ]("nonce", 56, 1200).encodeABI(),
+//       });
+//     }
+//     diff1 = await oracle.getCurrentVariables();
+//     //Deploy new upgraded Tellor
+//     oracleBase = await Tellor.new();
+//     oracle2 = await new web3.eth.Contract(oracleAbi, oracle.address);
+//     await oracle.changeTellorContract(oracleBase.address);
+//     for (var i = 0; i < 5; i++) {
+//       await web3.eth.sendTransaction({
+//         to: oracle.address,
+//         from: accounts[i],
+//         gas: 7000000,
+//         data: oracle2.methods[
+//           "testSubmitMiningSolution(string,uint256,uint256)"
+//         ]("nonce", 55, 1200).encodeABI(),
+//       });
+//     }
+//     diff2 = await oracle.getCurrentVariables();
+//     assert(diff2[2] < diff1[2] / 2, "difficulty should drop");
+//   });
+// });

--- a/test/testUpgrade.js
+++ b/test/testUpgrade.js
@@ -1,329 +1,734 @@
-// /** 
-// * This tests the oracle upgrade functions
-// */
-// const Web3 = require('web3')
-// const web3 = new Web3(new Web3.providers.WebsocketProvider('ws://localhost:8545'));
-// const helper = require("./helpers/test_helpers");
-// const TellorMaster = artifacts.require("./TellorMaster.sol");
-// const Tellor = artifacts.require("./Tellor.sol"); // globally injected artifacts helper
-// var oracleAbi = Tellor.abi;
-// var oracleByte = Tellor.bytecode;
-// var OldTellor = artifacts.require("./oldContracts/OldTellor.sol")
-// var oldTellorABI = OldTellor.abi;
+/**
+ * This tests the oracle upgrade functions
+ */
+const Web3 = require("web3");
+const web3 = new Web3(
+  new Web3.providers.WebsocketProvider("ws://localhost:8545")
+);
+const helper = require("./helpers/test_helpers");
+const TellorMaster = artifacts.require("./TellorMaster.sol");
+const Tellor = artifacts.require("./Tellor.sol"); // globally injected artifacts helper
+var oracleAbi = Tellor.abi;
+var oracleByte = Tellor.bytecode;
+var OldTellor = artifacts.require("./oldContracts/OldTellor.sol");
+var oldTellorABI = OldTellor.abi;
 
-// var OldTellor2 = artifacts.require("./oldContracts2/OldTellor2.sol")
-// var oldTellor2ABI = OldTellor2.abi;
-// var UtilitiesTests = artifacts.require("./UtilitiesTests.sol")
-// var masterAbi = TellorMaster.abi;
-// var api = "json(https://api.gdax.com/products/BTC-USD/ticker).price";
-// var api2 = "json(https://api.gdax.com/products/ETH-USD/ticker).price";
+var OldTellor2 = artifacts.require("./oldContracts2/OldTellor2.sol");
+var oldTellor2ABI = OldTellor2.abi;
+var UtilitiesTests = artifacts.require("./UtilitiesTests.sol");
+var masterAbi = TellorMaster.abi;
+var api = "json(https://api.gdax.com/products/BTC-USD/ticker).price";
+var api2 = "json(https://api.gdax.com/products/ETH-USD/ticker).price";
 
-// contract('Upgrade Tests', function(accounts) {
-//   let oracleBase;
-//   let oracle;
-//   let oracle2;
-//   let master;
-//   let oldTellor;
-//   let oldTellor2;
-//   let utilities;
+contract("Upgrade Tests", function(accounts) {
+  let oracleBase;
+  let oracle;
+  let oracle2;
+  let master;
+  let oldTellor;
+  let oldTellor2;
+  let utilities;
 
-//     it("Test upgrade no Q", async function () {
-//               //deploy old, request, update address, mine old challenge.
-//         oldTellor = await OldTellor.new()    
-//         oracle = await TellorMaster.new(oldTellor.address);
-//         master = await new web3.eth.Contract(masterAbi,oracle.address);
-//         oracle2 = await new web3.eth.Contract(oldTellorABI,oldTellor.address);
-//         for(var i = 0;i<6;i++){
-//             //print tokens 
-//             await web3.eth.sendTransaction({to:oracle.address,from:accounts[0],gas:7000000,data:oracle2.methods.theLazyCoon(accounts[i],web3.utils.toWei('1100', 'ether')).encodeABI()})
-//         }
+  it("Test upgrade no Q", async function() {
+    //deploy old, request, update address, mine old challenge.
+    oldTellor = await OldTellor.new();
+    oracle = await TellorMaster.new(oldTellor.address);
+    master = await new web3.eth.Contract(masterAbi, oracle.address);
+    oracle2 = await new web3.eth.Contract(oldTellorABI, oldTellor.address);
+    for (var i = 0; i < 6; i++) {
+      //print tokens
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[0],
+        gas: 7000000,
+        data: oracle2.methods
+          .theLazyCoon(accounts[i], web3.utils.toWei("1100", "ether"))
+          .encodeABI(),
+      });
+    }
 
-//         await web3.eth.sendTransaction({to: oracle.address,from:accounts[0],gas:7000000,data:oracle2.methods.requestData(api,"i",1000,0).encodeABI()})
-//         for(var i = 0;i<5;i++){
-//           await web3.eth.sendTransaction({to:oracle.address,from:accounts[i],gas:7000000,data:oracle2.methods['testSubmitMiningSolution(string,uint256,uint256)']("nonce",1,1200).encodeABI()})
-//         }
-//         oldTellor2 = await OldTellor2.new()    
-//         await oracle.changeTellorContract(oldTellor2.address)
-//         assert(await oracle.getAddressVars(web3.utils.keccak256("tellorContract")) == oldTellor2.address);
-//         await web3.eth.sendTransaction({to: oracle.address,from:accounts[0],gas:7000000,data:oracle2.methods.requestData("api2","i2",5000,0).encodeABI()})
-//         for(var i = 0;i<5;i++){
-//           await web3.eth.sendTransaction({to:oracle.address,from:accounts[i],gas:7000000,data:oracle2.methods['testSubmitMiningSolution(string,uint256,uint256)']("nonce",2,1200).encodeABI()})
-//         }
-//         await web3.eth.sendTransaction({to: oracle.address,from:accounts[0],gas:7000000,data:oracle2.methods.addTip(1,0).encodeABI()})
-//         for(var i=0; i<52;i++){
-//             x = "USD" + i
-//             apix = api + i
-//             await web3.eth.sendTransaction({to: oracle.address,from:accounts[0],gas:7000000,data:oracle2.methods.requestData(apix,x,1000,0).encodeABI()})
-//         }
-//         //Deploy new upgraded Tellor
-//         oracleBase = await Tellor.new();
-//         oracle2 = await new web3.eth.Contract(oracleAbi,oracle.address);
-//         await oracle.changeTellorContract(oracleBase.address)
-//         for(var i = 0;i<5;i++){
-//           await web3.eth.sendTransaction({to:oracle.address,from:accounts[i],gas:7000000,data:oracle2.methods['testSubmitMiningSolution(string,uint256,uint256)']("nonce",1,1200).encodeABI()})
-//         }
-//         vars =  await oracle2.methods.getNewCurrentVariables().call()
-//         for(var i = 0;i<5;i++){
-//             await web3.eth.sendTransaction({to:oracle.address,from:accounts[i],gas:7000000,data:oracle2.methods.testSubmitMiningSolution("nonce",vars['1'],[1200,1300,1400,1500,1600]).encodeABI()})
-//         }
-//         assert(await oracle.getAddressVars(web3.utils.keccak256("tellorContract")) == oracleBase.address);
-//     });
-//    it("Test upgrade with full queue", async function () {
-//   		              //deploy old, request, update address, mine old challenge.
-//         oldTellor = await OldTellor.new()    
-//         oracle = await TellorMaster.new(oldTellor.address);
-//         master = await new web3.eth.Contract(masterAbi,oracle.address);
-//         oracle2 = await new web3.eth.Contract(oldTellorABI,oldTellor.address);
-//         utilities = await UtilitiesTests.new(oracle.address)
-//         for(var i = 0;i<6;i++){
-//             await web3.eth.sendTransaction({to:oracle.address,from:accounts[0],gas:7000000,data:oracle2.methods.theLazyCoon(accounts[i],web3.utils.toWei('1100', 'ether')).encodeABI()})
-//         }
-//         for(var i=0; i<52;i++){
-//             x = "USD" + i
-//             apix = api + i
-//             await web3.eth.sendTransaction({to: oracle.address,from:accounts[0],gas:7000000,data:oracle2.methods.requestData(apix,x,1000,50+i).encodeABI()})
-//         }
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods.requestData(api, "i", 1000, 0).encodeABI(),
+    });
+    for (var i = 0; i < 5; i++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods[
+          "testSubmitMiningSolution(string,uint256,uint256)"
+        ]("nonce", 1, 1200).encodeABI(),
+      });
+    }
+    oldTellor2 = await OldTellor2.new();
+    await oracle.changeTellorContract(oldTellor2.address);
+    assert(
+      (await oracle.getAddressVars(web3.utils.keccak256("tellorContract"))) ==
+        oldTellor2.address
+    );
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods.requestData("api2", "i2", 5000, 0).encodeABI(),
+    });
+    for (var i = 0; i < 5; i++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods[
+          "testSubmitMiningSolution(string,uint256,uint256)"
+        ]("nonce", 2, 1200).encodeABI(),
+      });
+    }
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods.addTip(1, 0).encodeABI(),
+    });
+    for (var i = 0; i < 52; i++) {
+      x = "USD" + i;
+      apix = api + i;
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[0],
+        gas: 7000000,
+        data: oracle2.methods.requestData(apix, x, 1000, 0).encodeABI(),
+      });
+    }
+    //Deploy new upgraded Tellor
+    oracleBase = await Tellor.new();
+    oracle2 = await new web3.eth.Contract(oracleAbi, oracle.address);
+    await oracle.changeTellorContract(oracleBase.address);
+    for (var i = 0; i < 5; i++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods[
+          "testSubmitMiningSolution(string,uint256,uint256)"
+        ]("nonce", 1, 1200).encodeABI(),
+      });
+    }
+    vars = await oracle2.methods.getNewCurrentVariables().call();
+    for (var i = 0; i < 5; i++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods
+          .testSubmitMiningSolution("nonce", vars["1"], [
+            1200,
+            1300,
+            1400,
+            1500,
+            1600,
+          ])
+          .encodeABI(),
+      });
+    }
+    assert(
+      (await oracle.getAddressVars(web3.utils.keccak256("tellorContract"))) ==
+        oracleBase.address
+    );
+  });
+  it("Test upgrade with full queue", async function() {
+    //deploy old, request, update address, mine old challenge.
+    oldTellor = await OldTellor.new();
+    oracle = await TellorMaster.new(oldTellor.address);
+    master = await new web3.eth.Contract(masterAbi, oracle.address);
+    oracle2 = await new web3.eth.Contract(oldTellorABI, oldTellor.address);
+    utilities = await UtilitiesTests.new(oracle.address);
+    for (var i = 0; i < 6; i++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[0],
+        gas: 7000000,
+        data: oracle2.methods
+          .theLazyCoon(accounts[i], web3.utils.toWei("1100", "ether"))
+          .encodeABI(),
+      });
+    }
+    for (var i = 0; i < 52; i++) {
+      x = "USD" + i;
+      apix = api + i;
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[0],
+        gas: 7000000,
+        data: oracle2.methods.requestData(apix, x, 1000, 50 + i).encodeABI(),
+      });
+    }
 
-//         for(var i = 0;i<5;i++){
-//           await web3.eth.sendTransaction({to:oracle.address,from:accounts[i],gas:7000000,data:oracle2.methods['testSubmitMiningSolution(string,uint256,uint256)']("nonce",1,1200).encodeABI()})
-//         }
- 
-//         oldTellor2 = await OldTellor2.new()    
-//         oracle2 = await new web3.eth.Contract(oldTellor2ABI,oracle.address);
-//         await oracle.changeTellorContract(oldTellor2.address)
-//         assert(await oracle.getAddressVars(web3.utils.keccak256("tellorContract")) == oldTellor2.address);
-//         for(var i = 0;i<5;i++){
-//           await web3.eth.sendTransaction({to:oracle.address,from:accounts[i],gas:7000000,data:oracle2.methods['testSubmitMiningSolution(string,uint256,uint256)']("nonce",52,1200).encodeABI()})
-//         }
-//         await web3.eth.sendTransaction({to: oracle.address,from:accounts[0],gas:7000000,data:oracle2.methods.addTip(51,1).encodeABI()})
-        
-//         oracleBase = await Tellor.new();
-//         oracle2 = await new web3.eth.Contract(oracleAbi,oracle.address);
-//         await oracle.changeTellorContract(oracleBase.address)
-// 		for(var i = 0;i<5;i++){
-//           await web3.eth.sendTransaction({to:oracle.address,from:accounts[i],gas:7000000,data:oracle2.methods['testSubmitMiningSolution(string,uint256,uint256)']("nonce",51,1200).encodeABI()})
-//         }
-//         vars =  await oracle2.methods.getNewCurrentVariables().call()
-//         for(var i = 0;i<5;i++){
-//             await web3.eth.sendTransaction({to:oracle.address,from:accounts[i],gas:7000000,data:oracle2.methods.testSubmitMiningSolution("nonce",vars['1'],[1200,1300,1400,1500,1600]).encodeABI()})
-//         }
-//         assert(await oracle.getAddressVars(web3.utils.keccak256("tellorContract")) == oracleBase.address);
+    for (var i = 0; i < 5; i++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods[
+          "testSubmitMiningSolution(string,uint256,uint256)"
+        ]("nonce", 1, 1200).encodeABI(),
+      });
+    }
 
-//    });
-//     it("Test upgrade halfway through mining", async function () {
-//                     //deploy old, request, update address, mine old challenge.
-//         oldTellor = await OldTellor.new()    
-//         oracle = await TellorMaster.new(oldTellor.address);
-//         master = await new web3.eth.Contract(masterAbi,oracle.address);
-//         oracle2 = await new web3.eth.Contract(oldTellorABI,oldTellor.address);
-//         for(var i = 0;i<6;i++){
-//             await web3.eth.sendTransaction({to:oracle.address,from:accounts[0],gas:7000000,data:oracle2.methods.theLazyCoon(accounts[i],web3.utils.toWei('1100', 'ether')).encodeABI()})
-//         }
-//         for(var i=0; i<58;i++){
-//             x = "USD" + i
-//             apix = api + i
-//             await web3.eth.sendTransaction({to: oracle.address,from:accounts[0],gas:7000000,data:oracle2.methods.requestData(apix,x,1000,50+i).encodeABI()})
-//         }
+    oldTellor2 = await OldTellor2.new();
+    oracle2 = await new web3.eth.Contract(oldTellor2ABI, oracle.address);
+    await oracle.changeTellorContract(oldTellor2.address);
+    assert(
+      (await oracle.getAddressVars(web3.utils.keccak256("tellorContract"))) ==
+        oldTellor2.address
+    );
+    for (var i = 0; i < 5; i++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods[
+          "testSubmitMiningSolution(string,uint256,uint256)"
+        ]("nonce", 52, 1200).encodeABI(),
+      });
+    }
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods.addTip(51, 1).encodeABI(),
+    });
 
-//         for(var i = 0;i<5;i++){
-//           await web3.eth.sendTransaction({to:oracle.address,from:accounts[i],gas:7000000,data:oracle2.methods['testSubmitMiningSolution(string,uint256,uint256)']("nonce",1,1200).encodeABI()})
-//         }
-//         oldTellor2 = await OldTellor2.new()    
-//         await oracle.changeTellorContract(oldTellor2.address)
-//         assert(await oracle.getAddressVars(web3.utils.keccak256("tellorContract")) == oldTellor2.address);
+    oracleBase = await Tellor.new();
+    oracle2 = await new web3.eth.Contract(oracleAbi, oracle.address);
+    await oracle.changeTellorContract(oracleBase.address);
+    for (var i = 0; i < 5; i++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods[
+          "testSubmitMiningSolution(string,uint256,uint256)"
+        ]("nonce", 51, 1200).encodeABI(),
+      });
+    }
+    vars = await oracle2.methods.getNewCurrentVariables().call();
+    for (var i = 0; i < 5; i++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods
+          .testSubmitMiningSolution("nonce", vars["1"], [
+            1200,
+            1300,
+            1400,
+            1500,
+            1600,
+          ])
+          .encodeABI(),
+      });
+    }
+    assert(
+      (await oracle.getAddressVars(web3.utils.keccak256("tellorContract"))) ==
+        oracleBase.address
+    );
+  });
+  it("Test upgrade halfway through mining", async function() {
+    //deploy old, request, update address, mine old challenge.
+    oldTellor = await OldTellor.new();
+    oracle = await TellorMaster.new(oldTellor.address);
+    master = await new web3.eth.Contract(masterAbi, oracle.address);
+    oracle2 = await new web3.eth.Contract(oldTellorABI, oldTellor.address);
+    for (var i = 0; i < 6; i++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[0],
+        gas: 7000000,
+        data: oracle2.methods
+          .theLazyCoon(accounts[i], web3.utils.toWei("1100", "ether"))
+          .encodeABI(),
+      });
+    }
+    for (var i = 0; i < 58; i++) {
+      x = "USD" + i;
+      apix = api + i;
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[0],
+        gas: 7000000,
+        data: oracle2.methods.requestData(apix, x, 1000, 50 + i).encodeABI(),
+      });
+    }
 
-//         for(var i = 0;i<5;i++){
-//           await web3.eth.sendTransaction({to:oracle.address,from:accounts[i],gas:7000000,data:oracle2.methods['testSubmitMiningSolution(string,uint256,uint256)']("nonce",58,1200).encodeABI()})
-//         }
-//         oracleBase = await Tellor.new();
-//         oracle2 = await new web3.eth.Contract(oracleAbi,oracle.address);
-//                for(var i = 0;i<3;i++){
-//           await web3.eth.sendTransaction({to:oracle.address,from:accounts[i],gas:7000000,data:oracle2.methods['testSubmitMiningSolution(string,uint256,uint256)']("nonce",57,1200).encodeABI()})
-//         }
-//         await oracle.changeTellorContract(oracleBase.address)
-//         for(var i = 3;i<5;i++){
-//           await web3.eth.sendTransaction({to:oracle.address,from:accounts[i],gas:7000000,data:oracle2.methods['testSubmitMiningSolution(string,uint256,uint256)']("nonce",57,1200).encodeABI()})
-//         }
+    for (var i = 0; i < 5; i++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods[
+          "testSubmitMiningSolution(string,uint256,uint256)"
+        ]("nonce", 1, 1200).encodeABI(),
+      });
+    }
+    oldTellor2 = await OldTellor2.new();
+    await oracle.changeTellorContract(oldTellor2.address);
+    assert(
+      (await oracle.getAddressVars(web3.utils.keccak256("tellorContract"))) ==
+        oldTellor2.address
+    );
 
-//         vars =  await oracle2.methods.getNewCurrentVariables().call()
-//         for(var i = 0;i<5;i++){
-//             await web3.eth.sendTransaction({to:oracle.address,from:accounts[i],gas:7000000,data:oracle2.methods.testSubmitMiningSolution("nonce",vars['1'],[1200,1300,1400,1500,1600]).encodeABI()})
-//         }
-//         assert(await oracle.getAddressVars(web3.utils.keccak256("tellorContract")) == oracleBase.address);
-   
-//     });
-//    it("Test upgrade halfway through dispute", async function () {
-//                         //deploy old, request, update address, mine old challenge.
-//         oldTellor = await OldTellor.new()    
-//         oracle = await TellorMaster.new(oldTellor.address);
-//         master = await new web3.eth.Contract(masterAbi,oracle.address);
-//         oracle2 = await new web3.eth.Contract(oldTellorABI,oldTellor.address);
-//         for(var i = 0;i<6;i++){
-//             //print tokens 
-//             await web3.eth.sendTransaction({to:oracle.address,from:accounts[0],gas:7000000,data:oracle2.methods.theLazyCoon(accounts[i],web3.utils.toWei('1100', 'ether')).encodeABI()})
-//         }
-//         for(var i=0; i<57;i++){
-//             x = "USD" + i
-//             apix = api + i
-//             await web3.eth.sendTransaction({to: oracle.address,from:accounts[0],gas:7000000,data:oracle2.methods.requestData(apix,x,1000,i).encodeABI()})
-//         }
-//         for(var i = 0;i<5;i++){
-//           await web3.eth.sendTransaction({to:oracle.address,from:accounts[i],gas:7000000,data:oracle2.methods['testSubmitMiningSolution(string,uint256,uint256)']("nonce",1,1200).encodeABI()})
-//         }
-//         oldTellor2 = await OldTellor2.new()    
-//         await oracle.changeTellorContract(oldTellor2.address)
-//         assert(await oracle.getAddressVars(web3.utils.keccak256("tellorContract")) == oldTellor2.address);
-//         for(var i = 0;i<5;i++){
-//           res = await web3.eth.sendTransaction({to:oracle.address,from:accounts[i],gas:7000000,data:oracle2.methods['testSubmitMiningSolution(string,uint256,uint256)']("nonce",57,1200+i).encodeABI()})
-//         }
-//         for(var i=0; i<52;i++){
-//             x = "USD" + i
-//             apix = api + i
-//             await web3.eth.sendTransaction({to: oracle.address,from:accounts[0],gas:7000000,data:oracle2.methods.requestData(apix,x,1000,0).encodeABI()})
-//         }
+    for (var i = 0; i < 5; i++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods[
+          "testSubmitMiningSolution(string,uint256,uint256)"
+        ]("nonce", 58, 1200).encodeABI(),
+      });
+    }
+    oracleBase = await Tellor.new();
+    oracle2 = await new web3.eth.Contract(oracleAbi, oracle.address);
+    for (var i = 0; i < 3; i++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods[
+          "testSubmitMiningSolution(string,uint256,uint256)"
+        ]("nonce", 57, 1200).encodeABI(),
+      });
+    }
+    await oracle.changeTellorContract(oracleBase.address);
+    for (var i = 3; i < 5; i++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods[
+          "testSubmitMiningSolution(string,uint256,uint256)"
+        ]("nonce", 57, 1200).encodeABI(),
+      });
+    }
 
-//         //dispute piece
-//         balance1 = await oracle.balanceOf(accounts[2]);
-//         res = web3.eth.abi.decodeParameters(['uint256','uint256','uint256','bytes32'],res.logs['1'].data)
-//         blocknum = await oracle.getMinedBlockNum(1,res[0]);
-//         await web3.eth.sendTransaction({to:oracle.address,from:accounts[0],gas:7000000,data:oracle2.methods.theLazyCoon(accounts[1],web3.utils.toWei('5000', 'ether')).encodeABI()})
-//         dispBal1 = await oracle.balanceOf(accounts[1])
-//         await  web3.eth.sendTransaction({to: oracle.address,from:accounts[1],gas:7000000,data:oracle2.methods.beginDispute(57,res[0],2).encodeABI()});
-//         count = await oracle.getUintVar(web3.utils.keccak256("disputeCount"));
-//          assert(await oracle.isInDispute(57,res[0]), "should be in dispute")
-//         await web3.eth.sendTransaction({to: oracle.address,from:accounts[3],gas:7000000,data:oracle2.methods.vote(1,true).encodeABI()});
-//         await helper.advanceTime(86400 * 22);
-//                 //Deploy new upgraded Tellor
-//         oracleBase = await Tellor.new();
-//         oracle2 = await new web3.eth.Contract(oracleAbi,oracle.address);
-//         assert(await oracle.isInDispute(57,res[0]), "should still be in dispute1")
-// 			await oracle.changeTellorContract(oracleBase.address)
-//         await web3.eth.sendTransaction({to: oracle.address,from:accounts[0],gas:7000000,data:oracle2.methods.tallyVotes(1).encodeABI()});
-//                 await helper.advanceTime(86400 * 2 )
-//                 assert(await oracle.isInDispute(57,res[0]), "should still be in dispute2")
-//         await web3.eth.sendTransaction({to:oracle.address,from:accounts[0],gas:9000000,data:oracle2.methods.unlockDisputeFee(1).encodeABI()})
-//          assert(await oracle.isInDispute(57,res[0]), "should still be in dispute3")
-//          dispInfo = await oracle.getAllDisputeVars(1);
-//         assert(dispInfo[7][0] == 57)
-//         assert(dispInfo[7][1] == res[0])
-//         assert(dispInfo[7][2] == 1202,"dispute info should be correct")
-//         assert(dispInfo[2] == true,"Dispute Vote passed")
-//         voted = await oracle.didVote(1, accounts[3]);
-//         assert(voted == true, "account 3 voted");
-//         voted = await oracle.didVote(1, accounts[5]);
-//         assert(voted == false, "account 5 did not vote");
-//         apid2valueF = await oracle.retrieveData(57,res[0]);
-//         assert(apid2valueF == 1202 ,"value should now be zero this checks updateDisputeValue-internal fx  works");//note this will not be fixed if upgraded during
-//         assert(await oracle.isInDispute(57,res[0]), "should still be in dispute")
-//         balance2 = await oracle.balanceOf(accounts[2]);
-//         dispBal2 = await oracle.balanceOf(accounts[1])
-//         assert(balance1 - balance2 == await oracle.getUintVar(web3.utils.keccak256("stakeAmount")),"reported miner's balance should change correctly");
-//         assert(dispBal2 - dispBal1 == await oracle.getUintVar(web3.utils.keccak256("stakeAmount")), "disputing party's balance should change correctly")
-//         s =  await oracle.getStakerInfo(accounts[2])
-//         assert(s != 1, " Not staked" );
-//        await web3.eth.sendTransaction({to:oracle.address,from:accounts[0],gas:7000000,data:oracle2.methods.theLazyCoon(accounts[6],web3.utils.toWei('5000', 'ether')).encodeABI()})
-//        await web3.eth.sendTransaction({to: oracle.address,from:accounts[6],gas:7000000,data:oracle2.methods.depositStake().encodeABI()})
-//         for(var i = 0;i<6;i++){
-//         	if(i !=2){
-//         		  await web3.eth.sendTransaction({to:oracle.address,from:accounts[i],gas:7000000,data:oracle2.methods['testSubmitMiningSolution(string,uint256,uint256)']("nonce",56,1200).encodeABI()})
-//         	}
-//         }
-//         vars =  await oracle2.methods.getNewCurrentVariables().call()
-//         for(var i = 0;i<6;i++){
-//         	if(i !=2){
-//             await web3.eth.sendTransaction({to:oracle.address,from:accounts[i],gas:7000000,data:oracle2.methods.testSubmitMiningSolution("nonce",vars['1'],[1200,1300,1400,1500,1600]).encodeABI()})
-//         	}
-//         }
-//         assert(await oracle.getAddressVars(web3.utils.keccak256("tellorContract")) == oracleBase.address);
-//    });
-//    it("Test switch partially through with tips added before new block", async function () {
-//                 oldTellor = await OldTellor.new()    
-//         oracle = await TellorMaster.new(oldTellor.address);
-//         master = await new web3.eth.Contract(masterAbi,oracle.address);
-//         oracle2 = await new web3.eth.Contract(oldTellorABI,oldTellor.address);
-//         for(var i = 0;i<6;i++){
-//             await web3.eth.sendTransaction({to:oracle.address,from:accounts[0],gas:7000000,data:oracle2.methods.theLazyCoon(accounts[i],web3.utils.toWei('1100', 'ether')).encodeABI()})
-//         }
-//         for(var i=0; i<58;i++){
-//             x = "USD" + i
-//             apix = api + i
-//             await web3.eth.sendTransaction({to: oracle.address,from:accounts[0],gas:7000000,data:oracle2.methods.requestData(apix,x,1000,50+i).encodeABI()})
-//         }
+    vars = await oracle2.methods.getNewCurrentVariables().call();
+    for (var i = 0; i < 5; i++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods
+          .testSubmitMiningSolution("nonce", vars["1"], [
+            1200,
+            1300,
+            1400,
+            1500,
+            1600,
+          ])
+          .encodeABI(),
+      });
+    }
+    assert(
+      (await oracle.getAddressVars(web3.utils.keccak256("tellorContract"))) ==
+        oracleBase.address
+    );
+  });
+  it("Test upgrade halfway through dispute", async function() {
+    //deploy old, request, update address, mine old challenge.
+    oldTellor = await OldTellor.new();
+    oracle = await TellorMaster.new(oldTellor.address);
+    master = await new web3.eth.Contract(masterAbi, oracle.address);
+    oracle2 = await new web3.eth.Contract(oldTellorABI, oldTellor.address);
+    for (var i = 0; i < 6; i++) {
+      //print tokens
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[0],
+        gas: 7000000,
+        data: oracle2.methods
+          .theLazyCoon(accounts[i], web3.utils.toWei("1100", "ether"))
+          .encodeABI(),
+      });
+    }
+    for (var i = 0; i < 57; i++) {
+      x = "USD" + i;
+      apix = api + i;
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[0],
+        gas: 7000000,
+        data: oracle2.methods.requestData(apix, x, 1000, i).encodeABI(),
+      });
+    }
+    for (var i = 0; i < 5; i++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods[
+          "testSubmitMiningSolution(string,uint256,uint256)"
+        ]("nonce", 1, 1200).encodeABI(),
+      });
+    }
+    oldTellor2 = await OldTellor2.new();
+    await oracle.changeTellorContract(oldTellor2.address);
+    assert(
+      (await oracle.getAddressVars(web3.utils.keccak256("tellorContract"))) ==
+        oldTellor2.address
+    );
+    for (var i = 0; i < 5; i++) {
+      res = await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods[
+          "testSubmitMiningSolution(string,uint256,uint256)"
+        ]("nonce", 57, 1200 + i).encodeABI(),
+      });
+    }
+    for (var i = 0; i < 52; i++) {
+      x = "USD" + i;
+      apix = api + i;
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[0],
+        gas: 7000000,
+        data: oracle2.methods.requestData(apix, x, 1000, 0).encodeABI(),
+      });
+    }
 
-//         for(var i = 0;i<5;i++){
-//           await web3.eth.sendTransaction({to:oracle.address,from:accounts[i],gas:7000000,data:oracle2.methods['testSubmitMiningSolution(string,uint256,uint256)']("nonce",1,1200).encodeABI()})
-//         }
-//         oldTellor2 = await OldTellor2.new()    
-//         await oracle.changeTellorContract(oldTellor2.address)
-//         assert(await oracle.getAddressVars(web3.utils.keccak256("tellorContract")) == oldTellor2.address);
+    //dispute piece
+    balance1 = await oracle.balanceOf(accounts[2]);
+    res = web3.eth.abi.decodeParameters(
+      ["uint256", "uint256", "uint256", "bytes32"],
+      res.logs["1"].data
+    );
+    blocknum = await oracle.getMinedBlockNum(1, res[0]);
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods
+        .theLazyCoon(accounts[1], web3.utils.toWei("5000", "ether"))
+        .encodeABI(),
+    });
+    dispBal1 = await oracle.balanceOf(accounts[1]);
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[1],
+      gas: 7000000,
+      data: oracle2.methods.beginDispute(57, res[0], 2).encodeABI(),
+    });
+    count = await oracle.getUintVar(web3.utils.keccak256("disputeCount"));
+    assert(await oracle.isInDispute(57, res[0]), "should be in dispute");
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[3],
+      gas: 7000000,
+      data: oracle2.methods.vote(1, true).encodeABI(),
+    });
+    await helper.advanceTime(86400 * 22);
+    //Deploy new upgraded Tellor
+    oracleBase = await Tellor.new();
+    oracle2 = await new web3.eth.Contract(oracleAbi, oracle.address);
+    assert(await oracle.isInDispute(57, res[0]), "should still be in dispute1");
+    await oracle.changeTellorContract(oracleBase.address);
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods.tallyVotes(1).encodeABI(),
+    });
+    await helper.advanceTime(86400 * 2);
+    assert(await oracle.isInDispute(57, res[0]), "should still be in dispute2");
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 9000000,
+      data: oracle2.methods.unlockDisputeFee(1).encodeABI(),
+    });
+    assert(await oracle.isInDispute(57, res[0]), "should still be in dispute3");
+    dispInfo = await oracle.getAllDisputeVars(1);
+    assert(dispInfo[7][0] == 57);
+    assert(dispInfo[7][1] == res[0]);
+    assert(dispInfo[7][2] == 1202, "dispute info should be correct");
+    assert(dispInfo[2] == true, "Dispute Vote passed");
+    voted = await oracle.didVote(1, accounts[3]);
+    assert(voted == true, "account 3 voted");
+    voted = await oracle.didVote(1, accounts[5]);
+    assert(voted == false, "account 5 did not vote");
+    apid2valueF = await oracle.retrieveData(57, res[0]);
+    assert(
+      apid2valueF == 1202,
+      "value should now be zero this checks updateDisputeValue-internal fx  works"
+    ); //note this will not be fixed if upgraded during
+    assert(await oracle.isInDispute(57, res[0]), "should still be in dispute");
+    balance2 = await oracle.balanceOf(accounts[2]);
+    dispBal2 = await oracle.balanceOf(accounts[1]);
+    assert(
+      balance1 - balance2 ==
+        (await oracle.getUintVar(web3.utils.keccak256("stakeAmount"))),
+      "reported miner's balance should change correctly"
+    );
+    assert(
+      dispBal2 - dispBal1 ==
+        (await oracle.getUintVar(web3.utils.keccak256("stakeAmount"))),
+      "disputing party's balance should change correctly"
+    );
+    s = await oracle.getStakerInfo(accounts[2]);
+    assert(s != 1, " Not staked");
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods
+        .theLazyCoon(accounts[6], web3.utils.toWei("5000", "ether"))
+        .encodeABI(),
+    });
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[6],
+      gas: 7000000,
+      data: oracle2.methods.depositStake().encodeABI(),
+    });
+    for (var i = 0; i < 6; i++) {
+      if (i != 2) {
+        await web3.eth.sendTransaction({
+          to: oracle.address,
+          from: accounts[i],
+          gas: 7000000,
+          data: oracle2.methods[
+            "testSubmitMiningSolution(string,uint256,uint256)"
+          ]("nonce", 56, 1200).encodeABI(),
+        });
+      }
+    }
+    vars = await oracle2.methods.getNewCurrentVariables().call();
+    for (var i = 0; i < 6; i++) {
+      if (i != 2) {
+        await web3.eth.sendTransaction({
+          to: oracle.address,
+          from: accounts[i],
+          gas: 7000000,
+          data: oracle2.methods
+            .testSubmitMiningSolution("nonce", vars["1"], [
+              1200,
+              1300,
+              1400,
+              1500,
+              1600,
+            ])
+            .encodeABI(),
+        });
+      }
+    }
+    assert(
+      (await oracle.getAddressVars(web3.utils.keccak256("tellorContract"))) ==
+        oracleBase.address
+    );
+  });
+  it("Test switch partially through with tips added before new block", async function() {
+    oldTellor = await OldTellor.new();
+    oracle = await TellorMaster.new(oldTellor.address);
+    master = await new web3.eth.Contract(masterAbi, oracle.address);
+    oracle2 = await new web3.eth.Contract(oldTellorABI, oldTellor.address);
+    for (var i = 0; i < 6; i++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[0],
+        gas: 7000000,
+        data: oracle2.methods
+          .theLazyCoon(accounts[i], web3.utils.toWei("1100", "ether"))
+          .encodeABI(),
+      });
+    }
+    for (var i = 0; i < 58; i++) {
+      x = "USD" + i;
+      apix = api + i;
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[0],
+        gas: 7000000,
+        data: oracle2.methods.requestData(apix, x, 1000, 50 + i).encodeABI(),
+      });
+    }
 
-//         for(var i = 0;i<5;i++){
-//           await web3.eth.sendTransaction({to:oracle.address,from:accounts[i],gas:7000000,data:oracle2.methods['testSubmitMiningSolution(string,uint256,uint256)']("nonce",58,1200).encodeABI()})
-//         }
-//         //Deploy new upgraded Tellor
-//         oracleBase = await Tellor.new();
-//         oracle2 = await new web3.eth.Contract(oracleAbi,oracle.address);
-//         for(var i = 0;i<3;i++){
-//           await web3.eth.sendTransaction({to:oracle.address,from:accounts[i],gas:7000000,data:oracle2.methods['testSubmitMiningSolution(string,uint256,uint256)']("nonce",57,1200).encodeABI()})
-//         }
-//         await web3.eth.sendTransaction({to: oracle.address,from:accounts[0],gas:7000000,data:oracle2.methods.addTip(31,1000).encodeABI()})
-//         await oracle.changeTellorContract(oracleBase.address)
-//         await web3.eth.sendTransaction({to: oracle.address,from:accounts[0],gas:7000000,data:oracle2.methods.addTip(41,20000).encodeABI()})
-//         for(var i = 3;i<5;i++){
-//           await web3.eth.sendTransaction({to:oracle.address,from:accounts[i],gas:7000000,data:oracle2.methods['testSubmitMiningSolution(string,uint256,uint256)']("nonce",57,1200).encodeABI()})
-//         }
-//         vars =  await oracle2.methods.getNewCurrentVariables().call()
-//         for(var i = 0;i<5;i++){
-//             await web3.eth.sendTransaction({to:oracle.address,from:accounts[i],gas:7000000,data:oracle2.methods.testSubmitMiningSolution("nonce",vars['1'],[1200,1300,1400,1500,1600]).encodeABI()})
-//         }
-//         assert(await oracle.getAddressVars(web3.utils.keccak256("tellorContract")) == oracleBase.address);
-//         data = await oracle2.methods.getNewVariablesOnDeck().call();
-//         var x =0
-//         for(var i = 0; i < 5; i++){
-//         	if(data[0][i] == '41'){
-//         		x = x+1
-//         		assert(data[1][i] >20000, 'Th');
-//         	}
-//         	if(data[0][i] == '31'){
-//         		x = x+1
-//         		assert(data[1][i] >1000, 'The');
-//         	}
-// 	    }
-//    });
-//       it("Test initial difficulty drop", async function () {
-//    	           //deploy old, request, update address, mine old challenge.
-//         oldTellor = await OldTellor.new()    
-//         oracle = await TellorMaster.new(oldTellor.address);
-//            oracle2 = await new web3.eth.Contract(oracleAbi,oracle.address);
-//         master = await new web3.eth.Contract(masterAbi,oracle.address);
-//         oldTellorinst = await new web3.eth.Contract(oldTellorABI,oldTellor.address);
-//         for(var i = 0;i<6;i++){
-//             //print tokens 
-//             await web3.eth.sendTransaction({to:oracle.address,from:accounts[0],gas:7000000,data:oldTellorinst.methods.theLazyCoon(accounts[i],web3.utils.toWei('1100', 'ether')).encodeABI()})
-//         }
-//         for(var i=0; i<57;i++){
-//             x = "USD" + i
-//             apix = api + i
-//             await web3.eth.sendTransaction({to: oracle.address,from:accounts[0],gas:7000000,data:oldTellorinst.methods.requestData(apix,x,1000,i).encodeABI()})
-//         }
-//         for(var i = 0;i<5;i++){
-//           await web3.eth.sendTransaction({to:oracle.address,from:accounts[i],gas:7000000,data:oracle2.methods['testSubmitMiningSolution(string,uint256,uint256)']("nonce",1,1200).encodeABI()})
-//         }
-//         for(var i = 0;i<5;i++){
-//           await web3.eth.sendTransaction({to:oracle.address,from:accounts[i],gas:7000000,data:oracle2.methods['testSubmitMiningSolution(string,uint256,uint256)']("nonce",57,1200).encodeABI()})
-//         }
-//         for(var i = 0;i<5;i++){
-//           await web3.eth.sendTransaction({to:oracle.address,from:accounts[i],gas:7000000,data:oracle2.methods['testSubmitMiningSolution(string,uint256,uint256)']("nonce",56,1200).encodeABI()})
-//         }
-//         diff1 = await oracle.getCurrentVariables();
-//         //Deploy new upgraded Tellor
-//         oracleBase = await Tellor.new();
-//         oracle2 = await new web3.eth.Contract(oracleAbi,oracle.address);
-//         await oracle.changeTellorContract(oracleBase.address)
-//         for(var i = 0;i<5;i++){
-//           await web3.eth.sendTransaction({to:oracle.address,from:accounts[i],gas:7000000,data:oracle2.methods['testSubmitMiningSolution(string,uint256,uint256)']("nonce",55,1200).encodeABI()})
-//         }
-//         diff2 = await oracle.getCurrentVariables();
-//         assert(diff2[2] < diff1[2]/ 2,"difficulty should drop")
-//    });
-//  });    
+    for (var i = 0; i < 5; i++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods[
+          "testSubmitMiningSolution(string,uint256,uint256)"
+        ]("nonce", 1, 1200).encodeABI(),
+      });
+    }
+    oldTellor2 = await OldTellor2.new();
+    await oracle.changeTellorContract(oldTellor2.address);
+    assert(
+      (await oracle.getAddressVars(web3.utils.keccak256("tellorContract"))) ==
+        oldTellor2.address
+    );
+
+    for (var i = 0; i < 5; i++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods[
+          "testSubmitMiningSolution(string,uint256,uint256)"
+        ]("nonce", 58, 1200).encodeABI(),
+      });
+    }
+    //Deploy new upgraded Tellor
+    oracleBase = await Tellor.new();
+    oracle2 = await new web3.eth.Contract(oracleAbi, oracle.address);
+    for (var i = 0; i < 3; i++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods[
+          "testSubmitMiningSolution(string,uint256,uint256)"
+        ]("nonce", 57, 1200).encodeABI(),
+      });
+    }
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods.addTip(31, 1000).encodeABI(),
+    });
+    await oracle.changeTellorContract(oracleBase.address);
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods.addTip(41, 20000).encodeABI(),
+    });
+    for (var i = 3; i < 5; i++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods[
+          "testSubmitMiningSolution(string,uint256,uint256)"
+        ]("nonce", 57, 1200).encodeABI(),
+      });
+    }
+    vars = await oracle2.methods.getNewCurrentVariables().call();
+    for (var i = 0; i < 5; i++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods
+          .testSubmitMiningSolution("nonce", vars["1"], [
+            1200,
+            1300,
+            1400,
+            1500,
+            1600,
+          ])
+          .encodeABI(),
+      });
+    }
+    assert(
+      (await oracle.getAddressVars(web3.utils.keccak256("tellorContract"))) ==
+        oracleBase.address
+    );
+    data = await oracle2.methods.getNewVariablesOnDeck().call();
+    var x = 0;
+    for (var i = 0; i < 5; i++) {
+      if (data[0][i] == "41") {
+        x = x + 1;
+        assert(data[1][i] > 20000, "Th");
+      }
+      if (data[0][i] == "31") {
+        x = x + 1;
+        assert(data[1][i] > 1000, "The");
+      }
+    }
+  });
+  it("Test initial difficulty drop", async function() {
+    //deploy old, request, update address, mine old challenge.
+    oldTellor = await OldTellor.new();
+    oracle = await TellorMaster.new(oldTellor.address);
+    oracle2 = await new web3.eth.Contract(oracleAbi, oracle.address);
+    master = await new web3.eth.Contract(masterAbi, oracle.address);
+    oldTellorinst = await new web3.eth.Contract(
+      oldTellorABI,
+      oldTellor.address
+    );
+    for (var i = 0; i < 6; i++) {
+      //print tokens
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[0],
+        gas: 7000000,
+        data: oldTellorinst.methods
+          .theLazyCoon(accounts[i], web3.utils.toWei("1100", "ether"))
+          .encodeABI(),
+      });
+    }
+    for (var i = 0; i < 57; i++) {
+      x = "USD" + i;
+      apix = api + i;
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[0],
+        gas: 7000000,
+        data: oldTellorinst.methods.requestData(apix, x, 1000, i).encodeABI(),
+      });
+    }
+    for (var i = 0; i < 5; i++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods[
+          "testSubmitMiningSolution(string,uint256,uint256)"
+        ]("nonce", 1, 1200).encodeABI(),
+      });
+    }
+    for (var i = 0; i < 5; i++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods[
+          "testSubmitMiningSolution(string,uint256,uint256)"
+        ]("nonce", 57, 1200).encodeABI(),
+      });
+    }
+    for (var i = 0; i < 5; i++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods[
+          "testSubmitMiningSolution(string,uint256,uint256)"
+        ]("nonce", 56, 1200).encodeABI(),
+      });
+    }
+    diff1 = await oracle.getCurrentVariables();
+    //Deploy new upgraded Tellor
+    oracleBase = await Tellor.new();
+    oracle2 = await new web3.eth.Contract(oracleAbi, oracle.address);
+    await oracle.changeTellorContract(oracleBase.address);
+    for (var i = 0; i < 5; i++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods[
+          "testSubmitMiningSolution(string,uint256,uint256)"
+        ]("nonce", 55, 1200).encodeABI(),
+      });
+    }
+    diff2 = await oracle.getCurrentVariables();
+    assert(diff2[2] < diff1[2] / 2, "difficulty should drop");
+  });
+});

--- a/test/utilititiesTest.js
+++ b/test/utilititiesTest.js
@@ -1,50 +1,50 @@
-// const Web3 = require("web3");
-// const web3 = new Web3(
-//   new Web3.providers.WebsocketProvider("ws://localhost:8545")
-// );
-// const TellorMaster = artifacts.require("./TellorMaster.sol");
-// var OldTellor = artifacts.require("./oldContracts/OldTellor.sol");
-// var UtilitiesTests = artifacts.require("./UtilitiesTests.sol");
+const Web3 = require("web3");
+const web3 = new Web3(
+  new Web3.providers.WebsocketProvider("ws://localhost:8545")
+);
+const TellorMaster = artifacts.require("./TellorMaster.sol");
+var OldTellor = artifacts.require("./oldContracts/OldTellor.sol");
+var UtilitiesTests = artifacts.require("./UtilitiesTests.sol");
 
-// contract("Utilities Tests", function(accounts) {
-//   let oracle;
-//   let oldTellor;
-//   let utilities;
+contract("Utilities Tests", function(accounts) {
+  let oracle;
+  let oldTellor;
+  let utilities;
 
-//   beforeEach("Setup contract for each test", async function() {
-//     oldTellor = await OldTellor.new();
-//     oracle = await TellorMaster.new(oldTellor.address);
-//     utilities = await UtilitiesTests.new(oracle.address);
-//   });
-//   it("Test possible duplicates on top Requests", async function() {
-//     const testGetMax = async () => {
-//       let queue = [0];
-//       let ref = [0];
-//       for (var i = 0; i < 50; i++) {
-//         let x = Math.floor(Math.random() * 998) + 1;
-//         queue.push(x);
-//         ref.push(x);
-//       }
-//       // console.log(queue);
+  beforeEach("Setup contract for each test", async function() {
+    oldTellor = await OldTellor.new();
+    oracle = await TellorMaster.new(oldTellor.address);
+    utilities = await UtilitiesTests.new(oracle.address);
+  });
+  it("Test possible duplicates on top Requests", async function() {
+    const testGetMax = async () => {
+      let queue = [0];
+      let ref = [0];
+      for (var i = 0; i < 50; i++) {
+        let x = Math.floor(Math.random() * 998) + 1;
+        queue.push(x);
+        ref.push(x);
+      }
+      // console.log(queue);
 
-//       let res = await utilities.testgetMax5(queue);
-//       let values = [];
-//       let idexes = [];
+      let res = await utilities.testgetMax5(queue);
+      let values = [];
+      let idexes = [];
 
-//       let tempsorted = queue.sort((a, b) => a - b);
-//       let sorted = tempsorted.slice(46);
-//       for (var i = 0; i < 5; i++) {
-//         values.push(res["0"][i].toNumber());
-//         idexes.push(res["1"][i].toNumber());
-//       }
-//       let svals = values.sort((a, b) => a - b);
-//       for (var i = 0; i < 5; i++) {
-//         assert(svals[i] == sorted[i], "Value supposed to be on the top5");
-//       }
-//     };
+      let tempsorted = queue.sort((a, b) => a - b);
+      let sorted = tempsorted.slice(46);
+      for (var i = 0; i < 5; i++) {
+        values.push(res["0"][i].toNumber());
+        idexes.push(res["1"][i].toNumber());
+      }
+      let svals = values.sort((a, b) => a - b);
+      for (var i = 0; i < 5; i++) {
+        assert(svals[i] == sorted[i], "Value supposed to be on the top5");
+      }
+    };
 
-//     for (var k = 0; k < 25; k++) {
-//       await testGetMax();
-//     }
-//   });
-// });
+    for (var k = 0; k < 25; k++) {
+      await testGetMax();
+    }
+  });
+});

--- a/test/v2Tests.js
+++ b/test/v2Tests.js
@@ -1,1109 +1,1111 @@
-// const Web3 = require("web3");
-// const web3 = new Web3(
-//   new Web3.providers.WebsocketProvider("ws://localhost:8545")
-// );
-// const helper = require("./helpers/test_helpers");
-// const TellorMaster = artifacts.require("./TellorMaster.sol");
-// const Tellor = artifacts.require("./Tellor.sol"); // globally injected artifacts helper
-// var oracleAbi = Tellor.abi;
-// var oracleByte = Tellor.bytecode;
-// var OldTellor = artifacts.require("./oldContracts/OldTellor.sol");
-// var oldTellorABI = OldTellor.abi;
-// var UtilitiesTests = artifacts.require("./UtilitiesTests.sol");
+const Web3 = require("web3");
+const web3 = new Web3(
+  new Web3.providers.WebsocketProvider("ws://localhost:8545")
+);
+const helper = require("./helpers/test_helpers");
+const TellorMaster = artifacts.require("./TellorMaster.sol");
+const Tellor = artifacts.require("./Tellor.sol"); // globally injected artifacts helper
+var oracleAbi = Tellor.abi;
+var oracleByte = Tellor.bytecode;
+var OldTellor = artifacts.require("./oldContracts/OldTellor.sol");
+var oldTellorABI = OldTellor.abi;
+var UtilitiesTests = artifacts.require("./UtilitiesTests.sol");
 
-// var masterAbi = TellorMaster.abi;
-// var api = "json(https://api.gdax.com/products/BTC-USD/ticker).price";
-// var api2 = "json(https://api.gdax.com/products/ETH-USD/ticker).price";
+var masterAbi = TellorMaster.abi;
+var api = "json(https://api.gdax.com/products/BTC-USD/ticker).price";
+var api2 = "json(https://api.gdax.com/products/ETH-USD/ticker).price";
 
-// contract("v2 Tests", function(accounts) {
-//   let oracleBase;
-//   let oracle;
-//   let oracle2;
-//   let master;
-//   let oldTellor;
-//   let oldTellorinst;
-//   let utilities;
+contract("v2 Tests", function(accounts) {
+  let oracleBase;
+  let oracle;
+  let oracle2;
+  let master;
+  let oldTellor;
+  let oldTellorinst;
+  let utilities;
 
-//   beforeEach("Setup contract for each test", async function() {
-//     //deploy old, request, update address, mine old challenge.
-//     oldTellor = await OldTellor.new();
-//     oracle = await TellorMaster.new(oldTellor.address);
-//     master = await new web3.eth.Contract(masterAbi, oracle.address);
-//     oldTellorinst = await new web3.eth.Contract(
-//       oldTellorABI,
-//       oldTellor.address
-//     );
-//     for (var i = 0; i < 6; i++) {
-//       //print tokens
-//       await web3.eth.sendTransaction({
-//         to: oracle.address,
-//         from: accounts[0],
-//         gas: 7000000,
-//         data: oldTellorinst.methods
-//           .theLazyCoon(accounts[i], web3.utils.toWei("7000", "ether"))
-//           .encodeABI(),
-//       });
-//     }
-//     for (var i = 0; i < 52; i++) {
-//       x = "USD" + i;
-//       apix = api + i;
-//       await web3.eth.sendTransaction({
-//         to: oracle.address,
-//         from: accounts[0],
-//         gas: 7000000,
-//         data: oldTellorinst.methods.requestData(apix, x, 1000, 0).encodeABI(),
-//       });
-//     }
-//     let q = await oracle.getRequestQ();
-//     //Deploy new upgraded Tellor
-//     oracleBase = await Tellor.new();
-//     oracle2 = await new web3.eth.Contract(oracleAbi, oracle.address);
-//     await oracle.changeTellorContract(oracleBase.address);
-//     for (var i = 0; i < 5; i++) {
-//       await web3.eth.sendTransaction({
-//         to: oracle.address,
-//         from: accounts[i],
-//         gas: 7000000,
-//         data: oracle2.methods[
-//           "testSubmitMiningSolution(string,uint256,uint256)"
-//         ]("nonce", 1, 1200).encodeABI(),
-//       });
-//     }
-//   });
-//     it("Test zeroing out of currentTips", async function() {
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[2],
-//       gas: 7000000,
-//       data: oracle2.methods.addTip(1,100000000000).encodeABI(),
-//     });
-//     for (var i = 0; i < 5; i++) {
-//       res = await web3.eth.sendTransaction({
-//         to: oracle.address,
-//         from: accounts[i],
-//         gas: 7000000,
-//         data: oracle2.methods
-//           .testSubmitMiningSolution(
-//             "nonce",
-//             [1, 2, 3, 4, 5],
-//             [1200, 1300, 1400, 1500, 1600]
-//           )
-//           .encodeABI(),
-//       });
-//     }
-//     console.log(await oracle.getUintVar(web3.utils.keccak256("currentTotalTips")))
-//     assert(
-//       (await oracle.getUintVar(web3.utils.keccak256("currentTotalTips"))) == 0
-//     );
-//   });
+  beforeEach("Setup contract for each test", async function() {
+    //deploy old, request, update address, mine old challenge.
+    oldTellor = await OldTellor.new();
+    oracle = await TellorMaster.new(oldTellor.address);
+    master = await new web3.eth.Contract(masterAbi, oracle.address);
+    oldTellorinst = await new web3.eth.Contract(
+      oldTellorABI,
+      oldTellor.address
+    );
+    for (var i = 0; i < 6; i++) {
+      //print tokens
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[0],
+        gas: 7000000,
+        data: oldTellorinst.methods
+          .theLazyCoon(accounts[i], web3.utils.toWei("7000", "ether"))
+          .encodeABI(),
+      });
+    }
+    for (var i = 0; i < 52; i++) {
+      x = "USD" + i;
+      apix = api + i;
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[0],
+        gas: 7000000,
+        data: oldTellorinst.methods.requestData(apix, x, 1000, 0).encodeABI(),
+      });
+    }
+    let q = await oracle.getRequestQ();
+    //Deploy new upgraded Tellor
+    oracleBase = await Tellor.new();
+    oracle2 = await new web3.eth.Contract(oracleAbi, oracle.address);
+    await oracle.changeTellorContract(oracleBase.address);
+    for (var i = 0; i < 5; i++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods[
+          "testSubmitMiningSolution(string,uint256,uint256)"
+        ]("nonce", 1, 1200).encodeABI(),
+      });
+    }
+  });
+  it("Test zeroing out of currentTips", async function() {
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[2],
+      gas: 7000000,
+      data: oracle2.methods.addTip(1, 100000000000).encodeABI(),
+    });
+    for (var i = 0; i < 5; i++) {
+      res = await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods
+          .testSubmitMiningSolution(
+            "nonce",
+            [1, 2, 3, 4, 5],
+            [1200, 1300, 1400, 1500, 1600]
+          )
+          .encodeABI(),
+      });
+    }
+    console.log(
+      await oracle.getUintVar(web3.utils.keccak256("currentTotalTips"))
+    );
+    assert(
+      (await oracle.getUintVar(web3.utils.keccak256("currentTotalTips"))) == 0
+    );
+  });
 
-//   it("Test lower difficulty target (5 min)", async function() {
-//     assert(
-//       (await oracle.getUintVar(web3.utils.keccak256("timeTarget"))) == 300
-//     );
-//   });
-//   it("Test no time limit on disputes", async function() {
-//     for (var i = 0; i < 5; i++) {
-//       res = await web3.eth.sendTransaction({
-//         to: oracle.address,
-//         from: accounts[i],
-//         gas: 7000000,
-//         data: oracle2.methods
-//           .testSubmitMiningSolution(
-//             "nonce",
-//             [1, 2, 3, 4, 5],
-//             [1200, 1300, 1400, 1500, 1600]
-//           )
-//           .encodeABI(),
-//       });
-//     }
-//     res = web3.eth.abi.decodeParameters(
-//       ["uint256[5]", "uint256", "uint256[5]", "uint256"],
-//       res.logs["1"].data
-//     );
-//     balance1 = await oracle.balanceOf(accounts[2]);
-//     blocknum = await oracle.getMinedBlockNum(1, res[1]);
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[0],
-//       gas: 7000000,
-//       data: oracle2.methods
-//         .theLazyCoon(accounts[1], web3.utils.toWei("5000", "ether"))
-//         .encodeABI(),
-//     });
-//     dispBal1 = await oracle.balanceOf(accounts[1]);
-//     await helper.advanceTime(86400 * 22);
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[1],
-//       gas: 7000000,
-//       data: oracle2.methods.beginDispute(1, res[1], 2).encodeABI(),
-//     });
-//     count = await oracle.getUintVar(web3.utils.keccak256("disputeCount"));
-//     assert(count == 1);
-//   });
-//   it("Test multiple dispute rounds, passing all three", async function() {
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[0],
-//       gas: 7000000,
-//       data: oracle2.methods
-//         .theLazyCoon(accounts[1], web3.utils.toWei("500", "ether"))
-//         .encodeABI(),
-//     });
-//     for (var i = 0; i < 5; i++) {
-//       res = await web3.eth.sendTransaction({
-//         to: oracle.address,
-//         from: accounts[i],
-//         gas: 7000000,
-//         data: oracle2.methods
-//           .testSubmitMiningSolution(
-//             "nonce",
-//             [1, 2, 3, 4, 5],
-//             [1200, 1300, 1400, 1500, 1600]
-//           )
-//           .encodeABI(),
-//       });
-//     }
-//     res = web3.eth.abi.decodeParameters(
-//       ["uint256[5]", "uint256", "uint256[5]", "uint256"],
-//       res.logs["1"].data
-//     );
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[0],
-//       gas: 7000000,
-//       data: oracle2.methods
-//         .theLazyCoon(accounts[1], web3.utils.toWei("5000", "ether"))
-//         .encodeABI(),
-//     });
-//     balance1 = await oracle.balanceOf(accounts[2]);
-//     dispBal1 = await oracle.balanceOf(accounts[1]);
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[1],
-//       gas: 7000000,
-//       data: oracle2.methods.beginDispute(1, res[1], 2).encodeABI(),
-//     });
-//     count = await oracle.getUintVar(web3.utils.keccak256("disputeCount"));
-//     //vote 1 passes
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[3],
-//       gas: 7000000,
-//       data: oracle2.methods.vote(1, true).encodeABI(),
-//     });
-//     await helper.advanceTime(86400 * 3);
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[0],
-//       gas: 7000000,
-//       data: oracle2.methods.tallyVotes(1).encodeABI(),
-//     });
-//     await helper.expectThrow(
-//       web3.eth.sendTransaction({
-//         to: oracle.address,
-//         from: accounts[0],
-//         gas: 7000000,
-//         data: oracle2.methods.unlockDisputeFee(1).encodeABI(),
-//       })
-//     ); //try to withdraw
-//     dispInfo = await oracle.getAllDisputeVars(1);
-//     assert(
-//       dispInfo[4] == accounts[2],
-//       "account 2 should be the disputed miner"
-//     );
-//     assert(dispInfo[2] == true, "Dispute Vote passed");
-//     //vote 2 - fails
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[0],
-//       gas: 7000000,
-//       data: oracle2.methods
-//         .theLazyCoon(accounts[6], web3.utils.toWei("5000", "ether"))
-//         .encodeABI(),
-//     });
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[6],
-//       gas: 7000000,
-//       data: oracle2.methods.beginDispute(1, res[1], 2).encodeABI(),
-//     });
-//     count = await oracle.getUintVar(web3.utils.keccak256("disputeCount"));
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[6],
-//       gas: 7000000,
-//       data: oracle2.methods.vote(2, true).encodeABI(),
-//     });
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[4],
-//       gas: 7000000,
-//       data: oracle2.methods.vote(2, true).encodeABI(),
-//     });
-//     await helper.advanceTime(86400 * 5);
+  it("Test lower difficulty target (5 min)", async function() {
+    assert(
+      (await oracle.getUintVar(web3.utils.keccak256("timeTarget"))) == 300
+    );
+  });
+  it("Test no time limit on disputes", async function() {
+    for (var i = 0; i < 5; i++) {
+      res = await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods
+          .testSubmitMiningSolution(
+            "nonce",
+            [1, 2, 3, 4, 5],
+            [1200, 1300, 1400, 1500, 1600]
+          )
+          .encodeABI(),
+      });
+    }
+    res = web3.eth.abi.decodeParameters(
+      ["uint256[5]", "uint256", "uint256[5]", "uint256"],
+      res.logs["1"].data
+    );
+    balance1 = await oracle.balanceOf(accounts[2]);
+    blocknum = await oracle.getMinedBlockNum(1, res[1]);
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods
+        .theLazyCoon(accounts[1], web3.utils.toWei("5000", "ether"))
+        .encodeABI(),
+    });
+    dispBal1 = await oracle.balanceOf(accounts[1]);
+    await helper.advanceTime(86400 * 22);
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[1],
+      gas: 7000000,
+      data: oracle2.methods.beginDispute(1, res[1], 2).encodeABI(),
+    });
+    count = await oracle.getUintVar(web3.utils.keccak256("disputeCount"));
+    assert(count == 1);
+  });
+  it("Test multiple dispute rounds, passing all three", async function() {
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods
+        .theLazyCoon(accounts[1], web3.utils.toWei("500", "ether"))
+        .encodeABI(),
+    });
+    for (var i = 0; i < 5; i++) {
+      res = await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods
+          .testSubmitMiningSolution(
+            "nonce",
+            [1, 2, 3, 4, 5],
+            [1200, 1300, 1400, 1500, 1600]
+          )
+          .encodeABI(),
+      });
+    }
+    res = web3.eth.abi.decodeParameters(
+      ["uint256[5]", "uint256", "uint256[5]", "uint256"],
+      res.logs["1"].data
+    );
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods
+        .theLazyCoon(accounts[1], web3.utils.toWei("5000", "ether"))
+        .encodeABI(),
+    });
+    balance1 = await oracle.balanceOf(accounts[2]);
+    dispBal1 = await oracle.balanceOf(accounts[1]);
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[1],
+      gas: 7000000,
+      data: oracle2.methods.beginDispute(1, res[1], 2).encodeABI(),
+    });
+    count = await oracle.getUintVar(web3.utils.keccak256("disputeCount"));
+    //vote 1 passes
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[3],
+      gas: 7000000,
+      data: oracle2.methods.vote(1, true).encodeABI(),
+    });
+    await helper.advanceTime(86400 * 3);
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods.tallyVotes(1).encodeABI(),
+    });
+    await helper.expectThrow(
+      web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[0],
+        gas: 7000000,
+        data: oracle2.methods.unlockDisputeFee(1).encodeABI(),
+      })
+    ); //try to withdraw
+    dispInfo = await oracle.getAllDisputeVars(1);
+    assert(
+      dispInfo[4] == accounts[2],
+      "account 2 should be the disputed miner"
+    );
+    assert(dispInfo[2] == true, "Dispute Vote passed");
+    //vote 2 - fails
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods
+        .theLazyCoon(accounts[6], web3.utils.toWei("5000", "ether"))
+        .encodeABI(),
+    });
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[6],
+      gas: 7000000,
+      data: oracle2.methods.beginDispute(1, res[1], 2).encodeABI(),
+    });
+    count = await oracle.getUintVar(web3.utils.keccak256("disputeCount"));
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[6],
+      gas: 7000000,
+      data: oracle2.methods.vote(2, true).encodeABI(),
+    });
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[4],
+      gas: 7000000,
+      data: oracle2.methods.vote(2, true).encodeABI(),
+    });
+    await helper.advanceTime(86400 * 5);
 
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[0],
-//       gas: 7000000,
-//       data: oracle2.methods.tallyVotes(2).encodeABI(),
-//     });
-//     dispInfo = await oracle.getAllDisputeVars(2);
-//     assert(dispInfo[2] == true, "Dispute Vote passes again");
-//     // vote 3 - passes
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[0],
-//       gas: 7000000,
-//       data: oracle2.methods
-//         .theLazyCoon(accounts[3], web3.utils.toWei("5000", "ether"))
-//         .encodeABI(),
-//     });
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[1],
-//       gas: 7000000,
-//       data: oracle2.methods.beginDispute(1, res[1], 2).encodeABI(),
-//     });
-//     count = await oracle.getUintVar(web3.utils.keccak256("disputeCount"));
-//     assert(count == 3);
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[6],
-//       gas: 7000000,
-//       data: oracle2.methods.vote(3, false).encodeABI(),
-//     });
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[3],
-//       gas: 7000000,
-//       data: oracle2.methods.vote(3, true).encodeABI(),
-//     });
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[4],
-//       gas: 7000000,
-//       data: oracle2.methods.vote(3, true).encodeABI(),
-//     });
-//     await helper.advanceTime(86400 * 9);
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[0],
-//       gas: 7000000,
-//       data: oracle2.methods.tallyVotes(3).encodeABI(),
-//     });
-//     await helper.advanceTime(86400 * 2);
-//     dispInfo = await oracle.getAllDisputeVars(1);
-//     assert(dispInfo[2] == true, "Dispute Vote passed");
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[0],
-//       gas: 9000000,
-//       data: oracle2.methods.unlockDisputeFee(1).encodeABI(),
-//     });
-//     dispInfo = await oracle.getAllDisputeVars(1);
-//     assert(dispInfo[2] == true, "Dispute Vote passed");
-//     balance2 = await oracle.balanceOf(accounts[2]);
-//     dispBal2 = await oracle.balanceOf(accounts[1]);
-//     assert(
-//       balance1 - balance2 == web3.utils.toWei("1000"),
-//       "reported miner's balance should change correctly"
-//     );
-//     assert(
-//       dispBal2 - dispBal1 == web3.utils.toWei("1000"),
-//       "disputing party's balance should change correctly"
-//     );
-//   });
-//   it("Test multiple dispute rounds -- proposed fork", async function() {
-//     for (var i = 0; i < 5; i++) {
-//       res = await web3.eth.sendTransaction({
-//         to: oracle.address,
-//         from: accounts[i],
-//         gas: 7000000,
-//         data: oracle2.methods
-//           .testSubmitMiningSolution(
-//             "nonce",
-//             [1, 2, 3, 4, 5],
-//             [1200, 1300, 1400, 1500, 1600]
-//           )
-//           .encodeABI(),
-//       });
-//     }
-//     res = web3.eth.abi.decodeParameters(
-//       ["uint256[5]", "uint256", "uint256[5]", "uint256"],
-//       res.logs["1"].data
-//     );
-//     balance1 = await oracle.balanceOf(accounts[2]);
-//     dispBal1 = await oracle.balanceOf(accounts[1]);
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods.tallyVotes(2).encodeABI(),
+    });
+    dispInfo = await oracle.getAllDisputeVars(2);
+    assert(dispInfo[2] == true, "Dispute Vote passes again");
+    // vote 3 - passes
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods
+        .theLazyCoon(accounts[3], web3.utils.toWei("5000", "ether"))
+        .encodeABI(),
+    });
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[1],
+      gas: 7000000,
+      data: oracle2.methods.beginDispute(1, res[1], 2).encodeABI(),
+    });
+    count = await oracle.getUintVar(web3.utils.keccak256("disputeCount"));
+    assert(count == 3);
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[6],
+      gas: 7000000,
+      data: oracle2.methods.vote(3, false).encodeABI(),
+    });
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[3],
+      gas: 7000000,
+      data: oracle2.methods.vote(3, true).encodeABI(),
+    });
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[4],
+      gas: 7000000,
+      data: oracle2.methods.vote(3, true).encodeABI(),
+    });
+    await helper.advanceTime(86400 * 9);
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods.tallyVotes(3).encodeABI(),
+    });
+    await helper.advanceTime(86400 * 2);
+    dispInfo = await oracle.getAllDisputeVars(1);
+    assert(dispInfo[2] == true, "Dispute Vote passed");
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 9000000,
+      data: oracle2.methods.unlockDisputeFee(1).encodeABI(),
+    });
+    dispInfo = await oracle.getAllDisputeVars(1);
+    assert(dispInfo[2] == true, "Dispute Vote passed");
+    balance2 = await oracle.balanceOf(accounts[2]);
+    dispBal2 = await oracle.balanceOf(accounts[1]);
+    assert(
+      balance1 - balance2 == web3.utils.toWei("1000"),
+      "reported miner's balance should change correctly"
+    );
+    assert(
+      dispBal2 - dispBal1 == web3.utils.toWei("1000"),
+      "disputing party's balance should change correctly"
+    );
+  });
+  it("Test multiple dispute rounds -- proposed fork", async function() {
+    for (var i = 0; i < 5; i++) {
+      res = await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods
+          .testSubmitMiningSolution(
+            "nonce",
+            [1, 2, 3, 4, 5],
+            [1200, 1300, 1400, 1500, 1600]
+          )
+          .encodeABI(),
+      });
+    }
+    res = web3.eth.abi.decodeParameters(
+      ["uint256[5]", "uint256", "uint256[5]", "uint256"],
+      res.logs["1"].data
+    );
+    balance1 = await oracle.balanceOf(accounts[2]);
+    dispBal1 = await oracle.balanceOf(accounts[1]);
 
-//     let oracleBase2 = await Tellor.new();
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[2],
-//       gas: 7000000,
-//       data: oracle2.methods.proposeFork(oracleBase2.address).encodeABI(),
-//     });
-//     for (var i = 1; i < 5; i++) {
-//       await web3.eth.sendTransaction({
-//         to: oracle.address,
-//         from: accounts[i],
-//         gas: 7000000,
-//         data: oracle2.methods.vote(1, true).encodeABI(),
-//       });
-//     }
-//     await helper.advanceTime(86400 * 8);
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[i],
-//       gas: 7000000,
-//       data: oracle2.methods.tallyVotes(1).encodeABI(),
-//     });
-//     await helper.advanceTime(100);
-//     dispInfo = await oracle.getAllDisputeVars(1);
-//     assert(dispInfo[2] == true, "Dispute Vote passed");
-//     assert(
-//       (await oracle.getAddressVars(web3.utils.keccak256("tellorContract"))) !=
-//         oracleBase2.address
-//     );
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[3],
-//       gas: 7000000,
-//       data: oracle2.methods.proposeFork(oracleBase2.address).encodeABI(),
-//     });
-//     for (var i = 1; i < 5; i++) {
-//       await web3.eth.sendTransaction({
-//         to: oracle.address,
-//         from: accounts[i],
-//         gas: 7000000,
-//         data: oracle2.methods.vote(2, false).encodeABI(),
-//       });
-//     }
-//     await helper.advanceTime(86400 * 8);
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[0],
-//       gas: 7000000,
-//       data: oracle2.methods.tallyVotes(2).encodeABI(),
-//     });
-//     await helper.expectThrow(
-//       web3.eth.sendTransaction({
-//         to: oracle.address,
-//         from: accounts[0],
-//         gas: 7000000,
-//         data: oracle2.methods.updateTellor(1).encodeABI(),
-//       })
-//     ); //try to withdraw
-//     await helper.advanceTime(86400 * 8);
-//     await helper.expectThrow(
-//       web3.eth.sendTransaction({
-//         to: oracle.address,
-//         from: accounts[0],
-//         gas: 7000000,
-//         data: oracle2.methods.updateTellor(2).encodeABI(),
-//       })
-//     );
-//     assert(
-//       (await oracle.getAddressVars(web3.utils.keccak256("tellorContract"))) !=
-//         oracleBase2.address
-//     );
-//   });
-//   it("Test multiple dispute rounds - passing, then failing", async function() {
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[0],
-//       gas: 7000000,
-//       data: oracle2.methods
-//         .theLazyCoon(accounts[6], web3.utils.toWei("3000", "ether"))
-//         .encodeABI(),
-//     });
+    let oracleBase2 = await Tellor.new();
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[2],
+      gas: 7000000,
+      data: oracle2.methods.proposeFork(oracleBase2.address).encodeABI(),
+    });
+    for (var i = 1; i < 5; i++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods.vote(1, true).encodeABI(),
+      });
+    }
+    await helper.advanceTime(86400 * 8);
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[i],
+      gas: 7000000,
+      data: oracle2.methods.tallyVotes(1).encodeABI(),
+    });
+    await helper.advanceTime(100);
+    dispInfo = await oracle.getAllDisputeVars(1);
+    assert(dispInfo[2] == true, "Dispute Vote passed");
+    assert(
+      (await oracle.getAddressVars(web3.utils.keccak256("tellorContract"))) !=
+        oracleBase2.address
+    );
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[3],
+      gas: 7000000,
+      data: oracle2.methods.proposeFork(oracleBase2.address).encodeABI(),
+    });
+    for (var i = 1; i < 5; i++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods.vote(2, false).encodeABI(),
+      });
+    }
+    await helper.advanceTime(86400 * 8);
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods.tallyVotes(2).encodeABI(),
+    });
+    await helper.expectThrow(
+      web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[0],
+        gas: 7000000,
+        data: oracle2.methods.updateTellor(1).encodeABI(),
+      })
+    ); //try to withdraw
+    await helper.advanceTime(86400 * 8);
+    await helper.expectThrow(
+      web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[0],
+        gas: 7000000,
+        data: oracle2.methods.updateTellor(2).encodeABI(),
+      })
+    );
+    assert(
+      (await oracle.getAddressVars(web3.utils.keccak256("tellorContract"))) !=
+        oracleBase2.address
+    );
+  });
+  it("Test multiple dispute rounds - passing, then failing", async function() {
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods
+        .theLazyCoon(accounts[6], web3.utils.toWei("3000", "ether"))
+        .encodeABI(),
+    });
 
-//     for (var i = 0; i < 5; i++) {
-//       res = await web3.eth.sendTransaction({
-//         to: oracle.address,
-//         from: accounts[i],
-//         gas: 7000000,
-//         data: oracle2.methods
-//           .testSubmitMiningSolution(
-//             "nonce",
-//             [1, 2, 3, 4, 5],
-//             [1200, 1300, 1400, 1500, 1600]
-//           )
-//           .encodeABI(),
-//       });
-//     }
-//     res = web3.eth.abi.decodeParameters(
-//       ["uint256[5]", "uint256", "uint256[5]", "uint256"],
-//       res.logs["1"].data
-//     );
-//     balance1 = await oracle.balanceOf(accounts[2]);
-//     dispBal1 = await oracle.balanceOf(accounts[1]);
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[1],
-//       gas: 7000000,
-//       data: oracle2.methods.beginDispute(1, res[1], 2).encodeABI(),
-//     });
+    for (var i = 0; i < 5; i++) {
+      res = await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods
+          .testSubmitMiningSolution(
+            "nonce",
+            [1, 2, 3, 4, 5],
+            [1200, 1300, 1400, 1500, 1600]
+          )
+          .encodeABI(),
+      });
+    }
+    res = web3.eth.abi.decodeParameters(
+      ["uint256[5]", "uint256", "uint256[5]", "uint256"],
+      res.logs["1"].data
+    );
+    balance1 = await oracle.balanceOf(accounts[2]);
+    dispBal1 = await oracle.balanceOf(accounts[1]);
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[1],
+      gas: 7000000,
+      data: oracle2.methods.beginDispute(1, res[1], 2).encodeABI(),
+    });
 
-//     count = await oracle.getUintVar(web3.utils.keccak256("disputeCount"));
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[3],
-//       gas: 7000000,
-//       data: oracle2.methods.vote(1, true).encodeABI(),
-//     });
-//     await helper.advanceTime(86400 * 3);
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[0],
-//       gas: 7000000,
-//       data: oracle2.methods.tallyVotes(1).encodeABI(),
-//     });
-//     await helper.expectThrow(
-//       web3.eth.sendTransaction({
-//         to: oracle.address,
-//         from: accounts[0],
-//         gas: 7000000,
-//         data: oracle2.methods.unlockDisputeFee(1).encodeABI(),
-//       })
-//     ); //try to withdraw
-//     dispInfo = await oracle.getAllDisputeVars(1);
-//     assert(
-//       dispInfo[4] == accounts[2],
-//       "account 2 should be the disputed miner"
-//     );
-//     assert(dispInfo[2] == true, "Dispute Vote passed");
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[6],
-//       gas: 7000000,
-//       data: oracle2.methods.beginDispute(1, res[1], 2).encodeABI(),
-//     });
-//     count = await oracle.getUintVar(web3.utils.keccak256("disputeCount"));
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[6],
-//       gas: 7000000,
-//       data: oracle2.methods.vote(2, false).encodeABI(),
-//     });
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[4],
-//       gas: 7000000,
-//       data: oracle2.methods.vote(2, false).encodeABI(),
-//     });
-//     await helper.advanceTime(86400 * 5);
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[0],
-//       gas: 7000000,
-//       data: oracle2.methods.tallyVotes(2).encodeABI(),
-//     });
-//     dispInfo = await oracle.getAllDisputeVars(2);
-//     assert(dispInfo[2] == false, "Dispute Vote failed");
-//     await helper.advanceTime(86400 * 2);
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[0],
-//       gas: 7000000,
-//       data: oracle2.methods.unlockDisputeFee(1).encodeABI(),
-//     });
-//     dispInfo = await oracle.getAllDisputeVars(1);
-//     assert(dispInfo[2] == true, "Dispute Vote passed");
-//     dispInfo2 = await oracle.getAllDisputeVars(2);
-//     balance2 = await oracle.balanceOf(accounts[2]);
-//     dispBal2 = await oracle.balanceOf(accounts[1]);
-//     assert(
-//       web3.utils.fromWei(balance2) - web3.utils.fromWei(balance1) ==
-//         web3.utils.fromWei(dispInfo[7][8]) * 1 +
-//           web3.utils.fromWei(dispInfo2[7][8]) * 1,
-//       "reported miner's balance should change correctly"
-//     );
-//     assert(
-//       web3.utils.fromWei(dispBal1) - web3.utils.fromWei(dispBal2) ==
-//         web3.utils.fromWei(dispInfo[7][8]) * 1,
-//       "disputing party's balance should change correctly"
-//     );
-//   });
-//   it("Test multiple dispute rounds - failing, then passing", async function() {
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[0],
-//       gas: 7000000,
-//       data: oracle2.methods
-//         .theLazyCoon(accounts[6], web3.utils.toWei("4000", "ether"))
-//         .encodeABI(),
-//     });
+    count = await oracle.getUintVar(web3.utils.keccak256("disputeCount"));
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[3],
+      gas: 7000000,
+      data: oracle2.methods.vote(1, true).encodeABI(),
+    });
+    await helper.advanceTime(86400 * 3);
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods.tallyVotes(1).encodeABI(),
+    });
+    await helper.expectThrow(
+      web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[0],
+        gas: 7000000,
+        data: oracle2.methods.unlockDisputeFee(1).encodeABI(),
+      })
+    ); //try to withdraw
+    dispInfo = await oracle.getAllDisputeVars(1);
+    assert(
+      dispInfo[4] == accounts[2],
+      "account 2 should be the disputed miner"
+    );
+    assert(dispInfo[2] == true, "Dispute Vote passed");
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[6],
+      gas: 7000000,
+      data: oracle2.methods.beginDispute(1, res[1], 2).encodeABI(),
+    });
+    count = await oracle.getUintVar(web3.utils.keccak256("disputeCount"));
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[6],
+      gas: 7000000,
+      data: oracle2.methods.vote(2, false).encodeABI(),
+    });
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[4],
+      gas: 7000000,
+      data: oracle2.methods.vote(2, false).encodeABI(),
+    });
+    await helper.advanceTime(86400 * 5);
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods.tallyVotes(2).encodeABI(),
+    });
+    dispInfo = await oracle.getAllDisputeVars(2);
+    assert(dispInfo[2] == false, "Dispute Vote failed");
+    await helper.advanceTime(86400 * 2);
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods.unlockDisputeFee(1).encodeABI(),
+    });
+    dispInfo = await oracle.getAllDisputeVars(1);
+    assert(dispInfo[2] == true, "Dispute Vote passed");
+    dispInfo2 = await oracle.getAllDisputeVars(2);
+    balance2 = await oracle.balanceOf(accounts[2]);
+    dispBal2 = await oracle.balanceOf(accounts[1]);
+    assert(
+      web3.utils.fromWei(balance2) - web3.utils.fromWei(balance1) ==
+        web3.utils.fromWei(dispInfo[7][8]) * 1 +
+          web3.utils.fromWei(dispInfo2[7][8]) * 1,
+      "reported miner's balance should change correctly"
+    );
+    assert(
+      web3.utils.fromWei(dispBal1) - web3.utils.fromWei(dispBal2) ==
+        web3.utils.fromWei(dispInfo[7][8]) * 1,
+      "disputing party's balance should change correctly"
+    );
+  });
+  it("Test multiple dispute rounds - failing, then passing", async function() {
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods
+        .theLazyCoon(accounts[6], web3.utils.toWei("4000", "ether"))
+        .encodeABI(),
+    });
 
-//     for (var i = 0; i < 5; i++) {
-//       res = await web3.eth.sendTransaction({
-//         to: oracle.address,
-//         from: accounts[i],
-//         gas: 7000000,
-//         data: oracle2.methods
-//           .testSubmitMiningSolution(
-//             "nonce",
-//             [1, 2, 3, 4, 5],
-//             [1200, 1300, 1400, 1500, 1600]
-//           )
-//           .encodeABI(),
-//       });
-//     }
-//     res = web3.eth.abi.decodeParameters(
-//       ["uint256[5]", "uint256", "uint256[5]", "uint256"],
-//       res.logs["1"].data
-//     );
-//     balance1 = await oracle.balanceOf(accounts[2]);
-//     dispBal1 = await oracle.balanceOf(accounts[1]);
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[1],
-//       gas: 7000000,
-//       data: oracle2.methods.beginDispute(1, res[1], 2).encodeABI(),
-//     });
-//     count = await oracle.getUintVar(web3.utils.keccak256("disputeCount"));
-//     //vote 1 fails
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[3],
-//       gas: 7000000,
-//       data: oracle2.methods.vote(1, false).encodeABI(),
-//     });
-//     await helper.advanceTime(86400 * 3);
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[0],
-//       gas: 7000000,
-//       data: oracle2.methods.tallyVotes(1).encodeABI(),
-//     });
-//     await helper.expectThrow(
-//       web3.eth.sendTransaction({
-//         to: oracle.address,
-//         from: accounts[0],
-//         gas: 7000000,
-//         data: oracle2.methods.unlockDisputeFee(1).encodeABI(),
-//       })
-//     ); //try to withdraw
-//     dispInfo = await oracle.getAllDisputeVars(1);
-//     assert(
-//       dispInfo[4] == accounts[2],
-//       "account 2 should be the disputed miner"
-//     );
-//     assert(dispInfo[2] == false, "Dispute Vote failed");
-//     //vote 2 - passes
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[6],
-//       gas: 7000000,
-//       data: oracle2.methods.beginDispute(1, res[1], 2).encodeABI(),
-//     });
-//     count = await oracle.getUintVar(web3.utils.keccak256("disputeCount"));
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[6],
-//       gas: 7000000,
-//       data: oracle2.methods.vote(2, true).encodeABI(),
-//     });
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[4],
-//       gas: 7000000,
-//       data: oracle2.methods.vote(2, true).encodeABI(),
-//     });
-//     await helper.advanceTime(86400 * 5);
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[0],
-//       gas: 7000000,
-//       data: oracle2.methods.tallyVotes(2).encodeABI(),
-//     });
-//     dispInfo = await oracle.getAllDisputeVars(2);
-//     assert(dispInfo[2] == true, "Dispute Vote passed");
-//     await helper.advanceTime(86400 * 2);
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[0],
-//       gas: 7000000,
-//       data: oracle2.methods.unlockDisputeFee(1).encodeABI(),
-//     });
-//     balance2 = await oracle.balanceOf(accounts[2]);
-//     dispBal2 = await oracle.balanceOf(accounts[1]);
-//     assert(
-//       balance1 - balance2 ==
-//         (await oracle.getUintVar(web3.utils.keccak256("stakeAmount"))),
-//       "reported miner's balance should change correctly"
-//     );
-//     assert(
-//       web3.utils.fromWei(dispBal2) - web3.utils.fromWei(dispBal1) == 1000,
-//       "disputing party's balance should change correctly"
-//     );
-//     assert(
-//       web3.utils.fromWei(balance1) - web3.utils.fromWei(balance2) == 1000,
-//       "Account 2 balance should be correct"
-//     );
-//   });
-//   it("Test allow tip of current mined ID", async function() {
-//     vars = await oracle2.methods.getNewCurrentVariables().call();
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[0],
-//       gas: 7000000,
-//       data: oracle2.methods.addTip(1, 10000).encodeABI(),
-//     });
-//     vars2 = await oracle2.methods.getNewCurrentVariables().call();
-//     assert(vars2[3] - 10000 == vars[3], "tip should be big");
-//   });
-//   it("Test removal of request data", async function() {
-//     await helper.expectThrow(
-//       web3.eth.sendTransaction({
-//         to: oracle.address,
-//         from: accounts[0],
-//         gas: 7000000,
-//         data: oldTellorinst.methods
-//           .requestData("api", "x", 1000, 0)
-//           .encodeABI(),
-//       })
-//     );
-//   });
-//   it("Test token fee burning", async function() {
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[0],
-//       gas: 7000000,
-//       data: oracle2.methods
-//         .theLazyCoon(accounts[1], web3.utils.toWei("2000", "ether"))
-//         .encodeABI(),
-//     });
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[1],
-//       gas: 7000000,
-//       data: oracle2.methods
-//         .addTip(1, web3.utils.toWei("1000", "ether"))
-//         .encodeABI(),
-//     });
-//     vars = await oracle2.methods.getNewCurrentVariables().call();
-//     assert(vars[3] >= web3.utils.toWei("1000", "ether"), "tip should be big");
-//     balances = [];
-//     for (var i = 0; i < 6; i++) {
-//       balances[i] = await oracle.balanceOf(accounts[i]);
-//     }
-//     initTotalSupply = await oracle.totalSupply();
-//     for (var i = 0; i < 5; i++) {
-//       await web3.eth.sendTransaction({
-//         to: oracle.address,
-//         from: accounts[i],
-//         gas: 7000000,
-//         data: oracle2.methods
-//           .testSubmitMiningSolution(
-//             "nonce",
-//             [1, 2, 3, 4, 5],
-//             [1200, 1300, 1400, 1500, 1600]
-//           )
-//           .encodeABI(),
-//       });
-//     }
-//     new_balances = [];
-//     for (var i = 0; i < 6; i++) {
-//       new_balances[i] = await oracle.balanceOf(accounts[i]);
-//     }
-//     changes = [];
-//     for (var i = 0; i < 6; i++) {
-//       changes[i] = new_balances[i] - balances[i];
-//     }
-//     newTotalSupply = await oracle.totalSupply();
-//     assert(changes[0] <= web3.utils.toWei("103.75", "ether"));
-//     assert(changes[1] <= web3.utils.toWei("102.5", "ether"));
-//     assert(changes[2] <= web3.utils.toWei("102.5", "ether"));
-//     assert(changes[3] <= web3.utils.toWei("102.5", "ether"));
-//     assert(changes[4] <= web3.utils.toWei("102.5", "ether"));
-//     assert(
-//       initTotalSupply - newTotalSupply > web3.utils.toWei("480", "ether"),
-//       "total supply should drop significatntly"
-//     );
-//   });
+    for (var i = 0; i < 5; i++) {
+      res = await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods
+          .testSubmitMiningSolution(
+            "nonce",
+            [1, 2, 3, 4, 5],
+            [1200, 1300, 1400, 1500, 1600]
+          )
+          .encodeABI(),
+      });
+    }
+    res = web3.eth.abi.decodeParameters(
+      ["uint256[5]", "uint256", "uint256[5]", "uint256"],
+      res.logs["1"].data
+    );
+    balance1 = await oracle.balanceOf(accounts[2]);
+    dispBal1 = await oracle.balanceOf(accounts[1]);
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[1],
+      gas: 7000000,
+      data: oracle2.methods.beginDispute(1, res[1], 2).encodeABI(),
+    });
+    count = await oracle.getUintVar(web3.utils.keccak256("disputeCount"));
+    //vote 1 fails
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[3],
+      gas: 7000000,
+      data: oracle2.methods.vote(1, false).encodeABI(),
+    });
+    await helper.advanceTime(86400 * 3);
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods.tallyVotes(1).encodeABI(),
+    });
+    await helper.expectThrow(
+      web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[0],
+        gas: 7000000,
+        data: oracle2.methods.unlockDisputeFee(1).encodeABI(),
+      })
+    ); //try to withdraw
+    dispInfo = await oracle.getAllDisputeVars(1);
+    assert(
+      dispInfo[4] == accounts[2],
+      "account 2 should be the disputed miner"
+    );
+    assert(dispInfo[2] == false, "Dispute Vote failed");
+    //vote 2 - passes
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[6],
+      gas: 7000000,
+      data: oracle2.methods.beginDispute(1, res[1], 2).encodeABI(),
+    });
+    count = await oracle.getUintVar(web3.utils.keccak256("disputeCount"));
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[6],
+      gas: 7000000,
+      data: oracle2.methods.vote(2, true).encodeABI(),
+    });
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[4],
+      gas: 7000000,
+      data: oracle2.methods.vote(2, true).encodeABI(),
+    });
+    await helper.advanceTime(86400 * 5);
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods.tallyVotes(2).encodeABI(),
+    });
+    dispInfo = await oracle.getAllDisputeVars(2);
+    assert(dispInfo[2] == true, "Dispute Vote passed");
+    await helper.advanceTime(86400 * 2);
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods.unlockDisputeFee(1).encodeABI(),
+    });
+    balance2 = await oracle.balanceOf(accounts[2]);
+    dispBal2 = await oracle.balanceOf(accounts[1]);
+    assert(
+      balance1 - balance2 ==
+        (await oracle.getUintVar(web3.utils.keccak256("stakeAmount"))),
+      "reported miner's balance should change correctly"
+    );
+    assert(
+      web3.utils.fromWei(dispBal2) - web3.utils.fromWei(dispBal1) == 1000,
+      "disputing party's balance should change correctly"
+    );
+    assert(
+      web3.utils.fromWei(balance1) - web3.utils.fromWei(balance2) == 1000,
+      "Account 2 balance should be correct"
+    );
+  });
+  it("Test allow tip of current mined ID", async function() {
+    vars = await oracle2.methods.getNewCurrentVariables().call();
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods.addTip(1, 10000).encodeABI(),
+    });
+    vars2 = await oracle2.methods.getNewCurrentVariables().call();
+    assert(vars2[3] - 10000 == vars[3], "tip should be big");
+  });
+  it("Test removal of request data", async function() {
+    await helper.expectThrow(
+      web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[0],
+        gas: 7000000,
+        data: oldTellorinst.methods
+          .requestData("api", "x", 1000, 0)
+          .encodeABI(),
+      })
+    );
+  });
+  it("Test token fee burning", async function() {
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods
+        .theLazyCoon(accounts[1], web3.utils.toWei("2000", "ether"))
+        .encodeABI(),
+    });
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[1],
+      gas: 7000000,
+      data: oracle2.methods
+        .addTip(1, web3.utils.toWei("1000", "ether"))
+        .encodeABI(),
+    });
+    vars = await oracle2.methods.getNewCurrentVariables().call();
+    assert(vars[3] >= web3.utils.toWei("1000", "ether"), "tip should be big");
+    balances = [];
+    for (var i = 0; i < 6; i++) {
+      balances[i] = await oracle.balanceOf(accounts[i]);
+    }
+    initTotalSupply = await oracle.totalSupply();
+    for (var i = 0; i < 5; i++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods
+          .testSubmitMiningSolution(
+            "nonce",
+            [1, 2, 3, 4, 5],
+            [1200, 1300, 1400, 1500, 1600]
+          )
+          .encodeABI(),
+      });
+    }
+    new_balances = [];
+    for (var i = 0; i < 6; i++) {
+      new_balances[i] = await oracle.balanceOf(accounts[i]);
+    }
+    changes = [];
+    for (var i = 0; i < 6; i++) {
+      changes[i] = new_balances[i] - balances[i];
+    }
+    newTotalSupply = await oracle.totalSupply();
+    assert(changes[0] <= web3.utils.toWei("103.75", "ether"));
+    assert(changes[1] <= web3.utils.toWei("102.5", "ether"));
+    assert(changes[2] <= web3.utils.toWei("102.5", "ether"));
+    assert(changes[3] <= web3.utils.toWei("102.5", "ether"));
+    assert(changes[4] <= web3.utils.toWei("102.5", "ether"));
+    assert(
+      initTotalSupply - newTotalSupply > web3.utils.toWei("480", "ether"),
+      "total supply should drop significatntly"
+    );
+  });
 
-//   it("Test automatic pulling of top ID's (the last ones)", async function() {
-//     let vars = await oracle2.methods.getNewCurrentVariables().call();
-//     for (var i = 0; i < 5; i++) {
-//       await web3.eth.sendTransaction({
-//         to: oracle.address,
-//         from: accounts[i],
-//         gas: 7000000,
-//         data: oracle2.methods
-//           .testSubmitMiningSolution("nonce", vars["1"], [
-//             1200,
-//             1300,
-//             1400,
-//             1500,
-//             1600,
-//           ])
-//           .encodeABI(),
-//       });
-//     }
-//     vars = await oracle2.methods.getNewCurrentVariables().call();
-//     for (var i = 0; i < 5; i++) {
-//       assert(vars[1][i] == 5 - i);
-//     }
-//   });
-//   it("Test add tip on very far out API id (or on a tblock id?)", async function() {
-//     await helper.expectThrow(
-//       web3.eth.sendTransaction({
-//         to: oracle.address,
-//         from: accounts[0],
-//         gas: 7000000,
-//         data: oracle2.methods.addTip(web3.utils.toWei("1"), 1).encodeABI(),
-//       })
-//     );
-//     await helper.expectThrow(
-//       web3.eth.sendTransaction({
-//         to: oracle.address,
-//         from: accounts[0],
-//         gas: 7000000,
-//         data: oracle2.methods.addTip(66, 2000).encodeABI(),
-//       })
-//     );
-//     assert(
-//       (await oracle.getUintVar(web3.utils.keccak256("requestCount"))) == 52
-//     );
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[0],
-//       gas: 7000000,
-//       data: oracle2.methods.addTip(53, 2000).encodeABI(),
-//     });
-//     assert(
-//       (await oracle.getUintVar(web3.utils.keccak256("requestCount"))) == 53
-//     );
-//     let vars = await oracle2.methods.getNewCurrentVariables().call();
-//     for (var i = 0; i < 5; i++) {
-//       await web3.eth.sendTransaction({
-//         to: oracle.address,
-//         from: accounts[i],
-//         gas: 7000000,
-//         data: oracle2.methods
-//           .testSubmitMiningSolution("nonce", vars["1"], [
-//             1200,
-//             1300,
-//             1400,
-//             1500,
-//             1600,
-//           ])
-//           .encodeABI(),
-//       });
-//     }
-//     vars = await oracle2.methods.getNewCurrentVariables().call();
-//     for (var i = 0; i < 5; i++) {
-//       await web3.eth.sendTransaction({
-//         to: oracle.address,
-//         from: accounts[i],
-//         gas: 7000000,
-//         data: oracle2.methods
-//           .testSubmitMiningSolution("nonce", vars["1"], [
-//             1200,
-//             1300,
-//             1400,
-//             1500,
-//             1600,
-//           ])
-//           .encodeABI(),
-//       });
-//     }
-//     vars = await oracle.getLastNewValue();
-//     assert(vars[0] > 0);
-//   });
-//   it("Test Proper zeroing of Payout Test", async function() {
-//     vars = await oracle2.methods.getNewCurrentVariables().call();
-//     for (var i = 0; i < 5; i++) {
-//       await web3.eth.sendTransaction({
-//         to: oracle.address,
-//         from: accounts[i],
-//         gas: 7000000,
-//         data: oracle2.methods
-//           .testSubmitMiningSolution("nonce", vars["1"], [
-//             1200,
-//             1300,
-//             1400,
-//             1500,
-//             1600,
-//           ])
-//           .encodeABI(),
-//       });
-//     }
-//     vars = await oracle.getRequestVars(vars["1"][0]);
-//     assert(vars["5"] == 0, "api payout should be zero");
-//     vars = await oracle.getUintVar(web3.utils.keccak256("currentTotalTips"));
-//     assert(vars == 0, "api payout should be zero");
-//   });
-//   it("Test multiple dispute rounds, assure increasing per dispute round", async function() {
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[0],
-//       gas: 7000000,
-//       data: oracle2.methods
-//         .theLazyCoon(accounts[1], web3.utils.toWei("500", "ether"))
-//         .encodeABI(),
-//     });
-//     for (var i = 0; i < 5; i++) {
-//       res = await web3.eth.sendTransaction({
-//         to: oracle.address,
-//         from: accounts[i],
-//         gas: 7000000,
-//         data: oracle2.methods
-//           .testSubmitMiningSolution(
-//             "nonce",
-//             [1, 2, 3, 4, 5],
-//             [1200, 1300, 1400, 1500, 1600]
-//           )
-//           .encodeABI(),
-//       });
-//     }
-//     res = web3.eth.abi.decodeParameters(
-//       ["uint256[5]", "uint256", "uint256[5]", "uint256"],
-//       res.logs["1"].data
-//     );
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[0],
-//       gas: 7000000,
-//       data: oracle2.methods
-//         .theLazyCoon(accounts[1], web3.utils.toWei("5000", "ether"))
-//         .encodeABI(),
-//     });
-//     balance1 = await oracle.balanceOf(accounts[2]);
-//     dispBal1 = await oracle.balanceOf(accounts[1]);
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[1],
-//       gas: 7000000,
-//       data: oracle2.methods.beginDispute(1, res[1], 2).encodeABI(),
-//     });
-//     count = await oracle.getUintVar(web3.utils.keccak256("disputeCount"));
-//     //vote 1 passes
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[3],
-//       gas: 7000000,
-//       data: oracle2.methods.vote(1, true).encodeABI(),
-//     });
-//     await helper.advanceTime(86400 * 3);
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[0],
-//       gas: 7000000,
-//       data: oracle2.methods.tallyVotes(1).encodeABI(),
-//     });
-//     await helper.expectThrow(
-//       web3.eth.sendTransaction({
-//         to: oracle.address,
-//         from: accounts[0],
-//         gas: 7000000,
-//         data: oracle2.methods.unlockDisputeFee(1).encodeABI(),
-//       })
-//     ); //try to withdraw
-//     dispInfo = await oracle.getAllDisputeVars(1);
-//     assert(
-//       dispInfo[4] == accounts[2],
-//       "account 2 should be the disputed miner"
-//     );
-//     assert(dispInfo[2] == true, "Dispute Vote passed");
-//     assert(web3.utils.fromWei(dispInfo[7][8]) == 1000, "fee should be correct");
-//     //vote 2 - fails
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[0],
-//       gas: 7000000,
-//       data: oracle2.methods
-//         .theLazyCoon(accounts[6], web3.utils.toWei("5000", "ether"))
-//         .encodeABI(),
-//     });
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[6],
-//       gas: 7000000,
-//       data: oracle2.methods.beginDispute(1, res[1], 2).encodeABI(),
-//     });
-//     count = await oracle.getUintVar(web3.utils.keccak256("disputeCount"));
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[6],
-//       gas: 7000000,
-//       data: oracle2.methods.vote(2, true).encodeABI(),
-//     });
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[4],
-//       gas: 7000000,
-//       data: oracle2.methods.vote(2, true).encodeABI(),
-//     });
-//     await helper.advanceTime(86400 * 5);
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[0],
-//       gas: 7000000,
-//       data: oracle2.methods.tallyVotes(2).encodeABI(),
-//     });
-//     dispInfo = await oracle.getAllDisputeVars(2);
-//     assert(dispInfo[2] == true, "Dispute Vote passes again");
-//     assert(web3.utils.fromWei(dispInfo[7][8]) == 2000, "fee should be correct");
-//     await helper.advanceTime(86400 * 2);
-//     dispInfo = await oracle.getAllDisputeVars(1);
-//     assert(dispInfo[2] == true, "Dispute Vote passed");
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[0],
-//       gas: 9000000,
-//       data: oracle2.methods.unlockDisputeFee(1).encodeABI(),
-//     });
-//     dispInfo = await oracle.getAllDisputeVars(1);
-//     assert(dispInfo[2] == true, "Dispute Vote passed");
-//     balance2 = await oracle.balanceOf(accounts[2]);
-//     dispBal2 = await oracle.balanceOf(accounts[1]);
-//     assert(
-//       balance1 - balance2 == web3.utils.toWei("1000"),
-//       "reported miner's balance should change correctly"
-//     );
-//     assert(
-//       dispBal2 - dispBal1 == web3.utils.toWei("1000"),
-//       "disputing party's balance should change correctly"
-//     );
-//   });
-//   it("Test multiple dispute rounds, assure increasing per dispute round (nonZero)", async function() {
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[0],
-//       gas: 7000000,
-//       data: oracle2.methods
-//         .theLazyCoon(accounts[1], web3.utils.toWei("500", "ether"))
-//         .encodeABI(),
-//     });
-//     for (var i = 0; i < 5; i++) {
-//       res = await web3.eth.sendTransaction({
-//         to: oracle.address,
-//         from: accounts[i],
-//         gas: 7000000,
-//         data: oracle2.methods
-//           .testSubmitMiningSolution(
-//             "nonce",
-//             [1, 2, 3, 4, 5],
-//             [1200, 1300, 1400, 1500, 1600]
-//           )
-//           .encodeABI(),
-//       });
-//     }
-//     res = web3.eth.abi.decodeParameters(
-//       ["uint256[5]", "uint256", "uint256[5]", "uint256"],
-//       res.logs["1"].data
-//     );
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[0],
-//       gas: 7000000,
-//       data: oracle2.methods
-//         .theLazyCoon(accounts[1], web3.utils.toWei("5000", "ether"))
-//         .encodeABI(),
-//     });
-//     balance1 = await oracle.balanceOf(accounts[3]);
-//     dispBal1 = await oracle.balanceOf(accounts[1]);
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[1],
-//       gas: 7000000,
-//       data: oracle2.methods.beginDispute(1, res[1], 3).encodeABI(),
-//     });
-//     count = await oracle.getUintVar(web3.utils.keccak256("disputeCount"));
-//     //vote 1 passes
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[2],
-//       gas: 7000000,
-//       data: oracle2.methods.vote(1, true).encodeABI(),
-//     });
-//     await helper.advanceTime(86400 * 3);
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[0],
-//       gas: 7000000,
-//       data: oracle2.methods.tallyVotes(1).encodeABI(),
-//     });
-//     await helper.expectThrow(
-//       web3.eth.sendTransaction({
-//         to: oracle.address,
-//         from: accounts[0],
-//         gas: 7000000,
-//         data: oracle2.methods.unlockDisputeFee(1).encodeABI(),
-//       })
-//     ); //try to withdraw
-//     dispInfo = await oracle.getAllDisputeVars(1);
-//     assert(
-//       dispInfo[4] == accounts[3],
-//       "account 2 should be the disputed miner"
-//     );
-//     assert(dispInfo[2] == true, "Dispute Vote passed");
-//     assert(web3.utils.fromWei(dispInfo[7][8]) == 970, "fee should be correct");
-//     //vote 2 - fails
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[0],
-//       gas: 7000000,
-//       data: oracle2.methods
-//         .theLazyCoon(accounts[6], web3.utils.toWei("5000", "ether"))
-//         .encodeABI(),
-//     });
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[6],
-//       gas: 7000000,
-//       data: oracle2.methods.beginDispute(1, res[1], 3).encodeABI(),
-//     });
-//     count = await oracle.getUintVar(web3.utils.keccak256("disputeCount"));
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[6],
-//       gas: 7000000,
-//       data: oracle2.methods.vote(2, true).encodeABI(),
-//     });
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[4],
-//       gas: 7000000,
-//       data: oracle2.methods.vote(2, true).encodeABI(),
-//     });
-//     await helper.advanceTime(86400 * 5);
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[0],
-//       gas: 7000000,
-//       data: oracle2.methods.tallyVotes(2).encodeABI(),
-//     });
-//     dispInfo = await oracle.getAllDisputeVars(2);
-//     assert(dispInfo[2] == true, "Dispute Vote passes again");
-//     assert(
-//       web3.utils.fromWei(dispInfo[7][8]) == 970 * 2,
-//       "fee should be correct"
-//     );
-//     await helper.advanceTime(86400 * 2);
-//     dispInfo = await oracle.getAllDisputeVars(1);
-//     assert(dispInfo[2] == true, "Dispute Vote passed");
-//     await web3.eth.sendTransaction({
-//       to: oracle.address,
-//       from: accounts[0],
-//       gas: 9000000,
-//       data: oracle2.methods.unlockDisputeFee(1).encodeABI(),
-//     });
-//     dispInfo = await oracle.getAllDisputeVars(1);
-//     assert(dispInfo[2] == true, "Dispute Vote passed");
-//     balance2 = await oracle.balanceOf(accounts[3]);
-//     dispBal2 = await oracle.balanceOf(accounts[1]);
-//     assert(
-//       balance1 - balance2 == web3.utils.toWei("1000"),
-//       "reported miner's balance should change correctly"
-//     );
-//     assert(
-//       dispBal2 - dispBal1 == web3.utils.toWei("1000"),
-//       "disputing party's balance should change correctly"
-//     );
-//   });
-// });
+  it("Test automatic pulling of top ID's (the last ones)", async function() {
+    let vars = await oracle2.methods.getNewCurrentVariables().call();
+    for (var i = 0; i < 5; i++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods
+          .testSubmitMiningSolution("nonce", vars["1"], [
+            1200,
+            1300,
+            1400,
+            1500,
+            1600,
+          ])
+          .encodeABI(),
+      });
+    }
+    vars = await oracle2.methods.getNewCurrentVariables().call();
+    for (var i = 0; i < 5; i++) {
+      assert(vars[1][i] == 5 - i);
+    }
+  });
+  it("Test add tip on very far out API id (or on a tblock id?)", async function() {
+    await helper.expectThrow(
+      web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[0],
+        gas: 7000000,
+        data: oracle2.methods.addTip(web3.utils.toWei("1"), 1).encodeABI(),
+      })
+    );
+    await helper.expectThrow(
+      web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[0],
+        gas: 7000000,
+        data: oracle2.methods.addTip(66, 2000).encodeABI(),
+      })
+    );
+    assert(
+      (await oracle.getUintVar(web3.utils.keccak256("requestCount"))) == 52
+    );
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods.addTip(53, 2000).encodeABI(),
+    });
+    assert(
+      (await oracle.getUintVar(web3.utils.keccak256("requestCount"))) == 53
+    );
+    let vars = await oracle2.methods.getNewCurrentVariables().call();
+    for (var i = 0; i < 5; i++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods
+          .testSubmitMiningSolution("nonce", vars["1"], [
+            1200,
+            1300,
+            1400,
+            1500,
+            1600,
+          ])
+          .encodeABI(),
+      });
+    }
+    vars = await oracle2.methods.getNewCurrentVariables().call();
+    for (var i = 0; i < 5; i++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods
+          .testSubmitMiningSolution("nonce", vars["1"], [
+            1200,
+            1300,
+            1400,
+            1500,
+            1600,
+          ])
+          .encodeABI(),
+      });
+    }
+    vars = await oracle.getLastNewValue();
+    assert(vars[0] > 0);
+  });
+  it("Test Proper zeroing of Payout Test", async function() {
+    vars = await oracle2.methods.getNewCurrentVariables().call();
+    for (var i = 0; i < 5; i++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods
+          .testSubmitMiningSolution("nonce", vars["1"], [
+            1200,
+            1300,
+            1400,
+            1500,
+            1600,
+          ])
+          .encodeABI(),
+      });
+    }
+    vars = await oracle.getRequestVars(vars["1"][0]);
+    assert(vars["5"] == 0, "api payout should be zero");
+    vars = await oracle.getUintVar(web3.utils.keccak256("currentTotalTips"));
+    assert(vars == 0, "api payout should be zero");
+  });
+  it("Test multiple dispute rounds, assure increasing per dispute round", async function() {
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods
+        .theLazyCoon(accounts[1], web3.utils.toWei("500", "ether"))
+        .encodeABI(),
+    });
+    for (var i = 0; i < 5; i++) {
+      res = await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods
+          .testSubmitMiningSolution(
+            "nonce",
+            [1, 2, 3, 4, 5],
+            [1200, 1300, 1400, 1500, 1600]
+          )
+          .encodeABI(),
+      });
+    }
+    res = web3.eth.abi.decodeParameters(
+      ["uint256[5]", "uint256", "uint256[5]", "uint256"],
+      res.logs["1"].data
+    );
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods
+        .theLazyCoon(accounts[1], web3.utils.toWei("5000", "ether"))
+        .encodeABI(),
+    });
+    balance1 = await oracle.balanceOf(accounts[2]);
+    dispBal1 = await oracle.balanceOf(accounts[1]);
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[1],
+      gas: 7000000,
+      data: oracle2.methods.beginDispute(1, res[1], 2).encodeABI(),
+    });
+    count = await oracle.getUintVar(web3.utils.keccak256("disputeCount"));
+    //vote 1 passes
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[3],
+      gas: 7000000,
+      data: oracle2.methods.vote(1, true).encodeABI(),
+    });
+    await helper.advanceTime(86400 * 3);
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods.tallyVotes(1).encodeABI(),
+    });
+    await helper.expectThrow(
+      web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[0],
+        gas: 7000000,
+        data: oracle2.methods.unlockDisputeFee(1).encodeABI(),
+      })
+    ); //try to withdraw
+    dispInfo = await oracle.getAllDisputeVars(1);
+    assert(
+      dispInfo[4] == accounts[2],
+      "account 2 should be the disputed miner"
+    );
+    assert(dispInfo[2] == true, "Dispute Vote passed");
+    assert(web3.utils.fromWei(dispInfo[7][8]) == 1000, "fee should be correct");
+    //vote 2 - fails
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods
+        .theLazyCoon(accounts[6], web3.utils.toWei("5000", "ether"))
+        .encodeABI(),
+    });
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[6],
+      gas: 7000000,
+      data: oracle2.methods.beginDispute(1, res[1], 2).encodeABI(),
+    });
+    count = await oracle.getUintVar(web3.utils.keccak256("disputeCount"));
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[6],
+      gas: 7000000,
+      data: oracle2.methods.vote(2, true).encodeABI(),
+    });
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[4],
+      gas: 7000000,
+      data: oracle2.methods.vote(2, true).encodeABI(),
+    });
+    await helper.advanceTime(86400 * 5);
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods.tallyVotes(2).encodeABI(),
+    });
+    dispInfo = await oracle.getAllDisputeVars(2);
+    assert(dispInfo[2] == true, "Dispute Vote passes again");
+    assert(web3.utils.fromWei(dispInfo[7][8]) == 2000, "fee should be correct");
+    await helper.advanceTime(86400 * 2);
+    dispInfo = await oracle.getAllDisputeVars(1);
+    assert(dispInfo[2] == true, "Dispute Vote passed");
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 9000000,
+      data: oracle2.methods.unlockDisputeFee(1).encodeABI(),
+    });
+    dispInfo = await oracle.getAllDisputeVars(1);
+    assert(dispInfo[2] == true, "Dispute Vote passed");
+    balance2 = await oracle.balanceOf(accounts[2]);
+    dispBal2 = await oracle.balanceOf(accounts[1]);
+    assert(
+      balance1 - balance2 == web3.utils.toWei("1000"),
+      "reported miner's balance should change correctly"
+    );
+    assert(
+      dispBal2 - dispBal1 == web3.utils.toWei("1000"),
+      "disputing party's balance should change correctly"
+    );
+  });
+  it("Test multiple dispute rounds, assure increasing per dispute round (nonZero)", async function() {
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods
+        .theLazyCoon(accounts[1], web3.utils.toWei("500", "ether"))
+        .encodeABI(),
+    });
+    for (var i = 0; i < 5; i++) {
+      res = await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods
+          .testSubmitMiningSolution(
+            "nonce",
+            [1, 2, 3, 4, 5],
+            [1200, 1300, 1400, 1500, 1600]
+          )
+          .encodeABI(),
+      });
+    }
+    res = web3.eth.abi.decodeParameters(
+      ["uint256[5]", "uint256", "uint256[5]", "uint256"],
+      res.logs["1"].data
+    );
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods
+        .theLazyCoon(accounts[1], web3.utils.toWei("5000", "ether"))
+        .encodeABI(),
+    });
+    balance1 = await oracle.balanceOf(accounts[3]);
+    dispBal1 = await oracle.balanceOf(accounts[1]);
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[1],
+      gas: 7000000,
+      data: oracle2.methods.beginDispute(1, res[1], 3).encodeABI(),
+    });
+    count = await oracle.getUintVar(web3.utils.keccak256("disputeCount"));
+    //vote 1 passes
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[2],
+      gas: 7000000,
+      data: oracle2.methods.vote(1, true).encodeABI(),
+    });
+    await helper.advanceTime(86400 * 3);
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods.tallyVotes(1).encodeABI(),
+    });
+    await helper.expectThrow(
+      web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[0],
+        gas: 7000000,
+        data: oracle2.methods.unlockDisputeFee(1).encodeABI(),
+      })
+    ); //try to withdraw
+    dispInfo = await oracle.getAllDisputeVars(1);
+    assert(
+      dispInfo[4] == accounts[3],
+      "account 2 should be the disputed miner"
+    );
+    assert(dispInfo[2] == true, "Dispute Vote passed");
+    assert(web3.utils.fromWei(dispInfo[7][8]) == 970, "fee should be correct");
+    //vote 2 - fails
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods
+        .theLazyCoon(accounts[6], web3.utils.toWei("5000", "ether"))
+        .encodeABI(),
+    });
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[6],
+      gas: 7000000,
+      data: oracle2.methods.beginDispute(1, res[1], 3).encodeABI(),
+    });
+    count = await oracle.getUintVar(web3.utils.keccak256("disputeCount"));
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[6],
+      gas: 7000000,
+      data: oracle2.methods.vote(2, true).encodeABI(),
+    });
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[4],
+      gas: 7000000,
+      data: oracle2.methods.vote(2, true).encodeABI(),
+    });
+    await helper.advanceTime(86400 * 5);
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 7000000,
+      data: oracle2.methods.tallyVotes(2).encodeABI(),
+    });
+    dispInfo = await oracle.getAllDisputeVars(2);
+    assert(dispInfo[2] == true, "Dispute Vote passes again");
+    assert(
+      web3.utils.fromWei(dispInfo[7][8]) == 970 * 2,
+      "fee should be correct"
+    );
+    await helper.advanceTime(86400 * 2);
+    dispInfo = await oracle.getAllDisputeVars(1);
+    assert(dispInfo[2] == true, "Dispute Vote passed");
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 9000000,
+      data: oracle2.methods.unlockDisputeFee(1).encodeABI(),
+    });
+    dispInfo = await oracle.getAllDisputeVars(1);
+    assert(dispInfo[2] == true, "Dispute Vote passed");
+    balance2 = await oracle.balanceOf(accounts[3]);
+    dispBal2 = await oracle.balanceOf(accounts[1]);
+    assert(
+      balance1 - balance2 == web3.utils.toWei("1000"),
+      "reported miner's balance should change correctly"
+    );
+    assert(
+      dispBal2 - dispBal1 == web3.utils.toWei("1000"),
+      "disputing party's balance should change correctly"
+    );
+  });
+});

--- a/test/v2Tests.js
+++ b/test/v2Tests.js
@@ -65,8 +65,8 @@ contract("v2 Tests", function(accounts) {
         from: accounts[i],
         gas: 7000000,
         data: oracle2.methods[
-          "testSubmitMiningSolution(string,uint256,uint256)"
-        ]("nonce", 1, 1200).encodeABI(),
+          "testSubmitMiningSolution(string,uint256[5],uint256[5])"
+        ]("nonce", [1, 2, 3, 4, 5], [1100, 1200, 1300, 1400, 1500]).encodeABI(),
       });
     }
   });

--- a/test/v2Tests.js
+++ b/test/v2Tests.js
@@ -2,7 +2,7 @@
 // const web3 = new Web3(
 //   new Web3.providers.WebsocketProvider("ws://localhost:8545")
 // );
-// const helper = require("./helpers/test_helpers");
+const helper = require("./helpers/test_helpers");
 const TellorMaster = artifacts.require("./TellorMaster.sol");
 const Tellor = artifacts.require("./mocks/TellorTest.sol"); // globally injected artifacts helper
 const TellorLibraryTest = artifacts.require("TellorLibraryTest");
@@ -71,9 +71,11 @@ contract("v2 Tests", function(accounts) {
         to: oracle.address,
         from: accounts[i],
         gas: 7000000,
-        data: oracle2.methods[
-          "testSubmitMiningSolution(string,uint256[5],uint256[5])"
-        ]("nonce", [1, 2, 3, 4, 5], [1100, 1200, 1300, 1400, 1500]).encodeABI(),
+        data: oracle2.methods["submitMiningSolution(string,uint256,uint256)"](
+          "nonce",
+          1,
+          1200
+        ).encodeABI(),
       });
     }
   });
@@ -787,6 +789,7 @@ contract("v2 Tests", function(accounts) {
       (await oracle.getUintVar(web3.utils.keccak256("requestCount"))) == 53
     );
     let vars = await oracle2.methods.getNewCurrentVariables().call();
+    await helper.advanceTime(60 * 60 * 16);
     for (var i = 0; i < 5; i++) {
       await web3.eth.sendTransaction({
         to: oracle.address,
@@ -803,6 +806,8 @@ contract("v2 Tests", function(accounts) {
           .encodeABI(),
       });
     }
+    console.log("Here");
+    await helper.advanceTime(60 * 60 * 16);
     vars = await oracle2.methods.getNewCurrentVariables().call();
     for (var i = 0; i < 5; i++) {
       await web3.eth.sendTransaction({

--- a/test/v2Tests.js
+++ b/test/v2Tests.js
@@ -5,6 +5,8 @@
 // const helper = require("./helpers/test_helpers");
 const TellorMaster = artifacts.require("./TellorMaster.sol");
 const Tellor = artifacts.require("./mocks/TellorTest.sol"); // globally injected artifacts helper
+const TellorLibraryTest = artifacts.require("TellorLibraryTest");
+
 var oracleAbi = Tellor.abi;
 var oracleByte = Tellor.bytecode;
 var OldTellor = artifacts.require("./oldContracts/OldTellor.sol");
@@ -23,8 +25,13 @@ contract("v2 Tests", function(accounts) {
   let oldTellor;
   let oldTellorinst;
   let utilities;
+  let tellorTest;
+  let tellorTransfer;
+  let testLib;
 
   beforeEach("Setup contract for each test", async function() {
+    // testLib = await TellorLibraryTest.new();
+    // await Tellor.link(TellorLibraryTest, testLib.address);
     //deploy old, request, update address, mine old challenge.
     oldTellor = await OldTellor.new();
     oracle = await TellorMaster.new(oldTellor.address);

--- a/test/v2Tests.js
+++ b/test/v2Tests.js
@@ -1,10 +1,10 @@
-const Web3 = require("web3");
-const web3 = new Web3(
-  new Web3.providers.WebsocketProvider("ws://localhost:8545")
-);
-const helper = require("./helpers/test_helpers");
+// const Web3 = require("web3");
+// const web3 = new Web3(
+//   new Web3.providers.WebsocketProvider("ws://localhost:8545")
+// );
+// const helper = require("./helpers/test_helpers");
 const TellorMaster = artifacts.require("./TellorMaster.sol");
-const Tellor = artifacts.require("./Tellor.sol"); // globally injected artifacts helper
+const Tellor = artifacts.require("./mocks/TellorTest.sol"); // globally injected artifacts helper
 var oracleAbi = Tellor.abi;
 var oracleByte = Tellor.bytecode;
 var OldTellor = artifacts.require("./oldContracts/OldTellor.sol");

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -51,4 +51,6 @@ module.exports = {
       //runs: 5000,
     },
   },
+
+  plugins: ["solidity-coverage"],
 };


### PR DESCRIPTION
WIP PR to track initial changes to the V2.5 upgrade.

Main changes:
* Renamed and fixed all compilations issues with old and old2 Tellor contracts, because we were getting duplicate names warnings.
* Delete the old submitMiningSolution and from tellorLibrary and Tellor.sol>
ps. I had to bring them back due to upgrading in the test enviroment, but we can probably remove those on deployment

* I decoupled the nonceVerification form submitMiningSolution, so we don't need comment/uncomment test functions
* Created a TellorTest and TellorTestLibrary that are able to use  `lazycoon`  and `testsubmitminingsolution` functions