### PR TITLE
Idea: Transition Contracts

### DIFF
--- a/contracts/TransitionContract.sol
+++ b/contracts/TransitionContract.sol
@@ -1,10 +1,6 @@
 pragma solidity ^0.5.16;
 
-import "./libraries/SafeMath.sol";
 import "./libraries/TellorStorage.sol";
-import "./libraries/TellorTransfer.sol";
-import "./libraries/TellorGettersLibrary.sol";
-import "./libraries/TellorStake.sol";
 
 /**
 * @title Tellor Master
@@ -12,26 +8,10 @@ import "./libraries/TellorStake.sol";
 */
 contract TellorTransition {
 
-
-    using TellorTransfer for TellorStorage.TellorStorageStruct;
-    using TellorGettersLibrary for TellorStorage.TellorStorageStruct;
-    using TellorStake for TellorStorage.TellorStorageStruct;
-
     TellorStorage.TellorStorageStruct tellor;
 
-    address public newTellor;
-    address public currentTellor;
-
-    /**
-    * @dev The constructor sets the original `tellorStorageOwner` of the contract to the sender
-    * account, the tellor contract to the Tellor master address and owner to the Tellor master owner address
-    * @param _tellorContract is the address for the tellor contract
-    */
-    constructor(address _currentContract, address _newContract) public {
-        currentTellor = _currentContract;
-        newTellor = _newContract;
-    }
-
+    address public constant newTellor = 0x032Aa32e4069318b15e6462CE20926d4d821De90;
+    address public constant currentTellor = 0x6511D2957aa09350494f892Ce2881851f0bb26D3;
 
     /**
     * @dev Function to be executed before the first transaction to new version is called. After performing
@@ -50,22 +30,20 @@ contract TellorTransition {
     * @dev Function to be verify if the system is in the correct state for executing a transition.
     *  Ex: we're not in the middle of a block;
     */
-    function _isReady() internal returns(bool){
+    function _isReady() internal view returns(bool){
         if(tellor.uintVars[keccak256("slotProgress")] == 0){
             return true;
         }
         return false;
     }
 
-   
-    /**
-    * @dev This will perform the transition and then call the the newer Tellor version
-    */
-    function() external payable {
+    function() external payable{
+        
         address addr = currentTellor;
         //If contract is ready, perform the transition and set the definitive address as TellorContract;
         if(_isReady()){
             _transition();
+            addr = newTellor;
         } 
         bytes memory _calldata = msg.data;
         assembly {

--- a/contracts/TransitionContract.sol
+++ b/contracts/TransitionContract.sol
@@ -1,0 +1,88 @@
+pragma solidity ^0.5.16;
+
+import "./libraries/SafeMath.sol";
+import "./libraries/TellorStorage.sol";
+import "./libraries/TellorTransfer.sol";
+import "./libraries/TellorGettersLibrary.sol";
+import "./libraries/TellorStake.sol";
+
+/**
+* @title Tellor Master
+* @dev This is a transaction contract designed to perform a temporary configuration on a Tellor Update.
+*/
+contract TellorTransition {
+
+
+    using TellorTransfer for TellorStorage.TellorStorageStruct;
+    using TellorGettersLibrary for TellorStorage.TellorStorageStruct;
+    using TellorStake for TellorStorage.TellorStorageStruct;
+
+    TellorStorage.TellorStorageStruct tellor;
+
+    address public newTellor;
+    address public currentTellor;
+
+    /**
+    * @dev The constructor sets the original `tellorStorageOwner` of the contract to the sender
+    * account, the tellor contract to the Tellor master address and owner to the Tellor master owner address
+    * @param _tellorContract is the address for the tellor contract
+    */
+    constructor(address _currentContract, address _newContract) public {
+        currentTellor = _currentContract;
+        newTellor = _newContract;
+    }
+
+
+    /**
+    * @dev Function to be executed before the first transaction to new version is called. After performing
+    * the necessary steps, it just sets the "tellorContract" to the actual new version. 
+    */
+    function _transition() internal {
+        //Perfomr all necessary steps for the transition
+        tellor.uintVars[keccak256("currentReward")] = 1e18;
+        tellor.uintVars[keccak256("stakeAmount")] = 500e18;
+
+        //After, change the "tellorAddress" to the new version
+        tellor.addressVars[keccak256("tellorContract")] = newTellor;
+    } 
+
+    /**
+    * @dev Function to be verify if the system is in the correct state for executing a transition.
+    *  Ex: we're not in the middle of a block;
+    */
+    function _isReady() internal returns(bool){
+        TellorStorage.Request storage _tblock = tellor.requestDetails[tellor.uintVars[keccak256("_tBlock")]];
+        if(tellor.uintVars[keccak256("slotProgress")] == 0){
+            return true;
+        }
+        return false;
+    }
+
+   
+    /**
+    * @dev This will perform the transition and then call the the newer Tellor version
+    */
+    function() external payable {
+        address addr = currentTellor;
+        //If contract is ready, perform the transition and set the definitive address as TellorContract;
+        if(_isReady()){
+            _transition();
+        } 
+        bytes memory _calldata = msg.data;
+        assembly {
+            let result := delegatecall(not(0), addr, add(_calldata, 0x20), mload(_calldata), 0, 0)
+            let size := returndatasize
+            let ptr := mload(0x40)
+            returndatacopy(ptr, 0, size)
+            // revert instead of invalid() bc if the underlying call failed with invalid() it already wasted gas.
+            // if the call returned error data, forward it
+            switch result
+                case 0 {
+                    revert(ptr, size)
+                }
+                default {
+                    return(ptr, size)
+                }
+        }
+    }
+}

--- a/contracts/TransitionContract.sol
+++ b/contracts/TransitionContract.sol
@@ -51,7 +51,6 @@ contract TellorTransition {
     *  Ex: we're not in the middle of a block;
     */
     function _isReady() internal returns(bool){
-        TellorStorage.Request storage _tblock = tellor.requestDetails[tellor.uintVars[keccak256("_tBlock")]];
         if(tellor.uintVars[keccak256("slotProgress")] == 0){
             return true;
         }

--- a/test/transitionTest.js
+++ b/test/transitionTest.js
@@ -1,0 +1,242 @@
+const helper = require("./helpers/test_helpers");
+const TellorMaster = artifacts.require("./TellorMaster.sol");
+let Tellor = artifacts.require("./TellorTest.sol"); // globally injected artifacts helper
+const TransitionContract = artifacts.require("./TellorTransition");
+var oracleAbi = Tellor.abi;
+var oracleByte = Tellor.bytecode;
+var OldTellor = artifacts.require("./oldContracts/OldTellor.sol");
+var oldTellorABI = OldTellor.abi;
+var UtilitiesTests = artifacts.require("./UtilitiesTests.sol");
+
+var masterAbi = TellorMaster.abi;
+var api = "json(https://api.gdax.com/products/BTC-USD/ticker).price";
+var api2 = "json(https://api.gdax.com/products/ETH-USD/ticker).price";
+
+contract("Mining Tests", function(accounts) {
+  let oracleBase;
+  let oracle;
+  let oracle2;
+  let master;
+  let oldTellor;
+  let oldTellorinst;
+  let utilities;
+
+  //Hardcoded adress because they need to be known when the TransitionCOntract is compiled
+  const baseAdd = "0x6511D2957aa09350494f892Ce2881851f0bb26D3";
+  const newAdd = "0x032Aa32e4069318b15e6462CE20926d4d821De90";
+
+  beforeEach("Setup contract for each test", async function() {
+    oldTellor = await OldTellor.new();
+    oracle = await TellorMaster.new(oldTellor.address);
+    master = await new web3.eth.Contract(masterAbi, oracle.address);
+    oldTellorinst = await new web3.eth.Contract(
+      oldTellorABI,
+      oldTellor.address
+    );
+    for (var i = 0; i < 6; i++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[0],
+        gas: 7000000,
+        data: oldTellorinst.methods
+          .theLazyCoon(accounts[i], web3.utils.toWei("5000", "ether"))
+          .encodeABI(),
+      });
+    }
+    for (var i = 0; i < 52; i++) {
+      x = "USD" + i;
+      apix = api + i;
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[0],
+        gas: 7000000,
+        data: oldTellorinst.methods
+          .requestData(apix, x, 1000, 52 - i)
+          .encodeABI(),
+      });
+    }
+    let q = await oracle.getRequestQ();
+    //Deploy new upgraded Tellor
+    oracleBase = await Tellor.new({ from: accounts[9] });
+    oracle2 = await new web3.eth.Contract(oracleAbi, oracle.address);
+    await oracle.changeTellorContract(oracleBase.address);
+    for (var i = 0; i < 5; i++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 7000000,
+        data: oracle2.methods["submitMiningSolution(string,uint256,uint256)"](
+          "nonce",
+          1,
+          1200
+        ).encodeABI(),
+      });
+    }
+    await helper.advanceTime(60 * 16);
+    for (var i = 0; i < 5; i++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 10000000,
+        data: oracle2.methods
+          .testSubmitMiningSolution(
+            "nonce",
+            [1, 2, 3, 4, 5],
+            [1200, 1300, 1400, 1500, 1600]
+          )
+          .encodeABI(),
+      });
+    }
+  });
+
+  it("Should transition correctly at the beginning of a block", async () => {
+    let add = await oracle.getAddressVars(
+      web3.utils.keccak256("tellorContract")
+    );
+    console.log("add", add);
+    let stakeAmount = await oracle.getUintVar(
+      web3.utils.keccak256("stakeAmount")
+    );
+    console.log("stakeAmount", stakeAmount.toString());
+
+    let newTellor = await Tellor.new({ from: accounts[9] });
+    transitionContract = await TransitionContract.new();
+
+    newTellor = await Tellor.at(newAdd);
+    let currTellor = await Tellor.at(baseAdd);
+
+    console.log("base", currTellor.address);
+    console.log("new", newTellor.address);
+    console.log("trans", transitionContract.address);
+    vars = await oracle2.methods.getNewCurrentVariables().call();
+    await oracle.changeTellorContract(transitionContract.address);
+    let add1 = await oracle.getAddressVars(
+      web3.utils.keccak256("tellorContract")
+    );
+    console.log("add1", add1);
+    await helper.advanceTime(60 * 16);
+    for (var i = 0; i < 5; i++) {
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 10000000,
+        data: oracle2.methods
+          .testSubmitMiningSolution("nonce", vars["1"], [
+            1200,
+            1300,
+            1400,
+            1500,
+            1600,
+          ])
+          .encodeABI(),
+      });
+    }
+    // vars = await oracle2.methods.getNewCurrentVariables().call();
+    // console.log(vars);
+    let stakeAmount2 = await oracle.getUintVar(
+      web3.utils.keccak256("stakeAmount")
+    );
+    console.log("stakeAmount2", stakeAmount2.toString());
+    let add2 = await oracle.getAddressVars(
+      web3.utils.keccak256("tellorContract")
+    );
+    console.log("add2", add2);
+  });
+
+  it("Should transition correctly mid block", async () => {
+    let add = await oracle.getAddressVars(
+      web3.utils.keccak256("tellorContract")
+    );
+    console.log("add", add);
+    let stakeAmount = await oracle.getUintVar(
+      web3.utils.keccak256("stakeAmount")
+    );
+    console.log("stakeAmount", stakeAmount.toString());
+
+    let newTellor = await Tellor.new({ from: accounts[9] });
+    let transitionContract = await TransitionContract.new();
+
+    newTellor = await Tellor.at(newAdd);
+    let currTellor = await Tellor.at(baseAdd);
+    transitionContract = await TransitionContract.new();
+
+    console.log("base", currTellor.address);
+    console.log("new", newTellor.address);
+    console.log("trans", transitionContract.address);
+    vars = await oracle2.methods.getNewCurrentVariables().call();
+    await helper.advanceTime(60 * 16);
+    //Mine First Block
+    await web3.eth.sendTransaction({
+      to: oracle.address,
+      from: accounts[0],
+      gas: 10000000,
+      data: oracle2.methods
+        .testSubmitMiningSolution("nonce", vars["1"], [
+          1200,
+          1300,
+          1400,
+          1500,
+          1600,
+        ])
+        .encodeABI(),
+    });
+    //Change contract
+    await oracle.changeTellorContract(transitionContract.address);
+    //Those Should do through old address
+    for (var i = 1; i < 5; i++) {
+      let stakeAmount = await oracle.getUintVar(
+        web3.utils.keccak256("stakeAmount")
+      );
+      console.log("stakeAmount", stakeAmount.toString());
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 10000000,
+        data: oracle2.methods
+          .testSubmitMiningSolution("nonce", vars["1"], [
+            1200,
+            1300,
+            1400,
+            1500,
+            1600,
+          ])
+          .encodeABI(),
+      });
+    }
+    vars = await oracle2.methods.getNewCurrentVariables().call();
+    await helper.advanceTime(60 * 16);
+    //This should go to newAdd
+    for (var i = 0; i < 5; i++) {
+      console.log("New Block ------------");
+      await web3.eth.sendTransaction({
+        to: oracle.address,
+        from: accounts[i],
+        gas: 10000000,
+        data: oracle2.methods
+          .testSubmitMiningSolution("nonce", vars["1"], [
+            1200,
+            1300,
+            1400,
+            1500,
+            1600,
+          ])
+          .encodeABI(),
+      });
+      let stakeAmount = await oracle.getUintVar(
+        web3.utils.keccak256("stakeAmount")
+      );
+      console.log("stakeAmount2", stakeAmount.toString());
+    }
+
+    // vars = await oracle2.methods.getNewCurrentVariables().call();
+    // console.log(vars);
+    let stakeAmount2 = await oracle.getUintVar(
+      web3.utils.keccak256("stakeAmount")
+    );
+    console.log("stakeAmount2", stakeAmount2.toString());
+    let add2 = await oracle.getAddressVars(
+      web3.utils.keccak256("tellorContract")
+    );
+    console.log("add2", add2);
+  });
+});


### PR DESCRIPTION
Well, this is kind of a crazy idea I had while working on the V2.5. 

A lot of times, upgrades will be much easier if we could execute it at the correct state, as set up some variables in a constructor style logic.

The TransitionContract is an intermediary Tellor contract that is used between two version to do just that. The basic functionality is that it'll automatically forward to the oldTellor address, like it was never upgraded, until the internal function `_isReady()` returns true, when the `_transtition()` function would be called and upgrade would finalize and the system will go back to what it is as 
usual. 


I think this could be really useful for upgrades that only change a parameter(like decreasing the stake amount to another hardcoded value) because it could leave the make it possible just to deploy a new version using the same TellorMaster address. Also, it's good for not having to worry not add extra logic to deal with transitions mid-block, which will be problematic in the changing pay structure, for example.

The basic usage would be: 
1. Deploy a new Tellor Version
2. Deploy a TransitionContract passing both the new address and the old one.
3. In the current Tellor, propose a fork, passing the address of the transition.

This is just a quick draft, this could be made simpler or more complete, and I haven't tested at all. It's just to get the discussion going on weather it's worth the effort.

Let me know if you have any questions! 